### PR TITLE
Add CLI startup script and root command

### DIFF
--- a/synnergy-network/cmd/scripts/script_guide.md
+++ b/synnergy-network/cmd/scripts/script_guide.md
@@ -1,0 +1,19 @@
+# Synnergy Script Guide
+
+The `start_synnergy_network.sh` script builds the `synnergy` CLI and boots the
+core daemons using the commands provided by the CLI packages.  It also runs a
+sample security command.
+
+```bash
+./start_synnergy_network.sh
+```
+
+This will:
+
+1. Compile the CLI from `cmd/synnergy/main.go`.
+2. Start the networking, consensus, replication and VM services.
+3. Run a demo `~sec merkle` command.
+4. Wait until the services exit (Ctrl+C to terminate).
+
+Ensure that the Go toolchain is available in your `PATH` before running the
+script.

--- a/synnergy-network/cmd/scripts/start_synnergy_network.sh
+++ b/synnergy-network/cmd/scripts/start_synnergy_network.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Start essential Synnergy daemons using the CLI.
+# Requires Go toolchain installed.
+
+set -euo pipefail
+
+# Build the CLI binary
+GOFLAGS="-trimpath" go build -o synnergy ../synnergy
+
+# Launch background services
+./synnergy network start &
+NET_PID=$!
+
+./synnergy consensus start &
+CONS_PID=$!
+
+./synnergy replication start &
+REPL_PID=$!
+
+./synnergy vm start &
+VM_PID=$!
+
+# Example security action: compute Merkle root for demo data
+MERKLE=$(./synnergy ~sec merkle 68656c6c6f,776f726c64)
+echo "Merkle root: $MERKLE"
+
+echo "Synnergy network running. Press Ctrl+C to stop."
+trap 'kill $NET_PID $CONS_PID $REPL_PID $VM_PID' INT TERM
+wait $NET_PID $CONS_PID $REPL_PID $VM_PID

--- a/synnergy-network/cmd/synnergy/main.go
+++ b/synnergy-network/cmd/synnergy/main.go
@@ -1,2 +1,49 @@
-package main 
+package main
 
+import (
+	"github.com/spf13/cobra"
+
+	cli "synnergy-network/cmd/cli"
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "synnergy",
+		Short: "Synnergy network command line interface",
+	}
+
+	// Register sub‑commands exposed via helper functions.
+	cli.RegisterNetwork(rootCmd)
+	cli.RegisterConsensus(rootCmd)
+	cli.RegisterTokens(rootCmd)
+	cli.RegisterCoin(rootCmd)
+	cli.RegisterContracts(rootCmd)
+	cli.RegisterVM(rootCmd)
+	cli.RegisterTransactions(rootCmd)
+	cli.RegisterWallet(rootCmd)
+
+	// Add commands exported as variables or factories.
+	rootCmd.AddCommand(
+		cli.AICmd,
+		cli.AMMCmd,
+		cli.AuthCmd,
+		cli.CharityCmd,
+		cli.ComplianceCmd,
+		cli.CrossChainCmd,
+		cli.DataCmd,
+		cli.NewFaultToleranceCommand(),
+		cli.NewGovernanceCommand(),
+		cli.NewGreenCommand(),
+		cli.NewLedgerCommand(),
+		cli.NewReplicationCommand(),
+		cli.NewRollupCommand(),
+		cli.NewSecurityCommand(),
+		cli.NewShardingCommand(),
+		cli.NewSidechainCommand(),
+		cli.ChannelRoute,
+		cli.StorageRoute,
+		cli.UtilityRoute,
+	)
+
+	cobra.CheckErr(rootCmd.Execute())
+}


### PR DESCRIPTION
## Summary
- implement `cmd/synnergy/main.go` to register all CLI commands
- add `start_synnergy_network.sh` to build CLI and launch services
- document script usage in `script_guide.md`

## Testing
- `go test ./...` *(fails: no required module provides package github.com/spf13/viper)*

------
https://chatgpt.com/codex/tasks/task_e_688ac482959083208360d695b3aad7cb