### PR TITLE
Extend authority node module

### DIFF
--- a/synnergy-network/cmd/cli/authority_node.go
+++ b/synnergy-network/cmd/cli/authority_node.go
@@ -1,33 +1,35 @@
 // cmd/cli/authority_node.go – Cobra CLI for the authority‑node governance subsystem.
 // ------------------------------------------------------------------------------
 // File structure
-//   • Middleware (dependency wiring & guard‑rails)
-//   • Controller  (thin façade around core.AuthoritySet)
-//   • CLI command declarations (top section for quick scanning)
-//   • Consolidation & export (single AuthCmd for main‑index import)
+//   - Middleware (dependency wiring & guard‑rails)
+//   - Controller  (thin façade around core.AuthoritySet)
+//   - CLI command declarations (top section for quick scanning)
+//   - Consolidation & export (single AuthCmd for main‑index import)
 //
 // After adding to your root CLI:
-//     $ synnergy auth register tz1Bob MilitaryNode
-//     $ synnergy auth vote tz1Alice tz1Bob
-//     $ synnergy auth electorate 9            # sample 9 active authorities
-//     $ synnergy auth is tz1Carol            # boolean check
+//
+//	$ synnergy auth register tz1Bob MilitaryNode
+//	$ synnergy auth vote tz1Alice tz1Bob
+//	$ synnergy auth electorate 9            # sample 9 active authorities
+//	$ synnergy auth is tz1Carol            # boolean check
+//
 // ------------------------------------------------------------------------------
 package cli
 
 import (
-    "context"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "strconv"
-    "strings"
-    "time"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
 
-    "github.com/spf13/cobra"
-    "github.com/spf13/viper"
-    "go.uber.org/zap"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
 
-    core "github.com/synnergy-network/core" // adjust to your go.mod root
+	core "github.com/synnergy-network/core" // adjust to your go.mod root
 )
 
 //---------------------------------------------------------------------
@@ -37,17 +39,17 @@ import (
 var authSet *core.AuthoritySet // singleton for CLI lifetime
 
 func ensureAuthInitialised(cmd *cobra.Command, _ []string) error {
-    if authSet != nil {
-        return nil // already ready
-    }
-    led := core.CurrentLedger() // assumed helper returning StateRW
-    if led == nil {
-        return errors.New("ledger not initialised – start node or init ledger first")
-    }
-    logger := zap.L().Sugar()
-    authSet = core.NewAuthoritySet(logger.Desugar(), led)
-    zap.L().Sugar().Infow("authority subsystem initialised for CLI")
-    return nil
+	if authSet != nil {
+		return nil // already ready
+	}
+	led := core.CurrentLedger() // assumed helper returning StateRW
+	if led == nil {
+		return errors.New("ledger not initialised – start node or init ledger first")
+	}
+	logger := zap.L().Sugar()
+	authSet = core.NewAuthoritySet(logger.Desugar(), led)
+	zap.L().Sugar().Infow("authority subsystem initialised for CLI")
+	return nil
 }
 
 //---------------------------------------------------------------------
@@ -58,46 +60,63 @@ type AuthController struct{}
 
 // RegisterCandidate wraps AuthoritySet.RegisterCandidate
 func (c *AuthController) RegisterCandidate(addr core.Address, roleStr string) error {
-    role, err := parseRole(roleStr)
-    if err != nil { return err }
-    return authSet.RegisterCandidate(addr, role)
+	role, err := parseRole(roleStr)
+	if err != nil {
+		return err
+	}
+	return authSet.RegisterCandidate(addr, role)
 }
 
 // RecordVote wraps AuthoritySet.RecordVote
 func (c *AuthController) RecordVote(voter, candidate core.Address) error {
-    return authSet.RecordVote(voter, candidate)
+	return authSet.RecordVote(voter, candidate)
 }
 
 // Electorate samples N active nodes weighted by role.
 func (c *AuthController) Electorate(n int) ([]core.Address, error) {
-    return authSet.RandomElectorate(n)
+	return authSet.RandomElectorate(n)
 }
 
 // IsAuthority returns ACTIVE boolean
 func (c *AuthController) IsAuthority(addr core.Address) bool { return authSet.IsAuthority(addr) }
+
+// Info retrieves details for an authority node.
+func (c *AuthController) Info(addr core.Address) (core.AuthorityNode, error) {
+	return authSet.GetAuthority(addr)
+}
+
+// List returns all authority nodes. If activeOnly is true only active nodes are listed.
+func (c *AuthController) List(activeOnly bool) ([]core.AuthorityNode, error) {
+	return authSet.ListAuthorities(activeOnly)
+}
+
+// Deregister removes an authority node from the set.
+func (c *AuthController) Deregister(addr core.Address) error {
+	return authSet.Deregister(addr)
+}
 
 //---------------------------------------------------------------------
 // Helpers
 //---------------------------------------------------------------------
 
 func parseRole(s string) (core.AuthorityRole, error) {
-    s = strings.TrimSpace(strings.ToLower(s))
-    switch s {
-    case "governmentnode", "government":
-        return core.GovernmentNode, nil
-    case "centralbanknode", "centralbank":
-        return core.CentralBankNode, nil
-    case "regulationnode", "regulation":
-        return core.RegulationNode, nil
-    case "standardauthoritynode", "standard", "standardauthority":
-        return core.StandardAuthorityNode, nil
-    case "militarynode", "military":
-        return core.MilitaryNode, nil
-    case "largecommercenode", "commerce", "largecommerce":
-        return core.LargeCommerceNode, nil
-    default:
-        return 0, fmt.Errorf("unknown role %q", s)
-    }
+	s = strings.TrimSpace(strings.ToLower(s))
+	switch s {
+	case "governmentnode", "government":
+		return core.GovernmentNode, nil
+	case "centralbanknode", "centralbank":
+		return core.CentralBankNode, nil
+	case "regulationnode", "regulation":
+		return core.RegulationNode, nil
+	case "standardauthoritynode", "standard", "standardauthority":
+		return core.StandardAuthorityNode, nil
+	case "militarynode", "military":
+		return core.MilitaryNode, nil
+	case "largecommercenode", "commerce", "largecommerce":
+		return core.LargeCommerceNode, nil
+	default:
+		return 0, fmt.Errorf("unknown role %q", s)
+	}
 }
 
 func mustHex(addr string) core.Address { return core.Address(addr) }
@@ -107,74 +126,131 @@ func mustHex(addr string) core.Address { return core.Address(addr) }
 //---------------------------------------------------------------------
 
 var authCmd = &cobra.Command{
-    Use:               "auth",
-    Short:             "Authority‑node governance commands",
-    PersistentPreRunE: ensureAuthInitialised,
+	Use:               "auth",
+	Short:             "Authority‑node governance commands",
+	PersistentPreRunE: ensureAuthInitialised,
 }
 
 // register -------------------------------------------------------------------
 var registerCmd = &cobra.Command{
-    Use:   "register <addr> <role>",
-    Short: "Submit a new authority‑node candidate for a role",
-    Args:  cobra.ExactArgs(2),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctrl := &AuthController{}
-        addr, role := mustHex(args[0]), args[1]
-        if err := ctrl.RegisterCandidate(addr, role); err != nil {
-            return err
-        }
-        fmt.Printf("Candidate %s registered as %s\n", addr, role)
-        return nil
-    },
+	Use:   "register <addr> <role>",
+	Short: "Submit a new authority‑node candidate for a role",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &AuthController{}
+		addr, role := mustHex(args[0]), args[1]
+		if err := ctrl.RegisterCandidate(addr, role); err != nil {
+			return err
+		}
+		fmt.Printf("Candidate %s registered as %s\n", addr, role)
+		return nil
+	},
 }
 
 // vote -----------------------------------------------------------------------
 var voteCmd = &cobra.Command{
-    Use:   "vote <voterAddr> <candidateAddr>",
-    Short: "Cast a vote for a candidate (deduped and role‑weighted)",
-    Args:  cobra.ExactArgs(2),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctrl := &AuthController{}
-        voter, cand := mustHex(args[0]), mustHex(args[1])
-        if err := ctrl.RecordVote(voter, cand); err != nil {
-            return err
-        }
-        fmt.Printf("Vote recorded: %s → %s\n", voter, cand)
-        return nil
-    },
+	Use:   "vote <voterAddr> <candidateAddr>",
+	Short: "Cast a vote for a candidate (deduped and role‑weighted)",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &AuthController{}
+		voter, cand := mustHex(args[0]), mustHex(args[1])
+		if err := ctrl.RecordVote(voter, cand); err != nil {
+			return err
+		}
+		fmt.Printf("Vote recorded: %s → %s\n", voter, cand)
+		return nil
+	},
 }
 
 // electorate -----------------------------------------------------------------
 var electorateCmd = &cobra.Command{
-    Use:   "electorate <size>",
-    Short: "Sample a random weighted electorate of ACTIVE authority nodes",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctrl := &AuthController{}
-        size, err := strconv.Atoi(args[0])
-        if err != nil || size <= 0 {
-            return fmt.Errorf("size must be positive integer: %w", err)
-        }
-        addrs, err := ctrl.Electorate(size)
-        if err != nil { return err }
-        enc, _ := json.MarshalIndent(addrs, "", "  ")
-        fmt.Println(string(enc))
-        return nil
-    },
+	Use:   "electorate <size>",
+	Short: "Sample a random weighted electorate of ACTIVE authority nodes",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &AuthController{}
+		size, err := strconv.Atoi(args[0])
+		if err != nil || size <= 0 {
+			return fmt.Errorf("size must be positive integer: %w", err)
+		}
+		addrs, err := ctrl.Electorate(size)
+		if err != nil {
+			return err
+		}
+		enc, _ := json.MarshalIndent(addrs, "", "  ")
+		fmt.Println(string(enc))
+		return nil
+	},
 }
 
 // is-authority ---------------------------------------------------------------
 var isCmd = &cobra.Command{
-    Use:   "is <addr>",
-    Short: "Check if address is an ACTIVE authority node",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctrl := &AuthController{}
-        addr := mustHex(args[0])
-        ok := ctrl.IsAuthority(addr)
-        fmt.Printf("%s active: %v\n", addr, ok)
-        return nil
-    },
+	Use:   "is <addr>",
+	Short: "Check if address is an ACTIVE authority node",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &AuthController{}
+		addr := mustHex(args[0])
+		ok := ctrl.IsAuthority(addr)
+		fmt.Printf("%s active: %v\n", addr, ok)
+		return nil
+	},
+}
+
+// info -----------------------------------------------------------------------
+var infoCmd = &cobra.Command{
+	Use:   "info <addr>",
+	Short: "Show details for an authority node",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &AuthController{}
+		addr := mustHex(args[0])
+		n, err := ctrl.Info(addr)
+		if err != nil {
+			return err
+		}
+		enc, _ := json.MarshalIndent(n, "", "  ")
+		fmt.Println(string(enc))
+		return nil
+	},
+}
+
+// list -----------------------------------------------------------------------
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List authority nodes",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &AuthController{}
+		activeOnly, _ := cmd.Flags().GetBool("active")
+		nodes, err := ctrl.List(activeOnly)
+		if err != nil {
+			return err
+		}
+		enc, _ := json.MarshalIndent(nodes, "", "  ")
+		fmt.Println(string(enc))
+		return nil
+	},
+}
+
+func init() {
+	listCmd.Flags().Bool("active", false, "only show active nodes")
+}
+
+// deregister -------------------------------------------------------------
+var deregCmd = &cobra.Command{
+	Use:   "deregister <addr>",
+	Short: "Remove an authority node and its votes",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &AuthController{}
+		addr := mustHex(args[0])
+		if err := ctrl.Deregister(addr); err != nil {
+			return err
+		}
+		fmt.Printf("Authority %s deregistered\n", addr)
+		return nil
+	},
 }
 
 //---------------------------------------------------------------------
@@ -182,10 +258,13 @@ var isCmd = &cobra.Command{
 //---------------------------------------------------------------------
 
 func init() {
-    authCmd.AddCommand(registerCmd)
-    authCmd.AddCommand(voteCmd)
-    authCmd.AddCommand(electorateCmd)
-    authCmd.AddCommand(isCmd)
+	authCmd.AddCommand(registerCmd)
+	authCmd.AddCommand(voteCmd)
+	authCmd.AddCommand(electorateCmd)
+	authCmd.AddCommand(isCmd)
+	authCmd.AddCommand(infoCmd)
+	authCmd.AddCommand(listCmd)
+	authCmd.AddCommand(deregCmd)
 }
 
 // Export for main‑index import

--- a/synnergy-network/core/authority_nodes.go
+++ b/synnergy-network/core/authority_nodes.go
@@ -12,12 +12,12 @@ package core
 // Compile‑time dependencies: common, ledger, security (sig verify).
 
 import (
-    "encoding/json"
-    "errors"
-    "math/rand"
-    "time"
-    "crypto/sha256"
-    "github.com/sirupsen/logrus"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"github.com/sirupsen/logrus"
+	"math/rand"
+	"time"
 )
 
 //---------------------------------------------------------------------
@@ -27,116 +27,119 @@ import (
 type AuthorityRole uint8
 
 const (
-    GovernmentNode AuthorityRole = iota + 1
-    CentralBankNode
-    RegulationNode
-    StandardAuthorityNode
-    MilitaryNode
-    LargeCommerceNode
+	GovernmentNode AuthorityRole = iota + 1
+	CentralBankNode
+	RegulationNode
+	StandardAuthorityNode
+	MilitaryNode
+	LargeCommerceNode
 )
 
 func (r AuthorityRole) String() string {
-    switch r {
-    case GovernmentNode:
-        return "GovernmentNode"
-    case CentralBankNode:
-        return "CentralBankNode"
-    case RegulationNode:
-        return "RegulationNode"
-    case StandardAuthorityNode:
-        return "StandardAuthorityNode"
-    case MilitaryNode:
-        return "MilitaryNode"
-    case LargeCommerceNode:
-        return "LargeCommerceNode"
-    default:
-        return "Unknown"
-    }
+	switch r {
+	case GovernmentNode:
+		return "GovernmentNode"
+	case CentralBankNode:
+		return "CentralBankNode"
+	case RegulationNode:
+		return "RegulationNode"
+	case StandardAuthorityNode:
+		return "StandardAuthorityNode"
+	case MilitaryNode:
+		return "MilitaryNode"
+	case LargeCommerceNode:
+		return "LargeCommerceNode"
+	default:
+		return "Unknown"
+	}
 }
 
 // Admission thresholds by role.
 var admissionRules = map[AuthorityRole]struct {
-    PublicVotes uint32
-    AuthVotes   uint32
+	PublicVotes uint32
+	AuthVotes   uint32
 }{
-    GovernmentNode:        {PublicVotes: 5_000, AuthVotes: 20},
-    CentralBankNode:       {PublicVotes: 4_000, AuthVotes: 18},
-    RegulationNode:        {PublicVotes: 3_000, AuthVotes: 15},
-    StandardAuthorityNode: {PublicVotes: 500, AuthVotes: 10},
-    MilitaryNode:          {PublicVotes: 2_000, AuthVotes: 12},
-    LargeCommerceNode:     {PublicVotes: 1_000, AuthVotes: 8},
+	GovernmentNode:        {PublicVotes: 5_000, AuthVotes: 20},
+	CentralBankNode:       {PublicVotes: 4_000, AuthVotes: 18},
+	RegulationNode:        {PublicVotes: 3_000, AuthVotes: 15},
+	StandardAuthorityNode: {PublicVotes: 500, AuthVotes: 10},
+	MilitaryNode:          {PublicVotes: 2_000, AuthVotes: 12},
+	LargeCommerceNode:     {PublicVotes: 1_000, AuthVotes: 8},
 }
-
 
 //---------------------------------------------------------------------
 // AuthoritySet keeper
 //---------------------------------------------------------------------
 
-
 func NewAuthoritySet(lg *logrus.Logger, led StateRW) *AuthoritySet {
-    return &AuthoritySet{logger: lg, led: led}
+	return &AuthoritySet{logger: lg, led: led}
 }
 
 //---------------------------------------------------------------------
 // RecordVote – public or authority node voting for candidate.
 //---------------------------------------------------------------------
 
+// RecordVote registers a vote for an authority candidate. Duplicate votes are
+// rejected and the voter is classified as either a public or authority node
+// based on whether they are already registered. Once the admission thresholds
+// are met the candidate is marked as ACTIVE.
 func (as *AuthoritySet) RecordVote(voter, candidate Address) error {
-    as.mu.Lock(); defer as.mu.Unlock()
+	as.mu.Lock()
+	defer as.mu.Unlock()
 
-    nodeRaw, _ := as.led.GetState(nodeKey(candidate))
-    if len(nodeRaw) == 0 {
-        return errors.New("candidate not found")
-    }
-    var n AuthorityNode; _ = json.Unmarshal(nodeRaw, &n)
+	nodeRaw, _ := as.led.GetState(nodeKey(candidate))
+	if len(nodeRaw) == 0 {
+		return errors.New("candidate not found")
+	}
+	var n AuthorityNode
+	_ = json.Unmarshal(nodeRaw, &n)
 
-    // Prevent self vote & duplicate
-    vk := voteKey(hashFromAddress(candidate), voter)
-    if ok, _ := as.led.HasState(vk); ok {
-        return errors.New("duplicate vote")
-    }
-    as.led.SetState(vk, []byte{0x01})
+	// Prevent self vote & duplicate
+	vk := authorityVoteKey(hashFromAddress(candidate), voter)
+	if ok, _ := as.led.HasState(vk); ok {
+		return errors.New("duplicate vote")
+	}
+	as.led.SetState(vk, []byte{0x01})
 
-    // Determine bucket – authority or public
-    if n2, _ := as.led.GetState(nodeKey(voter)); len(n2) > 0 {
-        n.AuthVotes++
-    } else {
-        n.PublicVotes++
-    }
+	// Determine bucket – authority or public
+	if n2, _ := as.led.GetState(nodeKey(voter)); len(n2) > 0 {
+		n.AuthVotes++
+	} else {
+		n.PublicVotes++
+	}
 
-    // Check activation thresholds
-    rule := admissionRules[n.Role]
-    if !n.Active && n.PublicVotes >= rule.PublicVotes && n.AuthVotes >= rule.AuthVotes {
-        n.Active = true
-        as.logger.Printf("node %s promoted to ACTIVE %s", candidate.Short(), n.Role)
-    }
-    as.led.SetState(nodeKey(candidate), mustJSON(n))
-    return nil
+	// Check activation thresholds
+	rule := admissionRules[n.Role]
+	if !n.Active && n.PublicVotes >= rule.PublicVotes && n.AuthVotes >= rule.AuthVotes {
+		n.Active = true
+		as.logger.Printf("node %s promoted to ACTIVE %s", candidate.Short(), n.Role)
+	}
+	as.led.SetState(nodeKey(candidate), mustJSON(n))
+	return nil
 }
 
 func hashFromAddress(addr Address) Hash {
-    var h Hash
-    sum := sha256.Sum256(addr[:])
-    copy(h[:], sum[:])
-    return h
+	var h Hash
+	sum := sha256.Sum256(addr[:])
+	copy(h[:], sum[:])
+	return h
 }
-
 
 //---------------------------------------------------------------------
 // RegisterCandidate – owner submits node for role.
 //---------------------------------------------------------------------
 
 func (as *AuthoritySet) RegisterCandidate(addr Address, role AuthorityRole) error {
-    if role < GovernmentNode || role > LargeCommerceNode {
-        return errors.New("invalid role")
-    }
-    if exists, _ := as.led.HasState(nodeKey(addr)); exists {
-        return errors.New("already registered")
-    }
-    n := AuthorityNode{Addr: addr, Role: role, CreatedAt: time.Now().Unix()}
-    as.led.SetState(nodeKey(addr), mustJSON(n))
-    as.logger.Printf("authority candidate %s registered for role %s", addr.Short(), role)
-    return nil
+	if role < GovernmentNode || role > LargeCommerceNode {
+		return errors.New("invalid role")
+	}
+	if exists, _ := as.led.HasState(nodeKey(addr)); exists {
+		return errors.New("already registered")
+	}
+	n := AuthorityNode{Addr: addr, Role: role, CreatedAt: time.Now().Unix()}
+	as.led.SetState(nodeKey(addr), mustJSON(n))
+	as.logger.Printf("authority candidate %s registered for role %s", addr.Short(), role)
+	return nil
 }
 
 //---------------------------------------------------------------------
@@ -145,38 +148,105 @@ func (as *AuthoritySet) RegisterCandidate(addr Address, role AuthorityRole) erro
 
 // roleWeights influences sampling frequency (e.g. Gov nodes weights higher).
 var roleWeights = map[AuthorityRole]int{
-    GovernmentNode:        6,
-    CentralBankNode:       5,
-    RegulationNode:        4,
-    StandardAuthorityNode: 3,
-    MilitaryNode:          2,
-    LargeCommerceNode:     2,
+	GovernmentNode:        6,
+	CentralBankNode:       5,
+	RegulationNode:        4,
+	StandardAuthorityNode: 3,
+	MilitaryNode:          2,
+	LargeCommerceNode:     2,
 }
 
 func (as *AuthoritySet) RandomElectorate(size int) ([]Address, error) {
-    as.mu.RLock(); defer as.mu.RUnlock()
-    if size <= 0 { return nil, errors.New("size must be >0") }
+	as.mu.RLock()
+	defer as.mu.RUnlock()
+	if size <= 0 {
+		return nil, errors.New("size must be >0")
+	}
 
-    // Build weighted pool of active addresses
-    var pool []Address
-    iter := as.led.PrefixIterator([]byte("authority:node:"))
-    for iter.Next() {
-        var n AuthorityNode; _ = json.Unmarshal(iter.Value(), &n)
-        if !n.Active { continue }
-        w := roleWeights[n.Role]
-        for i := 0; i < w; i++ { pool = append(pool, n.Addr) }
-    }
-    if len(pool) == 0 {
-        return nil, errors.New("no active authority nodes")
-    }
+	// Build weighted pool of active addresses
+	var pool []Address
+	iter := as.led.PrefixIterator([]byte("authority:node:"))
+	for iter.Next() {
+		var n AuthorityNode
+		_ = json.Unmarshal(iter.Value(), &n)
+		if !n.Active {
+			continue
+		}
+		w := roleWeights[n.Role]
+		for i := 0; i < w; i++ {
+			pool = append(pool, n.Addr)
+		}
+	}
+	if len(pool) == 0 {
+		return nil, errors.New("no active authority nodes")
+	}
 
-    // Sample without replacement
-    rand.Shuffle(len(pool), func(i, j int) { pool[i], pool[j] = pool[j], pool[i] })
-    sel := unique(pool)
-    if len(sel) < size {
-        size = len(sel)
-    }
-    return sel[:size], nil
+	// Sample without replacement
+	rand.Shuffle(len(pool), func(i, j int) { pool[i], pool[j] = pool[j], pool[i] })
+	sel := unique(pool)
+	if len(sel) < size {
+		size = len(sel)
+	}
+	return sel[:size], nil
+}
+
+// GetAuthority returns the AuthorityNode information for the given address.
+// An error is returned if the address is not registered.
+func (as *AuthoritySet) GetAuthority(addr Address) (AuthorityNode, error) {
+	as.mu.RLock()
+	defer as.mu.RUnlock()
+	var n AuthorityNode
+	raw, _ := as.led.GetState(nodeKey(addr))
+	if len(raw) == 0 {
+		return n, errors.New("authority not found")
+	}
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// ListAuthorities returns all authority nodes. If activeOnly is true only active
+// nodes are returned.
+func (as *AuthoritySet) ListAuthorities(activeOnly bool) ([]AuthorityNode, error) {
+	as.mu.RLock()
+	defer as.mu.RUnlock()
+	iter := as.led.PrefixIterator([]byte("authority:node:"))
+	var out []AuthorityNode
+	for iter.Next() {
+		var n AuthorityNode
+		if err := json.Unmarshal(iter.Value(), &n); err != nil {
+			continue
+		}
+		if activeOnly && !n.Active {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+// Deregister removes an authority node and all associated votes.
+func (as *AuthoritySet) Deregister(addr Address) error {
+	as.mu.Lock()
+	defer as.mu.Unlock()
+
+	if ok, _ := as.led.HasState(nodeKey(addr)); !ok {
+		return errors.New("authority not found")
+	}
+	// remove node entry
+	if err := as.led.DeleteState(nodeKey(addr)); err != nil {
+		return err
+	}
+
+	// remove all votes for this candidate
+	prefix := append([]byte("authority:vote:"), hashFromAddress(addr)[:]...)
+	iter := as.led.PrefixIterator(prefix)
+	for iter.Next() {
+		_ = as.led.DeleteState(iter.Key())
+	}
+	as.logger.Printf("authority node %s deregistered", addr.Short())
+	return nil
 }
 
 //---------------------------------------------------------------------
@@ -184,24 +254,32 @@ func (as *AuthoritySet) RandomElectorate(size int) ([]Address, error) {
 //---------------------------------------------------------------------
 
 func (as *AuthoritySet) IsAuthority(addr Address) bool {
-    raw, _ := as.led.GetState(nodeKey(addr))
-    if len(raw) == 0 { return false }
-    var n AuthorityNode; _ = json.Unmarshal(raw, &n)
-    return n.Active
+	raw, _ := as.led.GetState(nodeKey(addr))
+	if len(raw) == 0 {
+		return false
+	}
+	var n AuthorityNode
+	_ = json.Unmarshal(raw, &n)
+	return n.Active
 }
 
 func nodeKey(addr Address) []byte { return []byte("authority:node:" + addr.Hex()) }
 
-
-
-func unique(in []Address) []Address {
-    seen := make(map[Address]struct{})
-    var out []Address
-    for _, a := range in {
-        if _, ok := seen[a]; !ok {
-            seen[a] = struct{}{}; out = append(out, a)
-        }
-    }
-    return out
+// authorityVoteKey returns the ledger key used to store a vote for a given
+// authority candidate from a specific voter. The prefix is distinct from other
+// subsystems to avoid key collisions.
+func authorityVoteKey(id Hash, voter Address) []byte {
+	return append(append([]byte("authority:vote:"), id[:]...), voter.Bytes()...)
 }
 
+func unique(in []Address) []Address {
+	seen := make(map[Address]struct{})
+	var out []Address
+	for _, a := range in {
+		if _, ok := seen[a]; !ok {
+			seen[a] = struct{}{}
+			out = append(out, a)
+		}
+	}
+	return out
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -9,18 +9,18 @@
 // and leave sufficient head-room for future optimisation.
 //
 // IMPORTANT
-//   • The table MUST contain a unique entry for every opcode exported from the
+//   - The table MUST contain a unique entry for every opcode exported from the
 //     `core/opcodes` package (compile-time enforced).
-//   • Unknown / un‐priced opcodes fall back to `DefaultGasCost`, which is set
+//   - Unknown / un‐priced opcodes fall back to `DefaultGasCost`, which is set
 //     deliberately high and logged exactly once per missing opcode.
-//   • All reads from the table are fully concurrent-safe.
+//   - All reads from the table are fully concurrent-safe.
 //
 // NOTE
-//   The `Opcode` type and individual opcode constants are defined elsewhere in
-//   the core package-tree (see `core/opcodes/*.go`).  This file purposefully
-//   contains **no** duplicate keys; if a symbol appears in multiple subsystems
-//   it is listed **once** and its gas cost applies network-wide.
 //
+//	The `Opcode` type and individual opcode constants are defined elsewhere in
+//	the core package-tree (see `core/opcodes/*.go`).  This file purposefully
+//	contains **no** duplicate keys; if a symbol appears in multiple subsystems
+//	it is listed **once** and its gas cost applies network-wide.
 package core
 
 import "log"
@@ -37,35 +37,38 @@ var gasTable = map[Opcode]uint64{
 	// ----------------------------------------------------------------------
 	// AI
 	// ----------------------------------------------------------------------
-	InitAI:          50_000,
-	AI:              40_000,
-	PredictAnomaly:  35_000,
-	OptimizeFees:    25_000,
-	PublishModel:    45_000,
-	FetchModel:      15_000,
-	ListModel:       8_000,
-	ValidateKYC:     1_000,
-	BuyModel:        30_000,
-	RentModel:       20_000,
-	ReleaseEscrow:   12_000,
+	InitAI:         50_000,
+	AI:             40_000,
+	PredictAnomaly: 35_000,
+	OptimizeFees:   25_000,
+	PublishModel:   45_000,
+	FetchModel:     15_000,
+	ListModel:      8_000,
+	ValidateKYC:    1_000,
+	BuyModel:       30_000,
+	RentModel:      20_000,
+	ReleaseEscrow:  12_000,
 
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker
 	// ----------------------------------------------------------------------
-	SwapExactIn:    4_500,
-	AddLiquidity:   5_000,
-	RemoveLiquidity:5_000,
-	Quote:          2_500,
-	AllPairs:       2_000,
+	SwapExactIn:     4_500,
+	AddLiquidity:    5_000,
+	RemoveLiquidity: 5_000,
+	Quote:           2_500,
+	AllPairs:        2_000,
 
 	// ----------------------------------------------------------------------
 	// Authority / Validator-Set
 	// ----------------------------------------------------------------------
-	NewAuthoritySet: 20_000,
-	RecordVote:      3_000,
-	RegisterCandidate:8_000,
-	RandomElectorate: 4_000,
-	IsAuthority:       800,
+	NewAuthoritySet:     20_000,
+	RecordVote:          3_000,
+	RegisterCandidate:   8_000,
+	RandomElectorate:    4_000,
+	IsAuthority:         800,
+	GetAuthority:        1_000,
+	ListAuthorities:     2_000,
+	DeregisterAuthority: 6_000,
 
 	// ----------------------------------------------------------------------
 	// Charity Pool
@@ -80,16 +83,16 @@ var gasTable = map[Opcode]uint64{
 	// Coin
 	// ----------------------------------------------------------------------
 	NewCoin:     12_000,
-	Mint:        2_100,  // shared with ledger & tokens
-	TotalSupply:   800,
-	BalanceOf:     400,
+	Mint:        2_100, // shared with ledger & tokens
+	TotalSupply: 800,
+	BalanceOf:   400,
 
 	// ----------------------------------------------------------------------
 	// Compliance
 	// ----------------------------------------------------------------------
-	InitCompliance:     8_000,
-	EraseData:          5_000,
-	RecordFraudSignal:  7_000,
+	InitCompliance:    8_000,
+	EraseData:         5_000,
+	RecordFraudSignal: 7_000,
 
 	// ----------------------------------------------------------------------
 	// Consensus Core
@@ -99,44 +102,44 @@ var gasTable = map[Opcode]uint64{
 	Subscribe:             1_500,
 	Sign:                  3_000, // shared with Security & Tx
 	Verify:                3_500, // shared with Security & Tx
-	ValidatorPubKey:         800,
+	ValidatorPubKey:       800,
 	StakeOf:               1_000,
-	LoanPoolAddress:         800,
-	Hash:                    600, // shared with Replication
+	LoanPoolAddress:       800,
+	Hash:                  600, // shared with Replication
 	SerializeWithoutNonce: 1_200,
-	NewConsensus:         25_000,
-	Start:                5_000,
-	ProposeSubBlock:     15_000,
-	ValidatePoH:        20_000,
-	SealMainBlockPOW:   60_000,
-	DistributeRewards:  10_000,
+	NewConsensus:          25_000,
+	Start:                 5_000,
+	ProposeSubBlock:       15_000,
+	ValidatePoH:           20_000,
+	SealMainBlockPOW:      60_000,
+	DistributeRewards:     10_000,
 
 	// ----------------------------------------------------------------------
 	// Contracts (WASM / EVM‐compat)
 	// ----------------------------------------------------------------------
 	InitContracts: 15_000,
 	CompileWASM:   45_000,
-	Invoke:         7_000,
+	Invoke:        7_000,
 
 	// ----------------------------------------------------------------------
 	// Cross-Chain
 	// ----------------------------------------------------------------------
 	RegisterBridge: 20_000,
-	AssertRelayer:   5_000,
-	Iterator:        2_000,
+	AssertRelayer:  5_000,
+	Iterator:       2_000,
 	LockAndMint:    30_000,
 	BurnAndRelease: 30_000,
-	GetBridge:       1_000,
+	GetBridge:      1_000,
 
 	// ----------------------------------------------------------------------
 	// Data / Oracle / IPFS Integration
 	// ----------------------------------------------------------------------
-	RegisterNode:  10_000,
-	UploadAsset:   30_000,
+	RegisterNode:   10_000,
+	UploadAsset:    30_000,
 	Pin:            5_000, // shared with Storage
 	Retrieve:       4_000, // shared with Storage
 	RetrieveAsset:  4_000,
-	RegisterOracle:10_000,
+	RegisterOracle: 10_000,
 	PushFeed:       3_000,
 	QueryOracle:    3_000,
 
@@ -148,98 +151,98 @@ var gasTable = map[Opcode]uint64{
 	RemovePeer:       1_500,
 	Snapshot:         4_000,
 	Recon:            8_000,
-	Ping:               300,
-	SendPing:           300,
-	AwaitPong:          300,
+	Ping:             300,
+	SendPing:         300,
+	AwaitPong:        300,
 
 	// ----------------------------------------------------------------------
 	// Governance
 	// ----------------------------------------------------------------------
 	UpdateParam:     5_000,
-	ProposeChange:  10_000,
+	ProposeChange:   10_000,
 	VoteChange:      3_000,
 	EnactChange:     8_000,
-	SubmitProposal: 10_000,
-	BalanceOfAsset:    600,
+	SubmitProposal:  10_000,
+	BalanceOfAsset:  600,
 	CastVote:        3_000,
-	ExecuteProposal:15_000,
+	ExecuteProposal: 15_000,
 
 	// ----------------------------------------------------------------------
 	// Green Technology
 	// ----------------------------------------------------------------------
-	InitGreenTech: 8_000,
-	Green:         2_000,
-	RecordUsage:   3_000,
-	RecordOffset:  3_000,
-	Certify:       7_000,
-	CertificateOf:   500,
-	ShouldThrottle:  200,
+	InitGreenTech:  8_000,
+	Green:          2_000,
+	RecordUsage:    3_000,
+	RecordOffset:   3_000,
+	Certify:        7_000,
+	CertificateOf:  500,
+	ShouldThrottle: 200,
 
 	// ----------------------------------------------------------------------
 	// Ledger / UTXO / Account-Model
 	// ----------------------------------------------------------------------
-	NewLedger:            50_000,
-	GetPendingSubBlocks:   2_000,
-	LastBlockHash:           600,
-	AppendBlock:          50_000,
-	MintBig:               2_200,
-	EmitApproval:          1_200,
-	EmitTransfer:          1_200,
-	DeductGas:             2_100,
-	WithinBlock:           1_000,
-	IsIDTokenHolder:         400,
-	TokenBalance:            400,
-	AddBlock:             40_000,
-	GetBlock:              2_000,
-	GetUTXO:               1_500,
-	AddToPool:             1_000,
-	ListPool:                800,
-	GetContract:           1_000,
-	Snapshot:              3_000,
-	MintToken:             2_000,
-	LastSubBlockHeight:      500,
-	LastBlockHeight:         500,
-	RecordPoSVote:         3_000,
-	AppendSubBlock:        8_000,
-	Transfer:              2_100, // shared with VM & Tokens
-	Burn:                  2_100, // shared with VM & Tokens
+	NewLedger:           50_000,
+	GetPendingSubBlocks: 2_000,
+	LastBlockHash:       600,
+	AppendBlock:         50_000,
+	MintBig:             2_200,
+	EmitApproval:        1_200,
+	EmitTransfer:        1_200,
+	DeductGas:           2_100,
+	WithinBlock:         1_000,
+	IsIDTokenHolder:     400,
+	TokenBalance:        400,
+	AddBlock:            40_000,
+	GetBlock:            2_000,
+	GetUTXO:             1_500,
+	AddToPool:           1_000,
+	ListPool:            800,
+	GetContract:         1_000,
+	Snapshot:            3_000,
+	MintToken:           2_000,
+	LastSubBlockHeight:  500,
+	LastBlockHeight:     500,
+	RecordPoSVote:       3_000,
+	AppendSubBlock:      8_000,
+	Transfer:            2_100, // shared with VM & Tokens
+	Burn:                2_100, // shared with VM & Tokens
 
 	// ----------------------------------------------------------------------
 	// Liquidity Manager (high-level AMM façade)
 	// ----------------------------------------------------------------------
-	InitAMM:      8_000,
-	Manager:      1_000,
-	CreatePool:  10_000,
-	Swap:         4_500,
+	InitAMM:    8_000,
+	Manager:    1_000,
+	CreatePool: 10_000,
+	Swap:       4_500,
 	// AddLiquidity & RemoveLiquidity already defined above
 
 	// ----------------------------------------------------------------------
 	// Loan-Pool
 	// ----------------------------------------------------------------------
 	NewLoanPool: 20_000,
-	Submit:       3_000,
-	Disburse:     8_000,
+	Submit:      3_000,
+	Disburse:    8_000,
 	// Vote  & Tick already priced
 	// RandomElectorate / IsAuthority already priced
 
 	// ----------------------------------------------------------------------
 	// Networking
 	// ----------------------------------------------------------------------
-	NewNode:          18_000,
-	HandlePeerFound:   1_500,
-	DialSeed:          2_000,
-	ListenAndServe:    8_000,
-	Close:               500,
-	Peers:               400,
-	NewDialer:         2_000,
-	Dial:              2_000,
+	NewNode:         18_000,
+	HandlePeerFound: 1_500,
+	DialSeed:        2_000,
+	ListenAndServe:  8_000,
+	Close:           500,
+	Peers:           400,
+	NewDialer:       2_000,
+	Dial:            2_000,
 	// Broadcast & Subscribe already priced
 
 	// ----------------------------------------------------------------------
 	// Replication / Data Availability
 	// ----------------------------------------------------------------------
-	NewReplicator: 12_000,
-	ReplicateBlock:30_000,
+	NewReplicator:  12_000,
+	ReplicateBlock: 30_000,
 	RequestMissing: 4_000,
 	Stop:           3_000,
 	// Hash & Start already priced
@@ -247,10 +250,10 @@ var gasTable = map[Opcode]uint64{
 	// ----------------------------------------------------------------------
 	// Roll-ups
 	// ----------------------------------------------------------------------
-	NewAggregator:     15_000,
-	SubmitBatch:       10_000,
-	SubmitFraudProof:  30_000,
-	FinalizeBatch:     10_000,
+	NewAggregator:    15_000,
+	SubmitBatch:      10_000,
+	SubmitFraudProof: 30_000,
+	FinalizeBatch:    10_000,
 
 	// ----------------------------------------------------------------------
 	// Security / Cryptography
@@ -266,48 +269,48 @@ var gasTable = map[Opcode]uint64{
 	// ----------------------------------------------------------------------
 	// Sharding
 	// ----------------------------------------------------------------------
-	NewShardCoordinator:20_000,
-	SetLeader:          1_000,
-	Leader:               800,
-	SubmitCrossShard:   15_000,
-	Send:               2_000,
-	PullReceipts:       3_000,
-	Reshard:           30_000,
+	NewShardCoordinator: 20_000,
+	SetLeader:           1_000,
+	Leader:              800,
+	SubmitCrossShard:    15_000,
+	Send:                2_000,
+	PullReceipts:        3_000,
+	Reshard:             30_000,
 	// Broadcast already priced
 
 	// ----------------------------------------------------------------------
 	// Side-chains
 	// ----------------------------------------------------------------------
-	InitSidechains:   12_000,
-	Sidechains:          600,
-	Register:          5_000,
-	SubmitHeader:      8_000,
-	VerifyWithdraw:    4_000,
-	VerifyAggregateSig:8_000,
-	VerifyMerkleProof: 1_200,
+	InitSidechains:     12_000,
+	Sidechains:         600,
+	Register:           5_000,
+	SubmitHeader:       8_000,
+	VerifyWithdraw:     4_000,
+	VerifyAggregateSig: 8_000,
+	VerifyMerkleProof:  1_200,
 	// Deposit already priced
 
 	// ----------------------------------------------------------------------
 	// State-Channels
 	// ----------------------------------------------------------------------
-	InitStateChannels:      8_000,
-	Channels:                 600,
-	OpenChannel:           10_000,
-	VerifyECDSASignature:   2_000,
-	InitiateClose:          3_000,
-	Challenge:              4_000,
-	Finalize:               5_000,
+	InitStateChannels:    8_000,
+	Channels:             600,
+	OpenChannel:          10_000,
+	VerifyECDSASignature: 2_000,
+	InitiateClose:        3_000,
+	Challenge:            4_000,
+	Finalize:             5_000,
 
 	// ----------------------------------------------------------------------
 	// Storage / Marketplace
 	// ----------------------------------------------------------------------
-	NewStorage:     12_000,
-	CreateListing:   8_000,
-	Exists:            400,
-	OpenDeal:        5_000,
-	Create:          8_000, // generic create (non-AMM/non-contract)
-	CloseDeal:       5_000,
-	Release:         2_000,
+	NewStorage:    12_000,
+	CreateListing: 8_000,
+	Exists:        400,
+	OpenDeal:      5_000,
+	Create:        8_000, // generic create (non-AMM/non-contract)
+	CloseDeal:     5_000,
+	Release:       2_000,
 	// Pin & Retrieve already priced
 
 	// ----------------------------------------------------------------------
@@ -370,30 +373,30 @@ var gasTable = map[Opcode]uint64{
 	// Token Utilities
 	// ----------------------------------------------------------------------
 	ID:              400,
-	Meta:             400,
-	Allowance:        400,
-	Approve:          800,
-	Add:              600,
-	Sub:              600,
-	Get:              400,
-	transfer:       2_100, // lower-case ERC20 compatibility
-	Calculate:        800,
-	RegisterToken:  8_000,
-	NewBalanceTable:5_000,
-	Set:              600,
-	RefundGas:        100,
-	PopUint32:        300,
-	PopAddress:       300,
-	PopUint64:        300,
-	PushBool:         300,
-	Push:             300,
-	Len:              200,
+	Meta:            400,
+	Allowance:       400,
+	Approve:         800,
+	Add:             600,
+	Sub:             600,
+	Get:             400,
+	transfer:        2_100, // lower-case ERC20 compatibility
+	Calculate:       800,
+	RegisterToken:   8_000,
+	NewBalanceTable: 5_000,
+	Set:             600,
+	RefundGas:       100,
+	PopUint32:       300,
+	PopAddress:      300,
+	PopUint64:       300,
+	PushBool:        300,
+	Push:            300,
+	Len:             200,
 
 	// ----------------------------------------------------------------------
 	// Transactions
 	// ----------------------------------------------------------------------
-	VerifySig:   3_500,
-	ValidateTx:  5_000,
+	VerifySig:  3_500,
+	ValidateTx: 5_000,
 	NewTxPool:  12_000,
 	// Sign already priced
 
@@ -403,89 +406,89 @@ var gasTable = map[Opcode]uint64{
 	//  micro-benchmarks – keep in mind that **all** word-size-dependent
 	//  corrections are applied at run-time by the VM).
 	// ----------------------------------------------------------------------
-	Short:              5,
-	BytesToAddress:     5,
-	Pop:                2,
-	opADD:              3,
-	opMUL:              5,
-	opSUB:              3,
-	OpDIV:              5,
-	opSDIV:             5,
-	opMOD:              5,
-	opSMOD:             5,
-	opADDMOD:           8,
-	opMULMOD:           8,
-	opEXP:             10,
-	opSIGNEXTEND:       5,
-	opLT:               3,
-	opGT:               3,
-	opSLT:              3,
-	opSGT:              3,
-	opEQ:               3,
-	opISZERO:           3,
-	opAND:              3,
-	opOR:               3,
-	opXOR:              3,
-	opNOT:              3,
-	opBYTE:             3,
-	opSHL:              3,
-	opSHR:              3,
-	opSAR:              3,
+	Short:            5,
+	BytesToAddress:   5,
+	Pop:              2,
+	opADD:            3,
+	opMUL:            5,
+	opSUB:            3,
+	OpDIV:            5,
+	opSDIV:           5,
+	opMOD:            5,
+	opSMOD:           5,
+	opADDMOD:         8,
+	opMULMOD:         8,
+	opEXP:            10,
+	opSIGNEXTEND:     5,
+	opLT:             3,
+	opGT:             3,
+	opSLT:            3,
+	opSGT:            3,
+	opEQ:             3,
+	opISZERO:         3,
+	opAND:            3,
+	opOR:             3,
+	opXOR:            3,
+	opNOT:            3,
+	opBYTE:           3,
+	opSHL:            3,
+	opSHR:            3,
+	opSAR:            3,
 	opECRECOVER:      700,
 	opEXTCODESIZE:    700,
 	opEXTCODECOPY:    700,
 	opEXTCODEHASH:    700,
-	opRETURNDATASIZE:   3,
+	opRETURNDATASIZE: 3,
 	opRETURNDATACOPY: 700,
-	opMLOAD:            3,
-	opMSTORE:           3,
-	opMSTORE8:          3,
-	opCALLDATALOAD:     3,
-	opCALLDATASIZE:     3,
+	opMLOAD:          3,
+	opMSTORE:         3,
+	opMSTORE8:        3,
+	opCALLDATALOAD:   3,
+	opCALLDATASIZE:   3,
 	opCALLDATACOPY:   700,
-	opCODESIZE:         3,
+	opCODESIZE:       3,
 	opCODECOPY:       700,
-	opJUMP:             8,
-	opJUMPI:           10,
-	opPC:               2,
-	opMSIZE:            2,
-	opGAS:              2,
-	opJUMPDEST:         1,
-	opSHA256:          60,
-	opKECCAK256:       30,
+	opJUMP:           8,
+	opJUMPI:          10,
+	opPC:             2,
+	opMSIZE:          2,
+	opGAS:            2,
+	opJUMPDEST:       1,
+	opSHA256:         60,
+	opKECCAK256:      30,
 	opRIPEMD160:      600,
-	opBLAKE2B256:      60,
-	opADDRESS:          2,
-	opCALLER:           2,
-	opORIGIN:           2,
-	opCALLVALUE:        2,
-	opGASPRICE:         2,
-	opNUMBER:           2,
-	opTIMESTAMP:        2,
-	opDIFFICULTY:       2,
-	opGASLIMIT:         2,
-	opCHAINID:          2,
-	opBLOCKHASH:       20,
+	opBLAKE2B256:     60,
+	opADDRESS:        2,
+	opCALLER:         2,
+	opORIGIN:         2,
+	opCALLVALUE:      2,
+	opGASPRICE:       2,
+	opNUMBER:         2,
+	opTIMESTAMP:      2,
+	opDIFFICULTY:     2,
+	opGASLIMIT:       2,
+	opCHAINID:        2,
+	opBLOCKHASH:      20,
 	opBALANCE:        400,
-	opSELFBALANCE:      5,
+	opSELFBALANCE:    5,
 	opLOG0:           375,
 	opLOG1:           750,
-	opLOG2:         1_125,
-	opLOG3:         1_500,
-	opLOG4:         1_875,
-	logN:           2_000,
-	opCREATE:      32_000,
+	opLOG2:           1_125,
+	opLOG3:           1_500,
+	opLOG4:           1_875,
+	logN:             2_000,
+	opCREATE:         32_000,
 	opCALL:           700,
 	opCALLCODE:       700,
 	opDELEGATECALL:   700,
 	opSTATICCALL:     700,
-	opRETURN:           0,
-	opREVERT:           0,
-	opSTOP:             0,
-	opSELFDESTRUCT: 5_000,
+	opRETURN:         0,
+	opREVERT:         0,
+	opSTOP:           0,
+	opSELFDESTRUCT:   5_000,
 
 	// Shared accounting ops
-	TransferVM:  2_100, // explicit VM variant (if separate constant exists)
+	TransferVM: 2_100, // explicit VM variant (if separate constant exists)
 
 	// ----------------------------------------------------------------------
 	// Virtual Machine Internals
@@ -493,28 +496,28 @@ var gasTable = map[Opcode]uint64{
 	BurnVM:            2_100,
 	BurnLP:            2_100,
 	MintLP:            2_100,
-	NewInMemory:         500,
-	CallCode:           700,
-	CallContract:       700,
-	StaticCallVM:       700,
-	GetBalance:         400,
-	GetTokenBalance:    400,
-	SetTokenBalance:    500,
-	GetTokenSupply:     500,
-	SetBalance:         500,
-	DelegateCall:       700,
-	GetToken:           400,
-	NewMemory:          500,
-	Read:                 3,
-	Write:                3,
-	LenVM:                3, // distinguish from token.Len if separate const
-	Call:               700,
-	SelectVM:         1_000,
-	CreateContract:  32_000,
+	NewInMemory:       500,
+	CallCode:          700,
+	CallContract:      700,
+	StaticCallVM:      700,
+	GetBalance:        400,
+	GetTokenBalance:   400,
+	SetTokenBalance:   500,
+	GetTokenSupply:    500,
+	SetBalance:        500,
+	DelegateCall:      700,
+	GetToken:          400,
+	NewMemory:         500,
+	Read:              3,
+	Write:             3,
+	LenVM:             3, // distinguish from token.Len if separate const
+	Call:              700,
+	SelectVM:          1_000,
+	CreateContract:    32_000,
 	AddLog:            375,
 	GetCode:           200,
 	GetCodeHash:       200,
-	MintTokenVM:     2_000,
+	MintTokenVM:       2_000,
 	PrefixIterator:    500,
 	NonceOf:           400,
 	GetState:          400,
@@ -522,26 +525,26 @@ var gasTable = map[Opcode]uint64{
 	HasState:          400,
 	DeleteState:       500,
 	NewGasMeter:       500,
-	SelfDestructVM:  5_000,
-	Remaining:           2,
-	Consume:             3,
-	ExecuteVM:        2_000,
+	SelfDestructVM:    5_000,
+	Remaining:         2,
+	Consume:           3,
+	ExecuteVM:         2_000,
 	NewSuperLightVM:   500,
 	NewLightVM:        800,
-	NewHeavyVM:      1_200,
-	ExecuteSuperLight:1_000,
-	ExecuteLight:    1_500,
-	ExecuteHeavy:    2_000,
+	NewHeavyVM:        1_200,
+	ExecuteSuperLight: 1_000,
+	ExecuteLight:      1_500,
+	ExecuteHeavy:      2_000,
 
 	// ----------------------------------------------------------------------
 	// Wallet / Key-Management
 	// ----------------------------------------------------------------------
-	NewRandomWallet:      10_000,
-	WalletFromMnemonic:    5_000,
-	NewHDWalletFromSeed:   6_000,
-	PrivateKey:              400,
-	NewAddress:              500,
-	SignTx:                3_000,
+	NewRandomWallet:     10_000,
+	WalletFromMnemonic:  5_000,
+	NewHDWalletFromSeed: 6_000,
+	PrivateKey:          400,
+	NewAddress:          500,
+	SignTx:              3_000,
 }
 
 // GasCost returns the **base** gas cost for a single opcode.  Dynamic portions

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -3,27 +3,28 @@
 // Synnergy Network – Core ▸ Opcode Dispatcher
 // -------------------------------------------
 //
-//  • Every high-level function in the protocol is assigned a UNIQUE 24-bit
-//    opcode:  0xCCNNNN  →  CC = category (1 byte), NNNN = ordinal (2 bytes).
-//  • The dispatcher maps opcodes ➝ concrete handlers and enforces gas-pricing
-//    through core.GasCost() before execution.
-//  • All collisions or missing handlers are FATAL at start-up; nothing slips
-//    into production unnoticed.
+//   - Every high-level function in the protocol is assigned a UNIQUE 24-bit
+//     opcode:  0xCCNNNN  →  CC = category (1 byte), NNNN = ordinal (2 bytes).
 //
-//  ────────────────────────────────────────────────────────────────────────────
-//  AUTOMATED SECTION
-//  -----------------
-//  The table below is **generated** by `go generate ./...` (see the generator
-//  in `cmd/genopcodes`).  Edit ONLY if you know what you’re doing; otherwise
-//  add new function names to `generator/input/functions.yml` and re-run
-//  `go generate`.  The generator guarantees deterministic, collision-free
-//  opcodes and keeps this file lint-clean.
+//   - The dispatcher maps opcodes ➝ concrete handlers and enforces gas-pricing
+//     through core.GasCost() before execution.
 //
-//  Format per line:
-//      <FunctionName>  =  <24-bit-binary>  =  <HexOpcode>
+//   - All collisions or missing handlers are FATAL at start-up; nothing slips
+//     into production unnoticed.
 //
-//  NB: Tabs are significant – tools rely on them when parsing for audits.
+//     ────────────────────────────────────────────────────────────────────────────
+//     AUTOMATED SECTION
+//     -----------------
+//     The table below is **generated** by `go generate ./...` (see the generator
+//     in `cmd/genopcodes`).  Edit ONLY if you know what you’re doing; otherwise
+//     add new function names to `generator/input/functions.yml` and re-run
+//     `go generate`.  The generator guarantees deterministic, collision-free
+//     opcodes and keeps this file lint-clean.
 //
+//     Format per line:
+//     <FunctionName>  =  <24-bit-binary>  =  <HexOpcode>
+//
+//     NB: Tabs are significant – tools rely on them when parsing for audits.
 package core
 
 import (
@@ -94,32 +95,32 @@ func wrap(name string) OpcodeFunc {
 // ────────────────────────────────────────────────────────────────────────────
 //
 // Category map:
-//   0x01 AI                     0x0F Liquidity
-//   0x02 AMM                    0x10 Loanpool
-//   0x03 Authority              0x11 Network
-//   0x04 Charity                0x12 Replication
-//   0x05 Coin                   0x13 Rollups
-//   0x06 Compliance             0x14 Security
-//   0x07 Consensus              0x15 Sharding
-//   0x08 Contracts              0x16 Sidechains
-//   0x09 CrossChain             0x17 StateChannel
-//   0x0A Data                   0x18 Storage
-//   0x0B FaultTolerance         0x19 Tokens
-//   0x0C Governance             0x1A Transactions
-//   0x0D GreenTech              0x1B Utilities
-//   0x0E Ledger                 0x1C VirtualMachine
-//                               0x1D Wallet
+//
+//	0x01 AI                     0x0F Liquidity
+//	0x02 AMM                    0x10 Loanpool
+//	0x03 Authority              0x11 Network
+//	0x04 Charity                0x12 Replication
+//	0x05 Coin                   0x13 Rollups
+//	0x06 Compliance             0x14 Security
+//	0x07 Consensus              0x15 Sharding
+//	0x08 Contracts              0x16 Sidechains
+//	0x09 CrossChain             0x17 StateChannel
+//	0x0A Data                   0x18 Storage
+//	0x0B FaultTolerance         0x19 Tokens
+//	0x0C Governance             0x1A Transactions
+//	0x0D GreenTech              0x1B Utilities
+//	0x0E Ledger                 0x1C VirtualMachine
+//	                            0x1D Wallet
 //
 // Each binary code is shown as a 24-bit big-endian string.
-//
 var catalogue = []struct {
 	name string
 	op   Opcode
 }{
 	// AI (0x01)
-	{"InitAI", 0x010001},           // 00000001 00000000 00000001
-	{"AI", 0x010002},               // 00000001 00000000 00000010
-	{"PredictAnomaly", 0x010003},   // 00000001 00000000 00000011
+	{"InitAI", 0x010001},         // 00000001 00000000 00000001
+	{"AI", 0x010002},             // 00000001 00000000 00000010
+	{"PredictAnomaly", 0x010003}, // 00000001 00000000 00000011
 	{"OptimizeFees", 0x010004},
 	{"PublishModel", 0x010005},
 	{"FetchModel", 0x010006},
@@ -142,6 +143,9 @@ var catalogue = []struct {
 	{"RegisterCandidate", 0x030003},
 	{"RandomElectorate", 0x030004},
 	{"IsAuthority", 0x030005},
+	{"GetAuthority", 0x030006},
+	{"ListAuthorities", 0x030007},
+	{"DeregisterAuthority", 0x030008},
 
 	// Charity (0x04)
 	{"NewCharityPool", 0x040001},


### PR DESCRIPTION
## Summary
- expand authority node governance module with retrieval, listing and removal
- expose new authority actions via CLI
- assign new opcodes and gas costs

## Testing
- `go build ./core`
- `go test ./tests -run Test -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688abe2347c8832086abe76caa2f9c98