### PR TITLE
Add pool bootstrap utility

### DIFF
--- a/synnergy-network/cmd/cli/amm.go
+++ b/synnergy-network/cmd/cli/amm.go
@@ -85,6 +85,10 @@ func (c *AMMController) Quote(tokenIn core.TokenID, amtIn uint64, tokenOut core.
 
 func (c *AMMController) AllPairs() [][2]core.TokenID { return core.AllPairs() }
 
+func (c *AMMController) InitFromFile(path string) error {
+    return core.InitPoolsFromFile(path)
+}
+
 //---------------------------------------------------------------------
 // CLI command declarations
 //---------------------------------------------------------------------
@@ -93,6 +97,20 @@ var ammCmd = &cobra.Command{
     Use:               "amm",
     Short:             "Automated‑market‑maker utilities (swap, liquidity, quotes)",
     PersistentPreRunE: ensureAMMInitialised,
+}
+
+var initCmd = &cobra.Command{
+    Use:   "init <fixture-file>",
+    Short: "Initialise pools from a JSON fixture",
+    Args:  cobra.ExactArgs(1),
+    RunE: func(cmd *cobra.Command, args []string) error {
+        ctrl := &AMMController{}
+        if err := ctrl.InitFromFile(args[0]); err != nil {
+            return err
+        }
+        fmt.Printf("Pools initialised from %s\n", args[0])
+        return nil
+    },
 }
 
 // swap -----------------------------------------------------------------------
@@ -198,6 +216,7 @@ func init() {
     swapCmd.Flags().Int("max‑hops", 4, "maximum hops allowed in the route")
     quoteCmd.Flags().Int("max‑hops", 4, "maximum hops allowed in the route")
 
+    ammCmd.AddCommand(initCmd)
     ammCmd.AddCommand(swapCmd)
     ammCmd.AddCommand(addCmd)
     ammCmd.AddCommand(removeCmd)

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -55,8 +55,9 @@ var gasTable = map[Opcode]uint64{
 	SwapExactIn:    4_500,
 	AddLiquidity:   5_000,
 	RemoveLiquidity:5_000,
-	Quote:          2_500,
-	AllPairs:       2_000,
+        Quote:          2_500,
+        AllPairs:       2_000,
+        InitPoolsFromFile: 6_000,
 
 	// ----------------------------------------------------------------------
 	// Authority / Validator-Set

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -133,8 +133,9 @@ var catalogue = []struct {
 	{"SwapExactIn", 0x020001},
 	{"AMM_AddLiquidity", 0x020002},
 	{"AMM_RemoveLiquidity", 0x020003},
-	{"Quote", 0x020004},
-	{"AllPairs", 0x020005},
+        {"Quote", 0x020004},
+        {"AllPairs", 0x020005},
+        {"InitPoolsFromFile", 0x020006},
 
 	// Authority (0x03)
 	{"NewAuthoritySet", 0x030001},


### PR DESCRIPTION
## Summary
- extend `amm` module with `InitPoolsFromFile` helper
- expose `init` command in AMM CLI
- register opcode and gas cost for pool bootstrap function

## Testing
- `go test ./...` *(fails: no required module provides package)*

------
https://chatgpt.com/codex/tasks/task_e_688abd5989e08320bd46caf3d591eb9b