### PR TITLE
Add opcode-based Solidity examples

### DIFF
--- a/synnergy-network/cmd/smart_contracts/cross_chain_eth.sol
+++ b/synnergy-network/cmd/smart_contracts/cross_chain_eth.sol
@@ -1,1 +1,55 @@
-package smartcontracts
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// CrossChainBridge demonstrates a minimal bridge contract that
+// locks Ether on this chain and emits events for off-chain relayers.
+// Admins can release funds after verifying proofs from the remote chain.
+// Some verification logic uses inline assembly to showcase opcode-level
+// operations.
+
+contract CrossChainBridge {
+    address public admin;
+    mapping(address => uint256) public balances;
+
+    event Deposit(address indexed from, bytes32 indexed toChain, uint256 amount);
+    event Withdraw(address indexed to, uint256 amount);
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "not admin");
+        _;
+    }
+
+    constructor() {
+        admin = msg.sender;
+    }
+
+    // Lock Ether and emit a deposit event containing the destination
+    // chain address encoded as bytes32.
+    function deposit(bytes32 toChainAddr) external payable {
+        require(msg.value > 0, "zero value");
+        unchecked { balances[msg.sender] += msg.value; }
+        emit Deposit(msg.sender, toChainAddr, msg.value);
+    }
+
+    // Release funds to a recipient after verifying a proof from the
+    // remote chain. The proof format is application specific and is
+    // validated with inline assembly for illustration.
+    function withdraw(address payable to, uint256 amount, bytes calldata proof) external onlyAdmin {
+        require(balances[to] >= amount, "insufficient");
+        require(_verifyProof(proof), "bad proof");
+        unchecked { balances[to] -= amount; }
+        emit Withdraw(to, amount);
+        (bool ok, ) = to.call{value: amount}("");
+        require(ok, "transfer failed");
+    }
+
+    // Example proof verification using assembly. For this demo we simply
+    // check that the first byte of the proof is 0x01, but more complex
+    // logic could be implemented directly with opcodes.
+    function _verifyProof(bytes calldata proof) private pure returns (bool valid) {
+        assembly {
+            // proof.offset gives the memory position of the bytes data
+            valid := eq(byte(0, calldataload(proof.offset)), 0x01)
+        }
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/liquidity_adder.sol
+++ b/synnergy-network/cmd/smart_contracts/liquidity_adder.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title LiquidityAdder showcases interaction with Synnergy's liquidity pool
+///        using opcode 0x0F0004 (Liquidity_AddLiquidity).
+/// @notice The gas table assigns 5,000 gas to this opcode.
+contract LiquidityAdder {
+    /// Add liquidity to a pool via a custom VM opcode.
+    /// @param poolId Identifier of the pool
+    /// @param amount Amount of base asset provided
+    function add(uint32 poolId, uint64 amount) external {
+        bytes4 opcode = 0x0F0004; // Liquidity_AddLiquidity
+        assembly {
+            mstore(0x0, poolId)
+            mstore(0x20, amount)
+            let success := call(gas(), 0, opcode, 0x0, 0x40, 0, 0)
+            if iszero(success) { revert(0, 0) }
+        }
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/oracle_reader.sol
+++ b/synnergy-network/cmd/smart_contracts/oracle_reader.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title OracleReader fetches data from Synnergy oracles via opcode 0x0A0008
+/// @notice Gas cost for QueryOracle is 3,000 as defined in `gas_table.go`.
+contract OracleReader {
+    /// Query an oracle ID and return raw bytes from the VM.
+    function query(bytes32 oracleId) external returns (bytes memory result) {
+        bytes4 opcode = 0x0A0008; // QueryOracle
+        assembly {
+            mstore(0x0, oracleId)
+            // We allocate 1K of return buffer for example purposes
+            let success := call(gas(), 0, opcode, 0x0, 0x20, 0x100, 0x400)
+            if iszero(success) { revert(0, 0) }
+            result := mload(0x100)
+        }
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/token_minter.sol
+++ b/synnergy-network/cmd/smart_contracts/token_minter.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title TokenMinter demonstrates calling Synnergy's custom MintToken opcode
+/// @notice Uses inline assembly to invoke opcode 0x1C001A defined in
+///         `opcode_dispatcher.go`. Gas cost is 2,000 per `gas_table.go`.
+contract TokenMinter {
+    /// Mint tokens to a recipient using a Synnergy VM opcode.
+    /// @param tokenId The 32-bit asset identifier
+    /// @param recipient Destination address that receives the minted amount
+    /// @param amount Number of tokens to mint
+    function mint(uint32 tokenId, address recipient, uint64 amount) external {
+        bytes4 opcode = 0x1C001A; // MintToken_VM
+        assembly {
+            // Layout: [tokenId(32)][recipient(32)][amount(32)]
+            mstore(0x0, tokenId)
+            mstore(0x20, recipient)
+            mstore(0x40, amount)
+            // Call precompile-like address 0 with custom opcode
+            let success := call(gas(), 0, opcode, 0x0, 0x60, 0, 0)
+            if iszero(success) { revert(0, 0) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add TokenMinter, LiquidityAdder and OracleReader example contracts demonstrating how to invoke Synnergy VM opcodes
- each contract references gas costs from the canonical gas table

## Testing
- `go test ./...` *(fails: go not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688ac4ba808083209277732be53ff8f8