### PR TITLE
Enhance coin module with transfer/burn support

### DIFF
--- a/synnergy-network/cmd/cli/coin.go
+++ b/synnergy-network/cmd/cli/coin.go
@@ -13,18 +13,18 @@ package cli
 // -----------------------------------------------------------------------------
 
 import (
-    "encoding/hex"
-    "fmt"
-    "os"
-    "strconv"
-    "strings"
-    "sync"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
 
-    "github.com/joho/godotenv"
-    "github.com/sirupsen/logrus"
-    "github.com/spf13/cobra"
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 
-    "synnergy-network/core"
+	"synnergy-network/core"
 )
 
 // -----------------------------------------------------------------------------
@@ -32,9 +32,9 @@ import (
 // -----------------------------------------------------------------------------
 
 var (
-    coinLedger *core.Ledger
-    coinMgr    *core.Coin
-    coinOnce   sync.Once
+	coinLedger *core.Ledger
+	coinMgr    *core.Coin
+	coinOnce   sync.Once
 )
 
 // -----------------------------------------------------------------------------
@@ -42,52 +42,81 @@ var (
 // -----------------------------------------------------------------------------
 
 func coinInitMiddleware(cmd *cobra.Command, _ []string) error {
-    var err error
-    coinOnce.Do(func() {
-        // 1) .env → ENV
-        _ = godotenv.Load()
+	var err error
+	coinOnce.Do(func() {
+		// 1) .env → ENV
+		_ = godotenv.Load()
 
-        // 2) Logging level
-        lvl := os.Getenv("LOG_LEVEL")
-        if lvl == "" { lvl = "info" }
-        lv, e := logrus.ParseLevel(lvl); if e != nil { err = e; return }
-        logrus.SetLevel(lv)
+		// 2) Logging level
+		lvl := os.Getenv("LOG_LEVEL")
+		if lvl == "" {
+			lvl = "info"
+		}
+		lv, e := logrus.ParseLevel(lvl)
+		if e != nil {
+			err = e
+			return
+		}
+		logrus.SetLevel(lv)
 
-        // 3) Build ledger config (WAL + snapshot paths configurable via ENV)
-        walPath  := coinEnvOr("LEDGER_WAL", "./ledger.wal")
-        snapPath := coinEnvOr("LEDGER_SNAPSHOT", "./ledger.snap")
-        interval := coinEnvOrInt("LEDGER_SNAPSHOT_INTERVAL", 100)
+		// 3) Build ledger config (WAL + snapshot paths configurable via ENV)
+		walPath := coinEnvOr("LEDGER_WAL", "./ledger.wal")
+		snapPath := coinEnvOr("LEDGER_SNAPSHOT", "./ledger.snap")
+		interval := coinEnvOrInt("LEDGER_SNAPSHOT_INTERVAL", 100)
 
-        coinLedger, e = core.NewLedger(core.LedgerConfig{
-            WALPath:          walPath,
-            SnapshotPath:     snapPath,
-            SnapshotInterval: interval,
-        })
-        if e != nil { err = e; return }
+		coinLedger, e = core.NewLedger(core.LedgerConfig{
+			WALPath:          walPath,
+			SnapshotPath:     snapPath,
+			SnapshotInterval: interval,
+		})
+		if e != nil {
+			err = e
+			return
+		}
 
-        coinMgr, e = core.NewCoin(coinLedger); if e != nil { err = e }
-    })
-    return err
+		coinMgr, e = core.NewCoin(coinLedger)
+		if e != nil {
+			err = e
+		}
+	})
+	return err
 }
 
-func coinEnvOr(key, def string) string { if v:=os.Getenv(key); v!="" { return v }; return def }
-func coinEnvOrInt(k string, def int) int { if v:=os.Getenv(k); v!="" { if n,err:=strconv.Atoi(v); err==nil { return n } }; return def }
+func coinEnvOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+func coinEnvOrInt(k string, def int) int {
+	if v := os.Getenv(k); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
 
 // -----------------------------------------------------------------------------
 // Helper parsing utils
 // -----------------------------------------------------------------------------
 
 func coinDecodeAddr(h string) (core.Address, error) {
-    var a core.Address
-    b, err := hex.DecodeString(strings.TrimPrefix(h, "0x"))
-    if err != nil || len(b) != len(a) { return a, fmt.Errorf("invalid address") }
-    copy(a[:], b); return a, nil
+	var a core.Address
+	b, err := hex.DecodeString(strings.TrimPrefix(h, "0x"))
+	if err != nil || len(b) != len(a) {
+		return a, fmt.Errorf("invalid address")
+	}
+	copy(a[:], b)
+	return a, nil
 }
 
 func coinParseAmt(s string) (uint64, error) {
-    n, err := strconv.ParseUint(s, 10, 64)
-    if err != nil || n == 0 { return 0, fmt.Errorf("amount must be positive uint64") }
-    return n, nil
+	n, err := strconv.ParseUint(s, 10, 64)
+	if err != nil || n == 0 {
+		return 0, fmt.Errorf("amount must be positive uint64")
+	}
+	return n, nil
 }
 
 // -----------------------------------------------------------------------------
@@ -95,22 +124,69 @@ func coinParseAmt(s string) (uint64, error) {
 // -----------------------------------------------------------------------------
 
 func coinHandleMint(cmd *cobra.Command, args []string) error {
-    addr, err := coinDecodeAddr(args[0]); if err != nil { return err }
-    amt,  err := coinParseAmt(args[1]);  if err != nil { return err }
-    if err := coinMgr.Mint(addr[:], amt); err != nil { return err }
-    fmt.Fprintf(cmd.OutOrStdout(), "minted %d %s to %s\n", amt, core.Code, args[0])
-    return nil
+	addr, err := coinDecodeAddr(args[0])
+	if err != nil {
+		return err
+	}
+	amt, err := coinParseAmt(args[1])
+	if err != nil {
+		return err
+	}
+	if err := coinMgr.Mint(addr[:], amt); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "minted %d %s to %s\n", amt, core.Code, args[0])
+	return nil
 }
 
 func coinHandleSupply(cmd *cobra.Command, _ []string) error {
-    fmt.Fprintf(cmd.OutOrStdout(), "%d\n", coinMgr.TotalSupply())
-    return nil
+	fmt.Fprintf(cmd.OutOrStdout(), "%d\n", coinMgr.TotalSupply())
+	return nil
 }
 
 func coinHandleBalance(cmd *cobra.Command, args []string) error {
-    addr, err := coinDecodeAddr(args[0]); if err != nil { return err }
-    fmt.Fprintf(cmd.OutOrStdout(), "%d\n", coinMgr.BalanceOf(addr[:]))
-    return nil
+	addr, err := coinDecodeAddr(args[0])
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%d\n", coinMgr.BalanceOf(addr[:]))
+	return nil
+}
+
+func coinHandleTransfer(cmd *cobra.Command, args []string) error {
+	from, err := coinDecodeAddr(args[0])
+	if err != nil {
+		return err
+	}
+	to, err := coinDecodeAddr(args[1])
+	if err != nil {
+		return err
+	}
+	amt, err := coinParseAmt(args[2])
+	if err != nil {
+		return err
+	}
+	if err := coinMgr.Transfer(from[:], to[:], amt); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "transferred %d %s from %s to %s\n", amt, core.Code, args[0], args[1])
+	return nil
+}
+
+func coinHandleBurn(cmd *cobra.Command, args []string) error {
+	addr, err := coinDecodeAddr(args[0])
+	if err != nil {
+		return err
+	}
+	amt, err := coinParseAmt(args[1])
+	if err != nil {
+		return err
+	}
+	if err := coinMgr.Burn(addr[:], amt); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "burned %d %s from %s\n", amt, core.Code, args[0])
+	return nil
 }
 
 // -----------------------------------------------------------------------------
@@ -118,16 +194,20 @@ func coinHandleBalance(cmd *cobra.Command, args []string) error {
 // -----------------------------------------------------------------------------
 
 var coinRootCmd = &cobra.Command{
-    Use:               "coin",
-    Short:             "Native SYNN coin operations",
-    PersistentPreRunE: coinInitMiddleware,
+	Use:               "coin",
+	Short:             "Native SYNN coin operations",
+	PersistentPreRunE: coinInitMiddleware,
 }
 
-var coinMintCmd   = &cobra.Command{Use: "mint <addr> <amt>", Short: "Mint SYNN",   Args: cobra.ExactArgs(2), RunE: coinHandleMint}
-var coinSupplyCmd = &cobra.Command{Use: "supply",            Short: "Total supply", Args: cobra.NoArgs,       RunE: coinHandleSupply}
-var coinBalCmd    = &cobra.Command{Use: "balance <addr>",    Short: "Balance",     Args: cobra.ExactArgs(1), RunE: coinHandleBalance}
+var coinMintCmd = &cobra.Command{Use: "mint <addr> <amt>", Short: "Mint SYNN", Args: cobra.ExactArgs(2), RunE: coinHandleMint}
+var coinSupplyCmd = &cobra.Command{Use: "supply", Short: "Total supply", Args: cobra.NoArgs, RunE: coinHandleSupply}
+var coinBalCmd = &cobra.Command{Use: "balance <addr>", Short: "Balance", Args: cobra.ExactArgs(1), RunE: coinHandleBalance}
+var coinTransferCmd = &cobra.Command{Use: "transfer <from> <to> <amt>", Short: "Transfer SYNN", Args: cobra.ExactArgs(3), RunE: coinHandleTransfer}
+var coinBurnCmd = &cobra.Command{Use: "burn <addr> <amt>", Short: "Burn SYNN", Args: cobra.ExactArgs(2), RunE: coinHandleBurn}
 
-func init() { coinRootCmd.AddCommand(coinMintCmd, coinSupplyCmd, coinBalCmd) }
+func init() {
+	coinRootCmd.AddCommand(coinMintCmd, coinSupplyCmd, coinBalCmd, coinTransferCmd, coinBurnCmd)
+}
 
 // -----------------------------------------------------------------------------
 // Export Helpers

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -3,27 +3,28 @@
 // Synnergy Network – Core ▸ Opcode Dispatcher
 // -------------------------------------------
 //
-//  • Every high-level function in the protocol is assigned a UNIQUE 24-bit
-//    opcode:  0xCCNNNN  →  CC = category (1 byte), NNNN = ordinal (2 bytes).
-//  • The dispatcher maps opcodes ➝ concrete handlers and enforces gas-pricing
-//    through core.GasCost() before execution.
-//  • All collisions or missing handlers are FATAL at start-up; nothing slips
-//    into production unnoticed.
+//   - Every high-level function in the protocol is assigned a UNIQUE 24-bit
+//     opcode:  0xCCNNNN  →  CC = category (1 byte), NNNN = ordinal (2 bytes).
 //
-//  ────────────────────────────────────────────────────────────────────────────
-//  AUTOMATED SECTION
-//  -----------------
-//  The table below is **generated** by `go generate ./...` (see the generator
-//  in `cmd/genopcodes`).  Edit ONLY if you know what you’re doing; otherwise
-//  add new function names to `generator/input/functions.yml` and re-run
-//  `go generate`.  The generator guarantees deterministic, collision-free
-//  opcodes and keeps this file lint-clean.
+//   - The dispatcher maps opcodes ➝ concrete handlers and enforces gas-pricing
+//     through core.GasCost() before execution.
 //
-//  Format per line:
-//      <FunctionName>  =  <24-bit-binary>  =  <HexOpcode>
+//   - All collisions or missing handlers are FATAL at start-up; nothing slips
+//     into production unnoticed.
 //
-//  NB: Tabs are significant – tools rely on them when parsing for audits.
+//     ────────────────────────────────────────────────────────────────────────────
+//     AUTOMATED SECTION
+//     -----------------
+//     The table below is **generated** by `go generate ./...` (see the generator
+//     in `cmd/genopcodes`).  Edit ONLY if you know what you’re doing; otherwise
+//     add new function names to `generator/input/functions.yml` and re-run
+//     `go generate`.  The generator guarantees deterministic, collision-free
+//     opcodes and keeps this file lint-clean.
 //
+//     Format per line:
+//     <FunctionName>  =  <24-bit-binary>  =  <HexOpcode>
+//
+//     NB: Tabs are significant – tools rely on them when parsing for audits.
 package core
 
 import (
@@ -94,32 +95,32 @@ func wrap(name string) OpcodeFunc {
 // ────────────────────────────────────────────────────────────────────────────
 //
 // Category map:
-//   0x01 AI                     0x0F Liquidity
-//   0x02 AMM                    0x10 Loanpool
-//   0x03 Authority              0x11 Network
-//   0x04 Charity                0x12 Replication
-//   0x05 Coin                   0x13 Rollups
-//   0x06 Compliance             0x14 Security
-//   0x07 Consensus              0x15 Sharding
-//   0x08 Contracts              0x16 Sidechains
-//   0x09 CrossChain             0x17 StateChannel
-//   0x0A Data                   0x18 Storage
-//   0x0B FaultTolerance         0x19 Tokens
-//   0x0C Governance             0x1A Transactions
-//   0x0D GreenTech              0x1B Utilities
-//   0x0E Ledger                 0x1C VirtualMachine
-//                               0x1D Wallet
+//
+//	0x01 AI                     0x0F Liquidity
+//	0x02 AMM                    0x10 Loanpool
+//	0x03 Authority              0x11 Network
+//	0x04 Charity                0x12 Replication
+//	0x05 Coin                   0x13 Rollups
+//	0x06 Compliance             0x14 Security
+//	0x07 Consensus              0x15 Sharding
+//	0x08 Contracts              0x16 Sidechains
+//	0x09 CrossChain             0x17 StateChannel
+//	0x0A Data                   0x18 Storage
+//	0x0B FaultTolerance         0x19 Tokens
+//	0x0C Governance             0x1A Transactions
+//	0x0D GreenTech              0x1B Utilities
+//	0x0E Ledger                 0x1C VirtualMachine
+//	                            0x1D Wallet
 //
 // Each binary code is shown as a 24-bit big-endian string.
-//
 var catalogue = []struct {
 	name string
 	op   Opcode
 }{
 	// AI (0x01)
-	{"InitAI", 0x010001},           // 00000001 00000000 00000001
-	{"AI", 0x010002},               // 00000001 00000000 00000010
-	{"PredictAnomaly", 0x010003},   // 00000001 00000000 00000011
+	{"InitAI", 0x010001},         // 00000001 00000000 00000001
+	{"AI", 0x010002},             // 00000001 00000000 00000010
+	{"PredictAnomaly", 0x010003}, // 00000001 00000000 00000011
 	{"OptimizeFees", 0x010004},
 	{"PublishModel", 0x010005},
 	{"FetchModel", 0x010006},
@@ -155,6 +156,8 @@ var catalogue = []struct {
 	{"Coin_Mint", 0x050002},
 	{"Coin_TotalSupply", 0x050003},
 	{"Coin_BalanceOf", 0x050004},
+	{"Coin_Transfer", 0x050005},
+	{"Coin_Burn", 0x050006},
 
 	// Compliance (0x06)
 	{"InitCompliance", 0x060001},


### PR DESCRIPTION
## Summary
- implement `Transfer` and `Burn` methods for the SYNN coin
- expose new CLI commands `transfer` and `burn`
- register coin transfer/burn opcodes

## Testing
- `go test ./...` *(fails: missing external modules)*

------
https://chatgpt.com/codex/tasks/task_e_688ac129fa9c8320935937eca973b56f