### PR TITLE
Extend charity pool API and CLI

### DIFF
--- a/synnergy-network/cmd/cli/charity_pool.go
+++ b/synnergy-network/cmd/cli/charity_pool.go
@@ -1,32 +1,34 @@
 // cmd/cli/charity_pool.go – Cobra CLI integration for the on‑chain CharityPool
 // -----------------------------------------------------------------------------
 // Layout
-//   • Middleware        – dependency & genesis wiring
-//   • Controller        – thin wrapper around core.CharityPool
-//   • Command decl.     – user‑visible sub‑commands at top of file
-//   • Consolidation     – all commands mounted under root `charity` and
-//                         exported via CharityCmd for main‑index import.
+//   - Middleware        – dependency & genesis wiring
+//   - Controller        – thin wrapper around core.CharityPool
+//   - Command decl.     – user‑visible sub‑commands at top of file
+//   - Consolidation     – all commands mounted under root `charity` and
+//     exported via CharityCmd for main‑index import.
 //
 // After mounting in your root command:
-//     $ synnergy charity register tz1Charity wildlife "Save the Whales"
-//     $ synnergy charity vote tz1Alice tz1Charity
-//     $ synnergy charity tick                     # manual cron kick
-//     $ synnergy charity winners                  # inspect winners list
+//
+//	$ synnergy charity register tz1Charity wildlife "Save the Whales"
+//	$ synnergy charity vote tz1Alice tz1Charity
+//	$ synnergy charity tick                     # manual cron kick
+//	$ synnergy charity winners                  # inspect winners list
+//
 // -----------------------------------------------------------------------------
 package cli
 
 import (
-    "encoding/json"
-    "errors"
-    "fmt"
-    "strconv"
-    "strings"
-    "time"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
 
-    "github.com/spf13/cobra"
-    "github.com/spf13/viper"
-    "github.com/sirupsen/logrus"
-    core "github.com/synnergy-network/core" // adjust if go.mod path differs
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	core "github.com/synnergy-network/core" // adjust if go.mod path differs
 )
 
 //---------------------------------------------------------------------
@@ -34,9 +36,9 @@ import (
 //---------------------------------------------------------------------
 
 const (
-    cycleDuration      = 90 * 24 * time.Hour
-    registrationCutoff = 30 * 24 * time.Hour
-    votingWindow       = 15 * 24 * time.Hour
+	cycleDuration      = 90 * 24 * time.Hour
+	registrationCutoff = 30 * 24 * time.Hour
+	votingWindow       = 15 * 24 * time.Hour
 )
 
 //---------------------------------------------------------------------
@@ -44,40 +46,40 @@ const (
 //---------------------------------------------------------------------
 
 var (
-    cp        *core.CharityPool
-    genesisTs time.Time
+	cp        *core.CharityPool
+	genesisTs time.Time
 )
 
 type cliElectorate struct{}
 
 func (cliElectorate) IsIDTokenHolder(a core.Address) bool {
-    // Defer to AuthoritySet if available, else allow (dev‑mode).
-    if set := core.CurrentAuthoritySet(); set != nil {
-        return set.IsAuthority(a)
-    }
-    return true // permissive fallback for local testing
+	// Defer to AuthoritySet if available, else allow (dev‑mode).
+	if set := core.CurrentAuthoritySet(); set != nil {
+		return set.IsAuthority(a)
+	}
+	return true // permissive fallback for local testing
 }
 
 func ensureCharityInitialised(cmd *cobra.Command, _ []string) error {
-    if cp != nil {
-        return nil // already ready
-    }
-    led := core.CurrentLedger()
-    if led == nil {
-        return errors.New("ledger not initialised – start node or init ledger first")
-    }
-    // Parse genesis timestamp – default to 2025‑01‑01 UTC if env not provided.
-    gstr := viper.GetString("CHARITY_GENESIS")
-    if gstr == "" {
-        gstr = "2025-01-01T00:00:00Z"
-    }
-    t, err := time.Parse(time.RFC3339, gstr)
-    if err != nil {
-        return fmt.Errorf("invalid CHARITY_GENESIS env: %w", err)
-    }
-    genesisTs = t
-    cp = core.NewCharityPool(logrus.StandardLogger(), led, cliElectorate{}, genesisTs)
-    return nil
+	if cp != nil {
+		return nil // already ready
+	}
+	led := core.CurrentLedger()
+	if led == nil {
+		return errors.New("ledger not initialised – start node or init ledger first")
+	}
+	// Parse genesis timestamp – default to 2025‑01‑01 UTC if env not provided.
+	gstr := viper.GetString("CHARITY_GENESIS")
+	if gstr == "" {
+		gstr = "2025-01-01T00:00:00Z"
+	}
+	t, err := time.Parse(time.RFC3339, gstr)
+	if err != nil {
+		return fmt.Errorf("invalid CHARITY_GENESIS env: %w", err)
+	}
+	genesisTs = t
+	cp = core.NewCharityPool(logrus.StandardLogger(), led, cliElectorate{}, genesisTs)
+	return nil
 }
 
 //---------------------------------------------------------------------
@@ -87,26 +89,32 @@ func ensureCharityInitialised(cmd *cobra.Command, _ []string) error {
 type CharityController struct{}
 
 func (c *CharityController) Register(addr core.Address, catStr, name string) error {
-    cat, err := parseCategory(catStr)
-    if err != nil { return err }
-    return cp.Register(addr, name, cat)
+	cat, err := parseCategory(catStr)
+	if err != nil {
+		return err
+	}
+	return cp.Register(addr, name, cat)
 }
 
 func (c *CharityController) Vote(voter, charity core.Address) error { return cp.Vote(voter, charity) }
 
 func (c *CharityController) Tick(now time.Time) {
-    cp.Tick(now)
+	cp.Tick(now)
 }
 
 func (c *CharityController) Winners(cycle uint64) ([]core.Address, error) {
-    key := []byte(fmt.Sprintf("charity:winners:%d", cycle))
-    raw, _ := core.CurrentLedger().GetState(key)
-    if len(raw) == 0 {
-        return nil, fmt.Errorf("no winner list for cycle %d", cycle)
-    }
-    var list []core.Address
-    _ = json.Unmarshal(raw, &list)
-    return list, nil
+	return cp.Winners(cycle)
+}
+
+func (c *CharityController) Registration(cycle uint64, addr core.Address) (*core.CharityRegistration, error) {
+	reg, ok, err := cp.GetRegistration(cycle, addr)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("charity not registered in cycle %d", cycle)
+	}
+	return &reg, nil
 }
 
 //---------------------------------------------------------------------
@@ -114,28 +122,30 @@ func (c *CharityController) Winners(cycle uint64) ([]core.Address, error) {
 //---------------------------------------------------------------------
 
 func parseCategory(s string) (core.CharityCategory, error) {
-    s = strings.TrimSpace(strings.ToLower(s))
-    switch s {
-    case "hunger", "hungerrelief":
-        return core.HungerRelief, nil
-    case "children", "childrenhelp":
-        return core.ChildrenHelp, nil
-    case "wildlife", "wildlifehelp":
-        return core.WildlifeHelp, nil
-    case "sea", "seasupport":
-        return core.SeaSupport, nil
-    case "disaster", "disastersupport":
-        return core.DisasterSupport, nil
-    case "war", "warsupport":
-        return core.WarSupport, nil
-    default:
-        return 0, fmt.Errorf("unknown category %q", s)
-    }
+	s = strings.TrimSpace(strings.ToLower(s))
+	switch s {
+	case "hunger", "hungerrelief":
+		return core.HungerRelief, nil
+	case "children", "childrenhelp":
+		return core.ChildrenHelp, nil
+	case "wildlife", "wildlifehelp":
+		return core.WildlifeHelp, nil
+	case "sea", "seasupport":
+		return core.SeaSupport, nil
+	case "disaster", "disastersupport":
+		return core.DisasterSupport, nil
+	case "war", "warsupport":
+		return core.WarSupport, nil
+	default:
+		return 0, fmt.Errorf("unknown category %q", s)
+	}
 }
 
 func currentCycle(now time.Time) uint64 {
-    if now.Before(genesisTs) { return 0 }
-    return uint64(now.Sub(genesisTs) / cycleDuration)
+	if now.Before(genesisTs) {
+		return 0
+	}
+	return uint64(now.Sub(genesisTs) / cycleDuration)
 }
 
 //---------------------------------------------------------------------
@@ -143,83 +153,115 @@ func currentCycle(now time.Time) uint64 {
 //---------------------------------------------------------------------
 
 var charityCmd = &cobra.Command{
-    Use:               "charity",
-    Short:             "On‑chain charity pool operations (register, vote, payouts)",
-    PersistentPreRunE: ensureCharityInitialised,
+	Use:               "charity",
+	Short:             "On‑chain charity pool operations (register, vote, payouts)",
+	PersistentPreRunE: ensureCharityInitialised,
 }
 
 // register -------------------------------------------------------------------
 var registerCmd = &cobra.Command{
-    Use:   "register <addr> <category> <name>",
-    Short: "Register a charity (must occur ≥30 days before cycle end)",
-    Args:  cobra.MinimumNArgs(3),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctrl := &CharityController{}
-        addr := core.Address(args[0])
-        catStr := args[1]
-        name := strings.Join(args[2:], " ")
-        if err := ctrl.Register(addr, catStr, name); err != nil {
-            return err
-        }
-        fmt.Printf("Charity %s registered in category %s\n", addr, catStr)
-        return nil
-    },
+	Use:   "register <addr> <category> <name>",
+	Short: "Register a charity (must occur ≥30 days before cycle end)",
+	Args:  cobra.MinimumNArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &CharityController{}
+		addr := core.Address(args[0])
+		catStr := args[1]
+		name := strings.Join(args[2:], " ")
+		if err := ctrl.Register(addr, catStr, name); err != nil {
+			return err
+		}
+		fmt.Printf("Charity %s registered in category %s\n", addr, catStr)
+		return nil
+	},
 }
 
 // vote -----------------------------------------------------------------------
 var voteCmd = &cobra.Command{
-    Use:   "vote <voterAddr> <charityAddr>",
-    Short: "Cast a vote (ID‑token holders only) during last 15d of cycle",
-    Args:  cobra.ExactArgs(2),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctrl := &CharityController{}
-        voter, charity := core.Address(args[0]), core.Address(args[1])
-        if err := ctrl.Vote(voter, charity); err != nil {
-            return err
-        }
-        fmt.Printf("Vote recorded %s → %s\n", voter, charity)
-        return nil
-    },
+	Use:   "vote <voterAddr> <charityAddr>",
+	Short: "Cast a vote (ID‑token holders only) during last 15d of cycle",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &CharityController{}
+		voter, charity := core.Address(args[0]), core.Address(args[1])
+		if err := ctrl.Vote(voter, charity); err != nil {
+			return err
+		}
+		fmt.Printf("Vote recorded %s → %s\n", voter, charity)
+		return nil
+	},
 }
 
 // tick -----------------------------------------------------------------------
 var tickCmd = &cobra.Command{
-    Use:   "tick [timestamp RFC3339]",
-    Short: "Manually trigger pool cron (daily payout & cycle finalise)",
-    Args:  cobra.RangeArgs(0, 1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctrl := &CharityController{}
-        now := time.Now().UTC()
-        if len(args) == 1 {
-            t, err := time.Parse(time.RFC3339, args[0])
-            if err != nil { return fmt.Errorf("invalid timestamp: %w", err) }
-            now = t.UTC()
-        }
-        ctrl.Tick(now)
-        fmt.Printf("Tick executed at %s\n", now.Format(time.RFC3339))
-        return nil
-    },
+	Use:   "tick [timestamp RFC3339]",
+	Short: "Manually trigger pool cron (daily payout & cycle finalise)",
+	Args:  cobra.RangeArgs(0, 1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &CharityController{}
+		now := time.Now().UTC()
+		if len(args) == 1 {
+			t, err := time.Parse(time.RFC3339, args[0])
+			if err != nil {
+				return fmt.Errorf("invalid timestamp: %w", err)
+			}
+			now = t.UTC()
+		}
+		ctrl.Tick(now)
+		fmt.Printf("Tick executed at %s\n", now.Format(time.RFC3339))
+		return nil
+	},
+}
+
+// registration ---------------------------------------------------------------
+var registrationCmd = &cobra.Command{
+	Use:   "registration <addr> [cycle]",
+	Short: "Show registration info for a charity in a given cycle",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &CharityController{}
+		addr := core.Address(args[0])
+		cycle := currentCycle(time.Now().UTC())
+		if len(args) == 2 {
+			c, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				return fmt.Errorf("cycle uint64: %w", err)
+			}
+			cycle = c
+		}
+		reg, err := ctrl.Registration(cycle, addr)
+		if err != nil {
+			return err
+		}
+		b, _ := json.MarshalIndent(reg, "", "  ")
+		fmt.Printf("Registration cycle %d:\n%s\n", cycle, string(b))
+		return nil
+	},
 }
 
 // winners --------------------------------------------------------------------
 var winnersCmd = &cobra.Command{
-    Use:   "winners [cycle]",
-    Short: "Show winner charities list for a cycle (default current)",
-    Args:  cobra.RangeArgs(0, 1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctrl := &CharityController{}
-        cycle := currentCycle(time.Now().UTC())
-        if len(args) == 1 {
-            c, err := strconv.ParseUint(args[0], 10, 64)
-            if err != nil { return fmt.Errorf("cycle uint64: %w", err) }
-            cycle = c
-        }
-        winners, err := ctrl.Winners(cycle)
-        if err != nil { return err }
-        b, _ := json.MarshalIndent(winners, "", "  ")
-        fmt.Printf("Winners cycle %d:\n%s\n", cycle, string(b))
-        return nil
-    },
+	Use:   "winners [cycle]",
+	Short: "Show winner charities list for a cycle (default current)",
+	Args:  cobra.RangeArgs(0, 1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &CharityController{}
+		cycle := currentCycle(time.Now().UTC())
+		if len(args) == 1 {
+			c, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("cycle uint64: %w", err)
+			}
+			cycle = c
+		}
+		winners, err := ctrl.Winners(cycle)
+		if err != nil {
+			return err
+		}
+		b, _ := json.MarshalIndent(winners, "", "  ")
+		fmt.Printf("Winners cycle %d:\n%s\n", cycle, string(b))
+		return nil
+	},
 }
 
 //---------------------------------------------------------------------
@@ -227,10 +269,11 @@ var winnersCmd = &cobra.Command{
 //---------------------------------------------------------------------
 
 func init() {
-    charityCmd.AddCommand(registerCmd)
-    charityCmd.AddCommand(voteCmd)
-    charityCmd.AddCommand(tickCmd)
-    charityCmd.AddCommand(winnersCmd)
+	charityCmd.AddCommand(registerCmd)
+	charityCmd.AddCommand(voteCmd)
+	charityCmd.AddCommand(tickCmd)
+	charityCmd.AddCommand(registrationCmd)
+	charityCmd.AddCommand(winnersCmd)
 }
 
 // Export for root‑CLI import

--- a/synnergy-network/core/charity_pool.go
+++ b/synnergy-network/core/charity_pool.go
@@ -18,15 +18,14 @@ package core
 // (sig verify for charity wallet keys). All times in UTC.
 
 import (
- 
-    "encoding/json"
-    "errors"
-    "fmt"
-    "sort"
-    "time"
-    "github.com/sirupsen/logrus"
-    "encoding/binary"
-    "crypto/sha256"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"sort"
+	"time"
 )
 
 //---------------------------------------------------------------------
@@ -36,62 +35,61 @@ import (
 type CharityCategory uint8
 
 const (
-    HungerRelief CharityCategory = iota + 1
-    ChildrenHelp
-    WildlifeHelp
-    SeaSupport
-    DisasterSupport
-    WarSupport
+	HungerRelief CharityCategory = iota + 1
+	ChildrenHelp
+	WildlifeHelp
+	SeaSupport
+	DisasterSupport
+	WarSupport
 )
 
 func (c CharityCategory) String() string {
-    switch c {
-    case HungerRelief:
-        return "HungerRelief"
-    case ChildrenHelp:
-        return "ChildrenHelp"
-    case WildlifeHelp:
-        return "WildlifeHelp"
-    case SeaSupport:
-        return "SeaSupport"
-    case DisasterSupport:
-        return "DisasterSupport"
-    case WarSupport:
-        return "WarSupport"
-    default:
-        return "Unknown"
-    }
+	switch c {
+	case HungerRelief:
+		return "HungerRelief"
+	case ChildrenHelp:
+		return "ChildrenHelp"
+	case WildlifeHelp:
+		return "WildlifeHelp"
+	case SeaSupport:
+		return "SeaSupport"
+	case DisasterSupport:
+		return "DisasterSupport"
+	case WarSupport:
+		return "WarSupport"
+	default:
+		return "Unknown"
+	}
 }
-
 
 //---------------------------------------------------------------------
 // Pool configuration
 //---------------------------------------------------------------------
 
 const (
-    cycleDuration      = 90 * 24 * time.Hour
-    registrationCutoff = 30 * 24 * time.Hour
-    votingWindow       = 15 * 24 * time.Hour
-    dailyPayout        = 24 * time.Hour
+	cycleDuration      = 90 * 24 * time.Hour
+	registrationCutoff = 30 * 24 * time.Hour
+	votingWindow       = 15 * 24 * time.Hour
+	dailyPayout        = 24 * time.Hour
 )
 
 var (
-    CharityPoolAccount     Address
-    InternalCharityAccount Address
+	CharityPoolAccount     Address
+	InternalCharityAccount Address
 )
 
 func init() {
-    var err error
+	var err error
 
-    CharityPoolAccount, err = StringToAddress("0x43686172697479426F7800000000000000000000")
-    if err != nil {
-        panic("invalid CharityPoolAccount: " + err.Error())
-    }
+	CharityPoolAccount, err = StringToAddress("0x43686172697479426F7800000000000000000000")
+	if err != nil {
+		panic("invalid CharityPoolAccount: " + err.Error())
+	}
 
-    InternalCharityAccount, err = StringToAddress("0x496E7443686172697479426F7800000000000000")
-    if err != nil {
-        panic("invalid InternalCharityAccount: " + err.Error())
-    }
+	InternalCharityAccount, err = StringToAddress("0x496E7443686172697479426F7800000000000000")
+	if err != nil {
+		panic("invalid InternalCharityAccount: " + err.Error())
+	}
 }
 
 //---------------------------------------------------------------------
@@ -99,25 +97,23 @@ func init() {
 //---------------------------------------------------------------------
 
 type electorate interface {
-    IsIDTokenHolder(addr Address) bool
+	IsIDTokenHolder(addr Address) bool
 }
 
 //---------------------------------------------------------------------
 // CharityPool struct
 //---------------------------------------------------------------------
 
-
 func NewCharityPool(lg *logrus.Logger, led StateRW, el electorate, genesis time.Time) *CharityPool {
-    return &CharityPool{logger: lg, led: led, vote: el, genesis: genesis}
+	return &CharityPool{logger: lg, led: led, vote: el, genesis: genesis}
 }
-
 
 //---------------------------------------------------------------------
 // Deposit – called by VM interpreter when charging gas fees (5% of total fee).
 //---------------------------------------------------------------------
 
 func (cp *CharityPool) Deposit(from Address, amount uint64) error {
-    return cp.led.Transfer(from, CharityPoolAccount, amount)
+	return cp.led.Transfer(from, CharityPoolAccount, amount)
 }
 
 //---------------------------------------------------------------------
@@ -125,28 +121,29 @@ func (cp *CharityPool) Deposit(from Address, amount uint64) error {
 //---------------------------------------------------------------------
 
 func (cp *CharityPool) Register(addr Address, name string, cat CharityCategory) error {
-    cp.mu.Lock(); defer cp.mu.Unlock()
-    now := time.Now().UTC()
-    cycle := cp.currentCycle(now.Add(registrationCutoff)) // registering for *next* cycle if within cutoff
-    if len(name) == 0 || len(name) > 64 {
-        return errors.New("invalid name")
-    }
-    if cat < HungerRelief || cat > WarSupport {
-        return errors.New("invalid category")
-    }
-    key := regKey(cycle, addr)
-    if exists, _ := cp.led.HasState(key); exists {
-        return errors.New("already registered")
-    }
-    // Ensure category cap <=5
-    count := cp.countCategoryRegistrations(cycle, cat)
-    if count >= 5 {
-        return errors.New("category full for cycle")
-    }
-    r := CharityRegistration{Addr: addr, Name: name, Category: cat, Cycle: cycle}
-    cp.led.SetState(key, mustJSON(r))
-    cp.logger.Printf("charity %s registered for cycle %d cat %s", addr.Short(), cycle, cat)
-    return nil
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	now := time.Now().UTC()
+	cycle := cp.currentCycle(now.Add(registrationCutoff)) // registering for *next* cycle if within cutoff
+	if len(name) == 0 || len(name) > 64 {
+		return errors.New("invalid name")
+	}
+	if cat < HungerRelief || cat > WarSupport {
+		return errors.New("invalid category")
+	}
+	key := regKey(cycle, addr)
+	if exists, _ := cp.led.HasState(key); exists {
+		return errors.New("already registered")
+	}
+	// Ensure category cap <=5
+	count := cp.countCategoryRegistrations(cycle, cat)
+	if count >= 5 {
+		return errors.New("category full for cycle")
+	}
+	r := CharityRegistration{Addr: addr, Name: name, Category: cat, Cycle: cycle}
+	cp.led.SetState(key, mustJSON(r))
+	cp.logger.Printf("charity %s registered for cycle %d cat %s", addr.Short(), cycle, cat)
+	return nil
 }
 
 //---------------------------------------------------------------------
@@ -154,62 +151,63 @@ func (cp *CharityPool) Register(addr Address, name string, cat CharityCategory) 
 //---------------------------------------------------------------------
 
 func (cp *CharityPool) Vote(voter, charity Address) error {
-    if !cp.vote.IsIDTokenHolder(voter) {
-        return errors.New("not verified voter")
-    }
-    now := time.Now().UTC()
-    cycle := cp.currentCycle(now)
-    cycleEnd := cp.cycleEnd(cycle)
-    if cycleEnd.Sub(now) > votingWindow {
-        return errors.New("voting not open yet")
-    }
-    regRaw, err := cp.led.GetState(regKey(cycle, charity))
-    if err != nil || len(regRaw) == 0 {
-        return errors.New("charity not registered this cycle")
-    }
-    // no double vote per cycle and voter
-    vkey := voteKey(cycleHash(cycle), voter)
-    if ok, _ := cp.led.HasState(vkey); ok {
-        return errors.New("already voted this cycle")
-    }
-    cp.led.SetState(vkey, charity.Bytes())
-    var reg CharityRegistration; _ = json.Unmarshal(regRaw, &reg)
-    reg.VoteCount++
-    cp.led.SetState(regKey(cycle, charity), mustJSON(reg))
-    return nil
+	if !cp.vote.IsIDTokenHolder(voter) {
+		return errors.New("not verified voter")
+	}
+	now := time.Now().UTC()
+	cycle := cp.currentCycle(now)
+	cycleEnd := cp.cycleEnd(cycle)
+	if cycleEnd.Sub(now) > votingWindow {
+		return errors.New("voting not open yet")
+	}
+	regRaw, err := cp.led.GetState(regKey(cycle, charity))
+	if err != nil || len(regRaw) == 0 {
+		return errors.New("charity not registered this cycle")
+	}
+	// no double vote per cycle and voter
+	vkey := voteKey(cycleHash(cycle), voter)
+	if ok, _ := cp.led.HasState(vkey); ok {
+		return errors.New("already voted this cycle")
+	}
+	cp.led.SetState(vkey, charity.Bytes())
+	var reg CharityRegistration
+	_ = json.Unmarshal(regRaw, &reg)
+	reg.VoteCount++
+	cp.led.SetState(regKey(cycle, charity), mustJSON(reg))
+	return nil
 }
 
 type Voter interface {
-    IsIDTokenHolder(Address) bool
+	IsIDTokenHolder(Address) bool
 }
 
 func cycleHash(cycle uint64) Hash {
-    var id Hash
-    var buf [8]byte
-    binary.BigEndian.PutUint64(buf[:], cycle)
-    h := sha256.Sum256(buf[:])
-    copy(id[:], h[:])
-    return id
+	var id Hash
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], cycle)
+	h := sha256.Sum256(buf[:])
+	copy(id[:], h[:])
+	return id
 }
-
 
 //---------------------------------------------------------------------
 // Tick – called each block; handles daily payouts and cycle transitions.
 //---------------------------------------------------------------------
 
 func (cp *CharityPool) Tick(ts time.Time) {
-    cp.mu.Lock(); defer cp.mu.Unlock()
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
 
-    // Daily payout?
-    if ts.Unix()-cp.lastDaily >= int64(dailyPayout.Seconds()) {
-        cp.distributeDaily()
-        cp.lastDaily = ts.Unix()
-    }
+	// Daily payout?
+	if ts.Unix()-cp.lastDaily >= int64(dailyPayout.Seconds()) {
+		cp.distributeDaily()
+		cp.lastDaily = ts.Unix()
+	}
 
-    // At cycle end +1 block, compute winners & persist for next 90d payouts.
-    if cp.isCycleBoundary(ts) {
-        cp.finaliseCycle(cp.currentCycle(ts))
-    }
+	// At cycle end +1 block, compute winners & persist for next 90d payouts.
+	if cp.isCycleBoundary(ts) {
+		cp.finaliseCycle(cp.currentCycle(ts))
+	}
 }
 
 //---------------------------------------------------------------------
@@ -217,48 +215,97 @@ func (cp *CharityPool) Tick(ts time.Time) {
 //---------------------------------------------------------------------
 
 func (cp *CharityPool) distributeDaily() {
-    bal := cp.led.BalanceOf(CharityPoolAccount)
-    if bal == 0 { return }
-    half := bal / 2
+	bal := cp.led.BalanceOf(CharityPoolAccount)
+	if bal == 0 {
+		return
+	}
+	half := bal / 2
 
-    cycle := cp.currentCycle(time.Now().UTC())
-    winners := cp.winnerList(cycle)
-    per := uint64(0)
-    if len(winners) > 0 {
-        per = half / uint64(len(winners))
-        for _, w := range winners {
-            _ = cp.led.Transfer(CharityPoolAccount, w, per)
-        }
-    }
-    _ = cp.led.Transfer(CharityPoolAccount, InternalCharityAccount, half)
-    cp.logger.Printf("charity daily payout half=%d perCharity=%d to %d winners", half, per, len(winners))
+	cycle := cp.currentCycle(time.Now().UTC())
+	winners := cp.winnerList(cycle)
+	per := uint64(0)
+	if len(winners) > 0 {
+		per = half / uint64(len(winners))
+		for _, w := range winners {
+			_ = cp.led.Transfer(CharityPoolAccount, w, per)
+		}
+	}
+	_ = cp.led.Transfer(CharityPoolAccount, InternalCharityAccount, half)
+	cp.logger.Printf("charity daily payout half=%d perCharity=%d to %d winners", half, per, len(winners))
 }
 
 func (cp *CharityPool) finaliseCycle(cycle uint64) {
-    // Determine top 5 per category by votes.
-    cats := make(map[CharityCategory][]CharityRegistration)
-    iter := cp.led.PrefixIterator([]byte(fmt.Sprintf("charity:reg:%d:", cycle)))
-    for iter.Next() {
-        var r CharityRegistration; _ = json.Unmarshal(iter.Value(), &r)
-        cats[r.Category] = append(cats[r.Category], r)
-    }
-    var winners []Address
-    for cat, list := range cats {
-        sort.Slice(list, func(i, j int) bool { return list[i].VoteCount > list[j].VoteCount })
-        n := 5; if len(list) < 5 { n = len(list) }
-        for i := 0; i < n; i++ {
-            winners = append(winners, list[i].Addr)
-        }
-        cp.logger.Printf("cycle %d cat %s winners: %d", cycle, cat, n)
-    }
-    // Persist winners set for daily payouts (next cycle period)
-    cp.led.SetState(winKey(cycle), mustJSON(winners))
+	// Determine top 5 per category by votes.
+	cats := make(map[CharityCategory][]CharityRegistration)
+	iter := cp.led.PrefixIterator([]byte(fmt.Sprintf("charity:reg:%d:", cycle)))
+	for iter.Next() {
+		var r CharityRegistration
+		_ = json.Unmarshal(iter.Value(), &r)
+		cats[r.Category] = append(cats[r.Category], r)
+	}
+	var winners []Address
+	for cat, list := range cats {
+		sort.Slice(list, func(i, j int) bool { return list[i].VoteCount > list[j].VoteCount })
+		n := 5
+		if len(list) < 5 {
+			n = len(list)
+		}
+		for i := 0; i < n; i++ {
+			winners = append(winners, list[i].Addr)
+		}
+		cp.logger.Printf("cycle %d cat %s winners: %d", cycle, cat, n)
+	}
+	// Persist winners set for daily payouts (next cycle period)
+	cp.led.SetState(winKey(cycle), mustJSON(winners))
 }
 
 func (cp *CharityPool) winnerList(cycle uint64) []Address {
-    raw, _ := cp.led.GetState(winKey(cycle))
-    if len(raw) == 0 { return nil }
-    var out []Address; _ = json.Unmarshal(raw, &out); return out
+	raw, _ := cp.led.GetState(winKey(cycle))
+	if len(raw) == 0 {
+		return nil
+	}
+	var out []Address
+	_ = json.Unmarshal(raw, &out)
+	return out
+}
+
+//---------------------------------------------------------------------
+// Winners – exported accessor returning winners for a given cycle
+//---------------------------------------------------------------------
+
+func (cp *CharityPool) Winners(cycle uint64) ([]Address, error) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	list := cp.winnerList(cycle)
+	if list == nil {
+		return nil, fmt.Errorf("no winners recorded for cycle %d", cycle)
+	}
+	out := make([]Address, len(list))
+	copy(out, list)
+	return out, nil
+}
+
+//---------------------------------------------------------------------
+// GetRegistration – return registration info if present
+//---------------------------------------------------------------------
+
+func (cp *CharityPool) GetRegistration(cycle uint64, addr Address) (CharityRegistration, bool, error) {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+
+	var reg CharityRegistration
+	raw, err := cp.led.GetState(regKey(cycle, addr))
+	if err != nil {
+		return reg, false, err
+	}
+	if len(raw) == 0 {
+		return reg, false, nil
+	}
+	if err := json.Unmarshal(raw, &reg); err != nil {
+		return reg, false, err
+	}
+	return reg, true, nil
 }
 
 //---------------------------------------------------------------------
@@ -266,32 +313,40 @@ func (cp *CharityPool) winnerList(cycle uint64) []Address {
 //---------------------------------------------------------------------
 
 func (cp *CharityPool) currentCycle(t time.Time) uint64 {
-    if t.Before(cp.genesis) { return 0 }
-    return uint64(t.Sub(cp.genesis) / cycleDuration)
+	if t.Before(cp.genesis) {
+		return 0
+	}
+	return uint64(t.Sub(cp.genesis) / cycleDuration)
 }
 
-func (cp *CharityPool) cycleEnd(cycle uint64) time.Time { return cp.genesis.Add(time.Duration(cycle+1) * cycleDuration) }
-func (cp *CharityPool) isCycleBoundary(ts time.Time) bool { return ts.UTC().Truncate(cycleDuration) == ts.UTC() }
+func (cp *CharityPool) cycleEnd(cycle uint64) time.Time {
+	return cp.genesis.Add(time.Duration(cycle+1) * cycleDuration)
+}
+func (cp *CharityPool) isCycleBoundary(ts time.Time) bool {
+	return ts.UTC().Truncate(cycleDuration) == ts.UTC()
+}
 
 //---------------------------------------------------------------------
 // Ledger key helpers
 //---------------------------------------------------------------------
 
 func regKey(cycle uint64, addr Address) []byte {
-    return []byte(fmt.Sprintf("charity:reg:%d:%s", cycle, addr.Hex()))
+	return []byte(fmt.Sprintf("charity:reg:%d:%s", cycle, addr.Hex()))
 }
 
 func winKey(cycle uint64) []byte { return []byte(fmt.Sprintf("charity:winners:%d", cycle)) }
 
-
 func (cp *CharityPool) countCategoryRegistrations(cycle uint64, cat CharityCategory) int {
-    iter := cp.led.PrefixIterator([]byte(fmt.Sprintf("charity:reg:%d:", cycle)))
-    count := 0
-    for iter.Next() {
-        var r CharityRegistration; _ = json.Unmarshal(iter.Value(), &r)
-        if r.Category == cat { count++ }
-    }
-    return count
+	iter := cp.led.PrefixIterator([]byte(fmt.Sprintf("charity:reg:%d:", cycle)))
+	count := 0
+	for iter.Next() {
+		var r CharityRegistration
+		_ = json.Unmarshal(iter.Value(), &r)
+		if r.Category == cat {
+			count++
+		}
+	}
+	return count
 }
 
 //---------------------------------------------------------------------

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -9,18 +9,18 @@
 // and leave sufficient head-room for future optimisation.
 //
 // IMPORTANT
-//   • The table MUST contain a unique entry for every opcode exported from the
+//   - The table MUST contain a unique entry for every opcode exported from the
 //     `core/opcodes` package (compile-time enforced).
-//   • Unknown / un‐priced opcodes fall back to `DefaultGasCost`, which is set
+//   - Unknown / un‐priced opcodes fall back to `DefaultGasCost`, which is set
 //     deliberately high and logged exactly once per missing opcode.
-//   • All reads from the table are fully concurrent-safe.
+//   - All reads from the table are fully concurrent-safe.
 //
 // NOTE
-//   The `Opcode` type and individual opcode constants are defined elsewhere in
-//   the core package-tree (see `core/opcodes/*.go`).  This file purposefully
-//   contains **no** duplicate keys; if a symbol appears in multiple subsystems
-//   it is listed **once** and its gas cost applies network-wide.
 //
+//	The `Opcode` type and individual opcode constants are defined elsewhere in
+//	the core package-tree (see `core/opcodes/*.go`).  This file purposefully
+//	contains **no** duplicate keys; if a symbol appears in multiple subsystems
+//	it is listed **once** and its gas cost applies network-wide.
 package core
 
 import "log"
@@ -37,59 +37,61 @@ var gasTable = map[Opcode]uint64{
 	// ----------------------------------------------------------------------
 	// AI
 	// ----------------------------------------------------------------------
-	InitAI:          50_000,
-	AI:              40_000,
-	PredictAnomaly:  35_000,
-	OptimizeFees:    25_000,
-	PublishModel:    45_000,
-	FetchModel:      15_000,
-	ListModel:       8_000,
-	ValidateKYC:     1_000,
-	BuyModel:        30_000,
-	RentModel:       20_000,
-	ReleaseEscrow:   12_000,
+	InitAI:         50_000,
+	AI:             40_000,
+	PredictAnomaly: 35_000,
+	OptimizeFees:   25_000,
+	PublishModel:   45_000,
+	FetchModel:     15_000,
+	ListModel:      8_000,
+	ValidateKYC:    1_000,
+	BuyModel:       30_000,
+	RentModel:      20_000,
+	ReleaseEscrow:  12_000,
 
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker
 	// ----------------------------------------------------------------------
-	SwapExactIn:    4_500,
-	AddLiquidity:   5_000,
-	RemoveLiquidity:5_000,
-	Quote:          2_500,
-	AllPairs:       2_000,
+	SwapExactIn:     4_500,
+	AddLiquidity:    5_000,
+	RemoveLiquidity: 5_000,
+	Quote:           2_500,
+	AllPairs:        2_000,
 
 	// ----------------------------------------------------------------------
 	// Authority / Validator-Set
 	// ----------------------------------------------------------------------
-	NewAuthoritySet: 20_000,
-	RecordVote:      3_000,
-	RegisterCandidate:8_000,
-	RandomElectorate: 4_000,
+	NewAuthoritySet:   20_000,
+	RecordVote:        3_000,
+	RegisterCandidate: 8_000,
+	RandomElectorate:  4_000,
 	IsAuthority:       800,
 
 	// ----------------------------------------------------------------------
 	// Charity Pool
 	// ----------------------------------------------------------------------
-	NewCharityPool: 10_000,
-	Deposit:        2_100,
-	Register:       2_500,
-	Vote:           3_000,
-	Tick:           1_000,
+	NewCharityPool:  10_000,
+	Deposit:         2_100,
+	Register:        2_500,
+	Vote:            3_000,
+	Tick:            1_000,
+	GetRegistration: 800,
+	Winners:         800,
 
 	// ----------------------------------------------------------------------
 	// Coin
 	// ----------------------------------------------------------------------
 	NewCoin:     12_000,
-	Mint:        2_100,  // shared with ledger & tokens
-	TotalSupply:   800,
-	BalanceOf:     400,
+	Mint:        2_100, // shared with ledger & tokens
+	TotalSupply: 800,
+	BalanceOf:   400,
 
 	// ----------------------------------------------------------------------
 	// Compliance
 	// ----------------------------------------------------------------------
-	InitCompliance:     8_000,
-	EraseData:          5_000,
-	RecordFraudSignal:  7_000,
+	InitCompliance:    8_000,
+	EraseData:         5_000,
+	RecordFraudSignal: 7_000,
 
 	// ----------------------------------------------------------------------
 	// Consensus Core
@@ -99,44 +101,44 @@ var gasTable = map[Opcode]uint64{
 	Subscribe:             1_500,
 	Sign:                  3_000, // shared with Security & Tx
 	Verify:                3_500, // shared with Security & Tx
-	ValidatorPubKey:         800,
+	ValidatorPubKey:       800,
 	StakeOf:               1_000,
-	LoanPoolAddress:         800,
-	Hash:                    600, // shared with Replication
+	LoanPoolAddress:       800,
+	Hash:                  600, // shared with Replication
 	SerializeWithoutNonce: 1_200,
-	NewConsensus:         25_000,
-	Start:                5_000,
-	ProposeSubBlock:     15_000,
-	ValidatePoH:        20_000,
-	SealMainBlockPOW:   60_000,
-	DistributeRewards:  10_000,
+	NewConsensus:          25_000,
+	Start:                 5_000,
+	ProposeSubBlock:       15_000,
+	ValidatePoH:           20_000,
+	SealMainBlockPOW:      60_000,
+	DistributeRewards:     10_000,
 
 	// ----------------------------------------------------------------------
 	// Contracts (WASM / EVM‐compat)
 	// ----------------------------------------------------------------------
 	InitContracts: 15_000,
 	CompileWASM:   45_000,
-	Invoke:         7_000,
+	Invoke:        7_000,
 
 	// ----------------------------------------------------------------------
 	// Cross-Chain
 	// ----------------------------------------------------------------------
 	RegisterBridge: 20_000,
-	AssertRelayer:   5_000,
-	Iterator:        2_000,
+	AssertRelayer:  5_000,
+	Iterator:       2_000,
 	LockAndMint:    30_000,
 	BurnAndRelease: 30_000,
-	GetBridge:       1_000,
+	GetBridge:      1_000,
 
 	// ----------------------------------------------------------------------
 	// Data / Oracle / IPFS Integration
 	// ----------------------------------------------------------------------
-	RegisterNode:  10_000,
-	UploadAsset:   30_000,
+	RegisterNode:   10_000,
+	UploadAsset:    30_000,
 	Pin:            5_000, // shared with Storage
 	Retrieve:       4_000, // shared with Storage
 	RetrieveAsset:  4_000,
-	RegisterOracle:10_000,
+	RegisterOracle: 10_000,
 	PushFeed:       3_000,
 	QueryOracle:    3_000,
 
@@ -148,98 +150,98 @@ var gasTable = map[Opcode]uint64{
 	RemovePeer:       1_500,
 	Snapshot:         4_000,
 	Recon:            8_000,
-	Ping:               300,
-	SendPing:           300,
-	AwaitPong:          300,
+	Ping:             300,
+	SendPing:         300,
+	AwaitPong:        300,
 
 	// ----------------------------------------------------------------------
 	// Governance
 	// ----------------------------------------------------------------------
 	UpdateParam:     5_000,
-	ProposeChange:  10_000,
+	ProposeChange:   10_000,
 	VoteChange:      3_000,
 	EnactChange:     8_000,
-	SubmitProposal: 10_000,
-	BalanceOfAsset:    600,
+	SubmitProposal:  10_000,
+	BalanceOfAsset:  600,
 	CastVote:        3_000,
-	ExecuteProposal:15_000,
+	ExecuteProposal: 15_000,
 
 	// ----------------------------------------------------------------------
 	// Green Technology
 	// ----------------------------------------------------------------------
-	InitGreenTech: 8_000,
-	Green:         2_000,
-	RecordUsage:   3_000,
-	RecordOffset:  3_000,
-	Certify:       7_000,
-	CertificateOf:   500,
-	ShouldThrottle:  200,
+	InitGreenTech:  8_000,
+	Green:          2_000,
+	RecordUsage:    3_000,
+	RecordOffset:   3_000,
+	Certify:        7_000,
+	CertificateOf:  500,
+	ShouldThrottle: 200,
 
 	// ----------------------------------------------------------------------
 	// Ledger / UTXO / Account-Model
 	// ----------------------------------------------------------------------
-	NewLedger:            50_000,
-	GetPendingSubBlocks:   2_000,
-	LastBlockHash:           600,
-	AppendBlock:          50_000,
-	MintBig:               2_200,
-	EmitApproval:          1_200,
-	EmitTransfer:          1_200,
-	DeductGas:             2_100,
-	WithinBlock:           1_000,
-	IsIDTokenHolder:         400,
-	TokenBalance:            400,
-	AddBlock:             40_000,
-	GetBlock:              2_000,
-	GetUTXO:               1_500,
-	AddToPool:             1_000,
-	ListPool:                800,
-	GetContract:           1_000,
-	Snapshot:              3_000,
-	MintToken:             2_000,
-	LastSubBlockHeight:      500,
-	LastBlockHeight:         500,
-	RecordPoSVote:         3_000,
-	AppendSubBlock:        8_000,
-	Transfer:              2_100, // shared with VM & Tokens
-	Burn:                  2_100, // shared with VM & Tokens
+	NewLedger:           50_000,
+	GetPendingSubBlocks: 2_000,
+	LastBlockHash:       600,
+	AppendBlock:         50_000,
+	MintBig:             2_200,
+	EmitApproval:        1_200,
+	EmitTransfer:        1_200,
+	DeductGas:           2_100,
+	WithinBlock:         1_000,
+	IsIDTokenHolder:     400,
+	TokenBalance:        400,
+	AddBlock:            40_000,
+	GetBlock:            2_000,
+	GetUTXO:             1_500,
+	AddToPool:           1_000,
+	ListPool:            800,
+	GetContract:         1_000,
+	Snapshot:            3_000,
+	MintToken:           2_000,
+	LastSubBlockHeight:  500,
+	LastBlockHeight:     500,
+	RecordPoSVote:       3_000,
+	AppendSubBlock:      8_000,
+	Transfer:            2_100, // shared with VM & Tokens
+	Burn:                2_100, // shared with VM & Tokens
 
 	// ----------------------------------------------------------------------
 	// Liquidity Manager (high-level AMM façade)
 	// ----------------------------------------------------------------------
-	InitAMM:      8_000,
-	Manager:      1_000,
-	CreatePool:  10_000,
-	Swap:         4_500,
+	InitAMM:    8_000,
+	Manager:    1_000,
+	CreatePool: 10_000,
+	Swap:       4_500,
 	// AddLiquidity & RemoveLiquidity already defined above
 
 	// ----------------------------------------------------------------------
 	// Loan-Pool
 	// ----------------------------------------------------------------------
 	NewLoanPool: 20_000,
-	Submit:       3_000,
-	Disburse:     8_000,
+	Submit:      3_000,
+	Disburse:    8_000,
 	// Vote  & Tick already priced
 	// RandomElectorate / IsAuthority already priced
 
 	// ----------------------------------------------------------------------
 	// Networking
 	// ----------------------------------------------------------------------
-	NewNode:          18_000,
-	HandlePeerFound:   1_500,
-	DialSeed:          2_000,
-	ListenAndServe:    8_000,
-	Close:               500,
-	Peers:               400,
-	NewDialer:         2_000,
-	Dial:              2_000,
+	NewNode:         18_000,
+	HandlePeerFound: 1_500,
+	DialSeed:        2_000,
+	ListenAndServe:  8_000,
+	Close:           500,
+	Peers:           400,
+	NewDialer:       2_000,
+	Dial:            2_000,
 	// Broadcast & Subscribe already priced
 
 	// ----------------------------------------------------------------------
 	// Replication / Data Availability
 	// ----------------------------------------------------------------------
-	NewReplicator: 12_000,
-	ReplicateBlock:30_000,
+	NewReplicator:  12_000,
+	ReplicateBlock: 30_000,
 	RequestMissing: 4_000,
 	Stop:           3_000,
 	// Hash & Start already priced
@@ -247,10 +249,10 @@ var gasTable = map[Opcode]uint64{
 	// ----------------------------------------------------------------------
 	// Roll-ups
 	// ----------------------------------------------------------------------
-	NewAggregator:     15_000,
-	SubmitBatch:       10_000,
-	SubmitFraudProof:  30_000,
-	FinalizeBatch:     10_000,
+	NewAggregator:    15_000,
+	SubmitBatch:      10_000,
+	SubmitFraudProof: 30_000,
+	FinalizeBatch:    10_000,
 
 	// ----------------------------------------------------------------------
 	// Security / Cryptography
@@ -266,48 +268,48 @@ var gasTable = map[Opcode]uint64{
 	// ----------------------------------------------------------------------
 	// Sharding
 	// ----------------------------------------------------------------------
-	NewShardCoordinator:20_000,
-	SetLeader:          1_000,
-	Leader:               800,
-	SubmitCrossShard:   15_000,
-	Send:               2_000,
-	PullReceipts:       3_000,
-	Reshard:           30_000,
+	NewShardCoordinator: 20_000,
+	SetLeader:           1_000,
+	Leader:              800,
+	SubmitCrossShard:    15_000,
+	Send:                2_000,
+	PullReceipts:        3_000,
+	Reshard:             30_000,
 	// Broadcast already priced
 
 	// ----------------------------------------------------------------------
 	// Side-chains
 	// ----------------------------------------------------------------------
-	InitSidechains:   12_000,
-	Sidechains:          600,
-	Register:          5_000,
-	SubmitHeader:      8_000,
-	VerifyWithdraw:    4_000,
-	VerifyAggregateSig:8_000,
-	VerifyMerkleProof: 1_200,
+	InitSidechains:     12_000,
+	Sidechains:         600,
+	Register:           5_000,
+	SubmitHeader:       8_000,
+	VerifyWithdraw:     4_000,
+	VerifyAggregateSig: 8_000,
+	VerifyMerkleProof:  1_200,
 	// Deposit already priced
 
 	// ----------------------------------------------------------------------
 	// State-Channels
 	// ----------------------------------------------------------------------
-	InitStateChannels:      8_000,
-	Channels:                 600,
-	OpenChannel:           10_000,
-	VerifyECDSASignature:   2_000,
-	InitiateClose:          3_000,
-	Challenge:              4_000,
-	Finalize:               5_000,
+	InitStateChannels:    8_000,
+	Channels:             600,
+	OpenChannel:          10_000,
+	VerifyECDSASignature: 2_000,
+	InitiateClose:        3_000,
+	Challenge:            4_000,
+	Finalize:             5_000,
 
 	// ----------------------------------------------------------------------
 	// Storage / Marketplace
 	// ----------------------------------------------------------------------
-	NewStorage:     12_000,
-	CreateListing:   8_000,
-	Exists:            400,
-	OpenDeal:        5_000,
-	Create:          8_000, // generic create (non-AMM/non-contract)
-	CloseDeal:       5_000,
-	Release:         2_000,
+	NewStorage:    12_000,
+	CreateListing: 8_000,
+	Exists:        400,
+	OpenDeal:      5_000,
+	Create:        8_000, // generic create (non-AMM/non-contract)
+	CloseDeal:     5_000,
+	Release:       2_000,
 	// Pin & Retrieve already priced
 
 	// ----------------------------------------------------------------------
@@ -370,30 +372,30 @@ var gasTable = map[Opcode]uint64{
 	// Token Utilities
 	// ----------------------------------------------------------------------
 	ID:              400,
-	Meta:             400,
-	Allowance:        400,
-	Approve:          800,
-	Add:              600,
-	Sub:              600,
-	Get:              400,
-	transfer:       2_100, // lower-case ERC20 compatibility
-	Calculate:        800,
-	RegisterToken:  8_000,
-	NewBalanceTable:5_000,
-	Set:              600,
-	RefundGas:        100,
-	PopUint32:        300,
-	PopAddress:       300,
-	PopUint64:        300,
-	PushBool:         300,
-	Push:             300,
-	Len:              200,
+	Meta:            400,
+	Allowance:       400,
+	Approve:         800,
+	Add:             600,
+	Sub:             600,
+	Get:             400,
+	transfer:        2_100, // lower-case ERC20 compatibility
+	Calculate:       800,
+	RegisterToken:   8_000,
+	NewBalanceTable: 5_000,
+	Set:             600,
+	RefundGas:       100,
+	PopUint32:       300,
+	PopAddress:      300,
+	PopUint64:       300,
+	PushBool:        300,
+	Push:            300,
+	Len:             200,
 
 	// ----------------------------------------------------------------------
 	// Transactions
 	// ----------------------------------------------------------------------
-	VerifySig:   3_500,
-	ValidateTx:  5_000,
+	VerifySig:  3_500,
+	ValidateTx: 5_000,
 	NewTxPool:  12_000,
 	// Sign already priced
 
@@ -403,89 +405,89 @@ var gasTable = map[Opcode]uint64{
 	//  micro-benchmarks – keep in mind that **all** word-size-dependent
 	//  corrections are applied at run-time by the VM).
 	// ----------------------------------------------------------------------
-	Short:              5,
-	BytesToAddress:     5,
-	Pop:                2,
-	opADD:              3,
-	opMUL:              5,
-	opSUB:              3,
-	OpDIV:              5,
-	opSDIV:             5,
-	opMOD:              5,
-	opSMOD:             5,
-	opADDMOD:           8,
-	opMULMOD:           8,
-	opEXP:             10,
-	opSIGNEXTEND:       5,
-	opLT:               3,
-	opGT:               3,
-	opSLT:              3,
-	opSGT:              3,
-	opEQ:               3,
-	opISZERO:           3,
-	opAND:              3,
-	opOR:               3,
-	opXOR:              3,
-	opNOT:              3,
-	opBYTE:             3,
-	opSHL:              3,
-	opSHR:              3,
-	opSAR:              3,
+	Short:            5,
+	BytesToAddress:   5,
+	Pop:              2,
+	opADD:            3,
+	opMUL:            5,
+	opSUB:            3,
+	OpDIV:            5,
+	opSDIV:           5,
+	opMOD:            5,
+	opSMOD:           5,
+	opADDMOD:         8,
+	opMULMOD:         8,
+	opEXP:            10,
+	opSIGNEXTEND:     5,
+	opLT:             3,
+	opGT:             3,
+	opSLT:            3,
+	opSGT:            3,
+	opEQ:             3,
+	opISZERO:         3,
+	opAND:            3,
+	opOR:             3,
+	opXOR:            3,
+	opNOT:            3,
+	opBYTE:           3,
+	opSHL:            3,
+	opSHR:            3,
+	opSAR:            3,
 	opECRECOVER:      700,
 	opEXTCODESIZE:    700,
 	opEXTCODECOPY:    700,
 	opEXTCODEHASH:    700,
-	opRETURNDATASIZE:   3,
+	opRETURNDATASIZE: 3,
 	opRETURNDATACOPY: 700,
-	opMLOAD:            3,
-	opMSTORE:           3,
-	opMSTORE8:          3,
-	opCALLDATALOAD:     3,
-	opCALLDATASIZE:     3,
+	opMLOAD:          3,
+	opMSTORE:         3,
+	opMSTORE8:        3,
+	opCALLDATALOAD:   3,
+	opCALLDATASIZE:   3,
 	opCALLDATACOPY:   700,
-	opCODESIZE:         3,
+	opCODESIZE:       3,
 	opCODECOPY:       700,
-	opJUMP:             8,
-	opJUMPI:           10,
-	opPC:               2,
-	opMSIZE:            2,
-	opGAS:              2,
-	opJUMPDEST:         1,
-	opSHA256:          60,
-	opKECCAK256:       30,
+	opJUMP:           8,
+	opJUMPI:          10,
+	opPC:             2,
+	opMSIZE:          2,
+	opGAS:            2,
+	opJUMPDEST:       1,
+	opSHA256:         60,
+	opKECCAK256:      30,
 	opRIPEMD160:      600,
-	opBLAKE2B256:      60,
-	opADDRESS:          2,
-	opCALLER:           2,
-	opORIGIN:           2,
-	opCALLVALUE:        2,
-	opGASPRICE:         2,
-	opNUMBER:           2,
-	opTIMESTAMP:        2,
-	opDIFFICULTY:       2,
-	opGASLIMIT:         2,
-	opCHAINID:          2,
-	opBLOCKHASH:       20,
+	opBLAKE2B256:     60,
+	opADDRESS:        2,
+	opCALLER:         2,
+	opORIGIN:         2,
+	opCALLVALUE:      2,
+	opGASPRICE:       2,
+	opNUMBER:         2,
+	opTIMESTAMP:      2,
+	opDIFFICULTY:     2,
+	opGASLIMIT:       2,
+	opCHAINID:        2,
+	opBLOCKHASH:      20,
 	opBALANCE:        400,
-	opSELFBALANCE:      5,
+	opSELFBALANCE:    5,
 	opLOG0:           375,
 	opLOG1:           750,
-	opLOG2:         1_125,
-	opLOG3:         1_500,
-	opLOG4:         1_875,
-	logN:           2_000,
-	opCREATE:      32_000,
+	opLOG2:           1_125,
+	opLOG3:           1_500,
+	opLOG4:           1_875,
+	logN:             2_000,
+	opCREATE:         32_000,
 	opCALL:           700,
 	opCALLCODE:       700,
 	opDELEGATECALL:   700,
 	opSTATICCALL:     700,
-	opRETURN:           0,
-	opREVERT:           0,
-	opSTOP:             0,
-	opSELFDESTRUCT: 5_000,
+	opRETURN:         0,
+	opREVERT:         0,
+	opSTOP:           0,
+	opSELFDESTRUCT:   5_000,
 
 	// Shared accounting ops
-	TransferVM:  2_100, // explicit VM variant (if separate constant exists)
+	TransferVM: 2_100, // explicit VM variant (if separate constant exists)
 
 	// ----------------------------------------------------------------------
 	// Virtual Machine Internals
@@ -493,28 +495,28 @@ var gasTable = map[Opcode]uint64{
 	BurnVM:            2_100,
 	BurnLP:            2_100,
 	MintLP:            2_100,
-	NewInMemory:         500,
-	CallCode:           700,
-	CallContract:       700,
-	StaticCallVM:       700,
-	GetBalance:         400,
-	GetTokenBalance:    400,
-	SetTokenBalance:    500,
-	GetTokenSupply:     500,
-	SetBalance:         500,
-	DelegateCall:       700,
-	GetToken:           400,
-	NewMemory:          500,
-	Read:                 3,
-	Write:                3,
-	LenVM:                3, // distinguish from token.Len if separate const
-	Call:               700,
-	SelectVM:         1_000,
-	CreateContract:  32_000,
+	NewInMemory:       500,
+	CallCode:          700,
+	CallContract:      700,
+	StaticCallVM:      700,
+	GetBalance:        400,
+	GetTokenBalance:   400,
+	SetTokenBalance:   500,
+	GetTokenSupply:    500,
+	SetBalance:        500,
+	DelegateCall:      700,
+	GetToken:          400,
+	NewMemory:         500,
+	Read:              3,
+	Write:             3,
+	LenVM:             3, // distinguish from token.Len if separate const
+	Call:              700,
+	SelectVM:          1_000,
+	CreateContract:    32_000,
 	AddLog:            375,
 	GetCode:           200,
 	GetCodeHash:       200,
-	MintTokenVM:     2_000,
+	MintTokenVM:       2_000,
 	PrefixIterator:    500,
 	NonceOf:           400,
 	GetState:          400,
@@ -522,26 +524,26 @@ var gasTable = map[Opcode]uint64{
 	HasState:          400,
 	DeleteState:       500,
 	NewGasMeter:       500,
-	SelfDestructVM:  5_000,
-	Remaining:           2,
-	Consume:             3,
-	ExecuteVM:        2_000,
+	SelfDestructVM:    5_000,
+	Remaining:         2,
+	Consume:           3,
+	ExecuteVM:         2_000,
 	NewSuperLightVM:   500,
 	NewLightVM:        800,
-	NewHeavyVM:      1_200,
-	ExecuteSuperLight:1_000,
-	ExecuteLight:    1_500,
-	ExecuteHeavy:    2_000,
+	NewHeavyVM:        1_200,
+	ExecuteSuperLight: 1_000,
+	ExecuteLight:      1_500,
+	ExecuteHeavy:      2_000,
 
 	// ----------------------------------------------------------------------
 	// Wallet / Key-Management
 	// ----------------------------------------------------------------------
-	NewRandomWallet:      10_000,
-	WalletFromMnemonic:    5_000,
-	NewHDWalletFromSeed:   6_000,
-	PrivateKey:              400,
-	NewAddress:              500,
-	SignTx:                3_000,
+	NewRandomWallet:     10_000,
+	WalletFromMnemonic:  5_000,
+	NewHDWalletFromSeed: 6_000,
+	PrivateKey:          400,
+	NewAddress:          500,
+	SignTx:              3_000,
 }
 
 // GasCost returns the **base** gas cost for a single opcode.  Dynamic portions

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -3,27 +3,28 @@
 // Synnergy Network – Core ▸ Opcode Dispatcher
 // -------------------------------------------
 //
-//  • Every high-level function in the protocol is assigned a UNIQUE 24-bit
-//    opcode:  0xCCNNNN  →  CC = category (1 byte), NNNN = ordinal (2 bytes).
-//  • The dispatcher maps opcodes ➝ concrete handlers and enforces gas-pricing
-//    through core.GasCost() before execution.
-//  • All collisions or missing handlers are FATAL at start-up; nothing slips
-//    into production unnoticed.
+//   - Every high-level function in the protocol is assigned a UNIQUE 24-bit
+//     opcode:  0xCCNNNN  →  CC = category (1 byte), NNNN = ordinal (2 bytes).
 //
-//  ────────────────────────────────────────────────────────────────────────────
-//  AUTOMATED SECTION
-//  -----------------
-//  The table below is **generated** by `go generate ./...` (see the generator
-//  in `cmd/genopcodes`).  Edit ONLY if you know what you’re doing; otherwise
-//  add new function names to `generator/input/functions.yml` and re-run
-//  `go generate`.  The generator guarantees deterministic, collision-free
-//  opcodes and keeps this file lint-clean.
+//   - The dispatcher maps opcodes ➝ concrete handlers and enforces gas-pricing
+//     through core.GasCost() before execution.
 //
-//  Format per line:
-//      <FunctionName>  =  <24-bit-binary>  =  <HexOpcode>
+//   - All collisions or missing handlers are FATAL at start-up; nothing slips
+//     into production unnoticed.
 //
-//  NB: Tabs are significant – tools rely on them when parsing for audits.
+//     ────────────────────────────────────────────────────────────────────────────
+//     AUTOMATED SECTION
+//     -----------------
+//     The table below is **generated** by `go generate ./...` (see the generator
+//     in `cmd/genopcodes`).  Edit ONLY if you know what you’re doing; otherwise
+//     add new function names to `generator/input/functions.yml` and re-run
+//     `go generate`.  The generator guarantees deterministic, collision-free
+//     opcodes and keeps this file lint-clean.
 //
+//     Format per line:
+//     <FunctionName>  =  <24-bit-binary>  =  <HexOpcode>
+//
+//     NB: Tabs are significant – tools rely on them when parsing for audits.
 package core
 
 import (
@@ -94,32 +95,32 @@ func wrap(name string) OpcodeFunc {
 // ────────────────────────────────────────────────────────────────────────────
 //
 // Category map:
-//   0x01 AI                     0x0F Liquidity
-//   0x02 AMM                    0x10 Loanpool
-//   0x03 Authority              0x11 Network
-//   0x04 Charity                0x12 Replication
-//   0x05 Coin                   0x13 Rollups
-//   0x06 Compliance             0x14 Security
-//   0x07 Consensus              0x15 Sharding
-//   0x08 Contracts              0x16 Sidechains
-//   0x09 CrossChain             0x17 StateChannel
-//   0x0A Data                   0x18 Storage
-//   0x0B FaultTolerance         0x19 Tokens
-//   0x0C Governance             0x1A Transactions
-//   0x0D GreenTech              0x1B Utilities
-//   0x0E Ledger                 0x1C VirtualMachine
-//                               0x1D Wallet
+//
+//	0x01 AI                     0x0F Liquidity
+//	0x02 AMM                    0x10 Loanpool
+//	0x03 Authority              0x11 Network
+//	0x04 Charity                0x12 Replication
+//	0x05 Coin                   0x13 Rollups
+//	0x06 Compliance             0x14 Security
+//	0x07 Consensus              0x15 Sharding
+//	0x08 Contracts              0x16 Sidechains
+//	0x09 CrossChain             0x17 StateChannel
+//	0x0A Data                   0x18 Storage
+//	0x0B FaultTolerance         0x19 Tokens
+//	0x0C Governance             0x1A Transactions
+//	0x0D GreenTech              0x1B Utilities
+//	0x0E Ledger                 0x1C VirtualMachine
+//	                            0x1D Wallet
 //
 // Each binary code is shown as a 24-bit big-endian string.
-//
 var catalogue = []struct {
 	name string
 	op   Opcode
 }{
 	// AI (0x01)
-	{"InitAI", 0x010001},           // 00000001 00000000 00000001
-	{"AI", 0x010002},               // 00000001 00000000 00000010
-	{"PredictAnomaly", 0x010003},   // 00000001 00000000 00000011
+	{"InitAI", 0x010001},         // 00000001 00000000 00000001
+	{"AI", 0x010002},             // 00000001 00000000 00000010
+	{"PredictAnomaly", 0x010003}, // 00000001 00000000 00000011
 	{"OptimizeFees", 0x010004},
 	{"PublishModel", 0x010005},
 	{"FetchModel", 0x010006},
@@ -149,6 +150,8 @@ var catalogue = []struct {
 	{"Charity_Register", 0x040003},
 	{"Charity_Vote", 0x040004},
 	{"Charity_Tick", 0x040005},
+	{"Charity_GetRegistration", 0x040006},
+	{"Charity_Winners", 0x040007},
 
 	// Coin (0x05)
 	{"NewCoin", 0x050001},


### PR DESCRIPTION
## Summary
- add exported methods `Winners` and `GetRegistration` to `CharityPool`
- expose query capability via CLI (new `registration` command)
- wire new queries to opcode dispatcher and gas table

## Testing
- `go test ./...` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_688ac0eee40483209c9077ca6ee2b447