### PR TITLE
Implement contract deployment registry

### DIFF
--- a/synnergy-network/cmd/cli/contracts.go
+++ b/synnergy-network/cmd/cli/contracts.go
@@ -30,20 +30,20 @@ package cli
 // ──────────────────────────────────────────────────────────────────────────────
 
 import (
-    "encoding/hex"
-    "encoding/json"
-    "fmt"
-    "io/ioutil"
-    "os"
-    "path/filepath"
-    "strconv"
-    "strings"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 
-    "github.com/joho/godotenv"
-    "github.com/sirupsen/logrus"
-    "github.com/spf13/cobra"
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 
-    "synnergy-network/core"
+	"synnergy-network/core"
 )
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -51,29 +51,40 @@ import (
 // ──────────────────────────────────────────────────────────────────────────────
 
 var (
-    vmSvc    core.VM
+	vmSvc core.VM
 )
 
 func initContractsMiddleware(cmd *cobra.Command, _ []string) error {
-    var err error
-    once.Do(func() {
-        _ = godotenv.Load()
+	var err error
+	once.Do(func() {
+		_ = godotenv.Load()
 
-        lvlStr := os.Getenv("LOG_LEVEL")
-        if lvlStr == "" { lvlStr = "info" }
-        lvl, e := logrus.ParseLevel(lvlStr)
-        if e != nil { err = fmt.Errorf("invalid LOG_LEVEL: %w", e); return }
-        logger.SetLevel(lvl)
+		lvlStr := os.Getenv("LOG_LEVEL")
+		if lvlStr == "" {
+			lvlStr = "info"
+		}
+		lvl, e := logrus.ParseLevel(lvlStr)
+		if e != nil {
+			err = fmt.Errorf("invalid LOG_LEVEL: %w", e)
+			return
+		}
+		logger.SetLevel(lvl)
 
-        lp := os.Getenv("LEDGER_PATH")
-        if lp == "" { err = fmt.Errorf("LEDGER_PATH env not set"); return }
-        ledger, e = core.OpenLedger(lp)
-        if e != nil { err = fmt.Errorf("open ledger: %w", e); return }
+		lp := os.Getenv("LEDGER_PATH")
+		if lp == "" {
+			err = fmt.Errorf("LEDGER_PATH env not set")
+			return
+		}
+		ledger, e = core.OpenLedger(lp)
+		if e != nil {
+			err = fmt.Errorf("open ledger: %w", e)
+			return
+		}
 
-        vmSvc = vm.NewEngine(vm.Config{Logger: logger})
-        core.InitContracts(ledger, vmSvc)
-    })
-    return err
+		vmSvc = vm.NewEngine(vm.Config{Logger: logger})
+		core.InitContracts(ledger, vmSvc)
+	})
+	return err
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -81,13 +92,13 @@ func initContractsMiddleware(cmd *cobra.Command, _ []string) error {
 // ──────────────────────────────────────────────────────────────────────────────
 
 func mustParseAddr(h string) (core.Address, error) {
-    var a core.Address
-    b, err := hex.DecodeString(strings.TrimPrefix(h, "0x"))
-    if err != nil || len(b) != len(a) {
-        return a, fmt.Errorf("invalid address %s", h)
-    }
-    copy(a[:], b)
-    return a, nil
+	var a core.Address
+	b, err := hex.DecodeString(strings.TrimPrefix(h, "0x"))
+	if err != nil || len(b) != len(a) {
+		return a, fmt.Errorf("invalid address %s", h)
+	}
+	copy(a[:], b)
+	return a, nil
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -97,93 +108,113 @@ func mustParseAddr(h string) (core.Address, error) {
 type compileFlags struct{ src string }
 
 func handleCompile(cmd *cobra.Command, _ []string) error {
-    cf := cmd.Context().Value("cflags").(compileFlags)
-    outDir := os.Getenv("WASM_OUT_DIR")
-    if outDir == "" { outDir = "./wasm" }
-    _ = os.MkdirAll(outDir, 0o755)
+	cf := cmd.Context().Value("cflags").(compileFlags)
+	outDir := os.Getenv("WASM_OUT_DIR")
+	if outDir == "" {
+		outDir = "./wasm"
+	}
+	_ = os.MkdirAll(outDir, 0o755)
 
-    wasm, hash, err := core.CompileWASM(cf.src, outDir)
-    if err != nil { return err }
+	wasm, hash, err := core.CompileWASM(cf.src, outDir)
+	if err != nil {
+		return err
+	}
 
-    outPath := filepath.Join(outDir, fmt.Sprintf("%x.wasm", hash[:8]))
-    if err := ioutil.WriteFile(outPath, wasm, 0o644); err != nil { return err }
-    fmt.Fprintf(cmd.OutOrStdout(), "compiled → %s\nhash: %x\n", outPath, hash[:])
-    return nil
+	outPath := filepath.Join(outDir, fmt.Sprintf("%x.wasm", hash[:8]))
+	if err := ioutil.WriteFile(outPath, wasm, 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "compiled → %s\nhash: %x\n", outPath, hash[:])
+	return nil
 }
 
 type deployFlags struct {
-    wasm   string
-    ric    string
-    gas    uint64
+	wasm string
+	ric  string
+	gas  uint64
 }
 
 func handleDeploy(cmd *cobra.Command, _ []string) error {
-    df := cmd.Context().Value("dflags").(deployFlags)
+	df := cmd.Context().Value("dflags").(deployFlags)
 
-    code, err := ioutil.ReadFile(df.wasm)
-    if err != nil { return err }
-    var ricData []byte
-    if df.ric != "" {
-        ricData, err = ioutil.ReadFile(df.ric)
-        if err != nil { return err }
-    }
+	code, err := ioutil.ReadFile(df.wasm)
+	if err != nil {
+		return err
+	}
+	var ricData []byte
+	if df.ric != "" {
+		ricData, err = ioutil.ReadFile(df.ric)
+		if err != nil {
+			return err
+		}
+	}
 
-    // derive address & register
-    caller := core.Address{} // system account 0x0…; could be flag in future
-    addr := core.DeriveContractAddress(caller, code)
-    cr := core.GetContractRegistry()
-    if err := cr.Deploy(addr, code, ricData, df.gas); err != nil { return err }
-    fmt.Fprintf(cmd.OutOrStdout(), "deployed at 0x%x\n", addr[:])
-    return nil
+	// derive address & register
+	caller := core.Address{} // system account 0x0…; could be flag in future
+	addr := core.DeriveContractAddress(caller, code)
+	cr := core.GetContractRegistry()
+	if err := cr.Deploy(addr, code, ricData, df.gas); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "deployed at 0x%x\n", addr[:])
+	return nil
 }
 
 type invokeFlags struct {
-    method string
-    args   string
-    gas    uint64
+	method string
+	args   string
+	gas    uint64
 }
 
 func handleInvoke(cmd *cobra.Command, args []string) error {
-    addrStr := args[0]
-    inv := cmd.Context().Value("iflags").(invokeFlags)
+	addrStr := args[0]
+	inv := cmd.Context().Value("iflags").(invokeFlags)
 
-    addr, err := mustParseAddr(addrStr)
-    if err != nil { return err }
+	addr, err := mustParseAddr(addrStr)
+	if err != nil {
+		return err
+	}
 
-    argBytes, err := hex.DecodeString(strings.TrimPrefix(inv.args, "0x"))
-    if err != nil && inv.args != "" {
-        return fmt.Errorf("args must be hex bytes")
-    }
+	argBytes, err := hex.DecodeString(strings.TrimPrefix(inv.args, "0x"))
+	if err != nil && inv.args != "" {
+		return fmt.Errorf("args must be hex bytes")
+	}
 
-    caller := core.Address{} // could add flag later
-    out, err := core.GetContractRegistry().Invoke(caller, addr, inv.method, argBytes, inv.gas)
-    if err != nil { return err }
-    fmt.Fprintf(cmd.OutOrStdout(), "%x\n", out)
-    return nil
+	caller := core.Address{} // could add flag later
+	out, err := core.GetContractRegistry().Invoke(caller, addr, inv.method, argBytes, inv.gas)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%x\n", out)
+	return nil
 }
 
 func handleList(cmd *cobra.Command, _ []string) error {
-    for addr, sc := range core.GetContractRegistry().All() {
-        fmt.Fprintf(cmd.OutOrStdout(), "0x%x\t%x\tgas %d\n", addr[:], sc.Hash[:8], sc.GasLimit)
-    }
-    return nil
+	for addr, sc := range core.GetContractRegistry().All() {
+		fmt.Fprintf(cmd.OutOrStdout(), "0x%x\t%x\tgas %d\n", addr[:], sc.Hash[:8], sc.GasLimit)
+	}
+	return nil
 }
 
 func handleInfo(cmd *cobra.Command, args []string) error {
-    addr, err := mustParseAddr(args[0])
-    if err != nil { return err }
-    ric, err := core.GetContractRegistry().Ricardian(addr)
-    if err != nil { return err }
-    var pretty map[string]any
-    if err := json.Unmarshal(ric, &pretty); err == nil {
-        b, _ := json.MarshalIndent(pretty, "", "  ")
-        cmd.OutOrStdout().Write(b)
-        fmt.Fprintln(cmd.OutOrStdout())
-    } else {
-        cmd.OutOrStdout().Write(ric)
-        fmt.Fprintln(cmd.OutOrStdout())
-    }
-    return nil
+	addr, err := mustParseAddr(args[0])
+	if err != nil {
+		return err
+	}
+	ric, err := core.GetContractRegistry().Ricardian(addr)
+	if err != nil {
+		return err
+	}
+	var pretty map[string]any
+	if err := json.Unmarshal(ric, &pretty); err == nil {
+		b, _ := json.MarshalIndent(pretty, "", "  ")
+		cmd.OutOrStdout().Write(b)
+		fmt.Fprintln(cmd.OutOrStdout())
+	} else {
+		cmd.OutOrStdout().Write(ric)
+		fmt.Fprintln(cmd.OutOrStdout())
+	}
+	return nil
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -191,71 +222,81 @@ func handleInfo(cmd *cobra.Command, args []string) error {
 // ──────────────────────────────────────────────────────────────────────────────
 
 var contractsCmd = &cobra.Command{
-    Use:               "contracts",
-    Short:             "Compile, deploy & invoke WASM smart‑contracts",
-    PersistentPreRunE: initContractsMiddleware,
+	Use:               "contracts",
+	Short:             "Compile, deploy & invoke WASM smart‑contracts",
+	PersistentPreRunE: initContractsMiddleware,
 }
 
 var compileCmd = &cobra.Command{
-    Use:   "compile <src.wat|src.wasm>",
-    Short: "Compile WAT/wasm to deterministic wasm blob",
-    Args:  cobra.ExactArgs(1),
-    RunE:  handleCompile,
-    PreRunE: func(cmd *cobra.Command, args []string) error {
-        cf := compileFlags{src: args[0]}
-        cmd.SetContext(context.WithValue(cmd.Context(), "cflags", cf))
-        return nil
-    },
+	Use:   "compile <src.wat|src.wasm>",
+	Short: "Compile WAT/wasm to deterministic wasm blob",
+	Args:  cobra.ExactArgs(1),
+	RunE:  handleCompile,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		cf := compileFlags{src: args[0]}
+		cmd.SetContext(context.WithValue(cmd.Context(), "cflags", cf))
+		return nil
+	},
 }
 
 var deployCmd = &cobra.Command{
-    Use:   "deploy",
-    Short: "Deploy compiled wasm with optional ricardian JSON",
-    Args:  cobra.NoArgs,
-    RunE:  handleDeploy,
-    PreRunE: func(cmd *cobra.Command, args []string) error {
-        df := deployFlags{}
-        df.wasm, _ = cmd.Flags().GetString("wasm")
-        df.ric, _ = cmd.Flags().GetString("ric")
-        gasStr, _ := cmd.Flags().GetString("gas")
-        if df.wasm == "" { return fmt.Errorf("--wasm required") }
-        if gasStr == "" { df.gas = 3_000_000 } else {
-            g, err := strconv.ParseUint(gasStr, 10, 64); if err != nil { return err } ; df.gas = g
-        }
-        cmd.SetContext(context.WithValue(cmd.Context(), "dflags", df))
-        return nil
-    },
+	Use:   "deploy",
+	Short: "Deploy compiled wasm with optional ricardian JSON",
+	Args:  cobra.NoArgs,
+	RunE:  handleDeploy,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		df := deployFlags{}
+		df.wasm, _ = cmd.Flags().GetString("wasm")
+		df.ric, _ = cmd.Flags().GetString("ric")
+		gasStr, _ := cmd.Flags().GetString("gas")
+		if df.wasm == "" {
+			return fmt.Errorf("--wasm required")
+		}
+		if gasStr == "" {
+			df.gas = 3_000_000
+		} else {
+			g, err := strconv.ParseUint(gasStr, 10, 64)
+			if err != nil {
+				return err
+			}
+			df.gas = g
+		}
+		cmd.SetContext(context.WithValue(cmd.Context(), "dflags", df))
+		return nil
+	},
 }
 
 var invokeCmd = &cobra.Command{
-    Use:   "invoke <address>",
-    Short: "Invoke a contract method",
-    Args:  cobra.ExactArgs(1),
-    RunE:  handleInvoke,
-    PreRunE: func(cmd *cobra.Command, args []string) error {
-        iv := invokeFlags{}
-        iv.method, _ = cmd.Flags().GetString("method")
-        iv.args, _ = cmd.Flags().GetString("args")
-        iv.gas, _ = cmd.Flags().GetUint64("gas")
-        if iv.method == "" { return fmt.Errorf("--method required") }
-        cmd.SetContext(context.WithValue(cmd.Context(), "iflags", iv))
-        return nil
-    },
+	Use:   "invoke <address>",
+	Short: "Invoke a contract method",
+	Args:  cobra.ExactArgs(1),
+	RunE:  handleInvoke,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		iv := invokeFlags{}
+		iv.method, _ = cmd.Flags().GetString("method")
+		iv.args, _ = cmd.Flags().GetString("args")
+		iv.gas, _ = cmd.Flags().GetUint64("gas")
+		if iv.method == "" {
+			return fmt.Errorf("--method required")
+		}
+		cmd.SetContext(context.WithValue(cmd.Context(), "iflags", iv))
+		return nil
+	},
 }
 
 var listCmd = &cobra.Command{Use: "list", Short: "List deployed contracts", Args: cobra.NoArgs, RunE: handleList}
 var infoCmd = &cobra.Command{Use: "info <address>", Short: "Show ricardian manifest", Args: cobra.ExactArgs(1), RunE: handleInfo}
 
 func init() {
-    deployCmd.Flags().String("wasm", "", "compiled wasm path")
-    deployCmd.Flags().String("ric", "", "ricardian manifest JSON (optional)")
-    deployCmd.Flags().String("gas", "", "gas limit (default 3M)")
+	deployCmd.Flags().String("wasm", "", "compiled wasm path")
+	deployCmd.Flags().String("ric", "", "ricardian manifest JSON (optional)")
+	deployCmd.Flags().String("gas", "", "gas limit (default 3M)")
 
-    invokeCmd.Flags().String("method", "", "method name")
-    invokeCmd.Flags().String("args", "", "hex‑encoded arg bytes")
-    invokeCmd.Flags().Uint64("gas", 200_000, "gas limit")
+	invokeCmd.Flags().String("method", "", "method name")
+	invokeCmd.Flags().String("args", "", "hex‑encoded arg bytes")
+	invokeCmd.Flags().Uint64("gas", 200_000, "gas limit")
 
-    contractsCmd.AddCommand(compileCmd, deployCmd, invokeCmd, listCmd, infoCmd)
+	contractsCmd.AddCommand(compileCmd, deployCmd, invokeCmd, listCmd, infoCmd)
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/synnergy-network/core/contracts.go
+++ b/synnergy-network/core/contracts.go
@@ -16,38 +16,37 @@ package core
 // -----------------------------------------------------------------------------
 
 import (
-    "crypto/sha256"
-    "errors"
-    "os/exec"
-    "path/filepath"
-    "sync"
-    "os"
-    "github.com/ethereum/go-ethereum/common"
+	"crypto/sha256"
+	"errors"
+	"github.com/ethereum/go-ethereum/common"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
 )
-
 
 //---------------------------------------------------------------------
 // Registry (singleton)
 //---------------------------------------------------------------------
 
 var (
-    contractOnce sync.Once
-    reg          *ContractRegistry
+	contractOnce sync.Once
+	reg          *ContractRegistry
 )
 
-
 func InitContracts(led StateRW, vmm VM) {
-    contractOnce.Do(func() {
-        reg = &ContractRegistry{
-            ledger: led,
-            vm:     vmm,
-            byAddr: make(map[Address]*SmartContract),
-        }
-    })
+	contractOnce.Do(func() {
+		reg = &ContractRegistry{
+			ledger: led,
+			vm:     vmm,
+			byAddr: make(map[Address]*SmartContract),
+		}
+	})
 }
 
-
-
+// GetContractRegistry exposes the singleton instance for other packages.
+func GetContractRegistry() *ContractRegistry { return reg }
 
 //---------------------------------------------------------------------
 // Compile & Deploy pipeline
@@ -55,92 +54,147 @@ func InitContracts(led StateRW, vmm VM) {
 
 // CompileWASM compiles source file to WASM byte‑blob via wazero CLI (deterministic build).
 func CompileWASM(srcPath string, outDir string) ([]byte, [32]byte, error) {
-    if filepath.Ext(srcPath) != ".wat" && filepath.Ext(srcPath) != ".wasm" {
-        return nil, [32]byte{}, errors.New("unsupported source – must be .wat/.wasm compiled offline beforehand")
-    }
+	if filepath.Ext(srcPath) != ".wat" && filepath.Ext(srcPath) != ".wasm" {
+		return nil, [32]byte{}, errors.New("unsupported source – must be .wat/.wasm compiled offline beforehand")
+	}
 
-    // If .wasm supplied, just read bytes; else use 'wat2wasm'.
-    var wasm []byte
-    if filepath.Ext(srcPath) == ".wasm" {
-        b, err := os.ReadFile(srcPath)
-        if err != nil { return nil, [32]byte{}, err }
-        wasm = b
-    } else {
-        out := filepath.Join(outDir, filepath.Base(srcPath)+".wasm")
-        cmd := exec.Command("wat2wasm", "-o", out, srcPath)
-        if err := cmd.Run(); err != nil { return nil, [32]byte{}, err }
-        b, _ := os.ReadFile(out); wasm = b
-    }
-    hash := sha256.Sum256(wasm)
-    return wasm, hash, nil
+	// If .wasm supplied, just read bytes; else use 'wat2wasm'.
+	var wasm []byte
+	if filepath.Ext(srcPath) == ".wasm" {
+		b, err := os.ReadFile(srcPath)
+		if err != nil {
+			return nil, [32]byte{}, err
+		}
+		wasm = b
+	} else {
+		out := filepath.Join(outDir, filepath.Base(srcPath)+".wasm")
+		cmd := exec.Command("wat2wasm", "-o", out, srcPath)
+		if err := cmd.Run(); err != nil {
+			return nil, [32]byte{}, err
+		}
+		b, _ := os.ReadFile(out)
+		wasm = b
+	}
+	hash := sha256.Sum256(wasm)
+	return wasm, hash, nil
 }
-
-
 
 //---------------------------------------------------------------------
 // Invocation – routed through VM.
 //---------------------------------------------------------------------
 
 func (cr *ContractRegistry) Invoke(
-    caller   Address,   // your own 20-byte address type
-    addr     Address,
-    method   string,
-    args     []byte,
-    gasLimit uint64,
+	caller Address, // your own 20-byte address type
+	addr Address,
+	method string,
+	args []byte,
+	gasLimit uint64,
 ) ([]byte, error) {
 
-    // 1. Look up the contract
-    cr.mu.RLock()
-    sc, ok := cr.byAddr[addr]
-    cr.mu.RUnlock()
-    if !ok {
-        return nil, errors.New("contract not found")
-    }
+	// 1. Look up the contract
+	cr.mu.RLock()
+	sc, ok := cr.byAddr[addr]
+	cr.mu.RUnlock()
+	if !ok {
+		return nil, errors.New("contract not found")
+	}
 
-    // 2. Clamp gas
-    if gasLimit == 0 || gasLimit > sc.GasLimit {
-        gasLimit = sc.GasLimit
-    }
+	// 2. Clamp gas
+	if gasLimit == 0 || gasLimit > sc.GasLimit {
+		gasLimit = sc.GasLimit
+	}
 
-    // 3. Convert your Address → common.Address
-    callerAddr := common.BytesToAddress(caller[:])   // helper from go-ethereum
-    originAddr := callerAddr                         // same for now
+	// 3. Convert your Address → common.Address
+	callerAddr := common.BytesToAddress(caller[:]) // helper from go-ethereum
+	originAddr := callerAddr                       // same for now
 
-    // 4. Build the VM context (only the fields that exist!)
-    vmCtx := &VMContext{
-        Caller:   callerAddr,
-        Origin:   originAddr,
-        TxHash:   zeroHash,  // or real hash if you have it
-        GasLimit: gasLimit,
-    }
+	// 4. Build the VM context (only the fields that exist!)
+	vmCtx := &VMContext{
+		Caller:   callerAddr,
+		Origin:   originAddr,
+		TxHash:   zeroHash, // or real hash if you have it
+		GasLimit: gasLimit,
+	}
 
-    // 5. IMPORTANT: argument order is (code, ctx)
-    rec, err := cr.vm.Execute(sc.Bytecode, vmCtx)
-    if err != nil {
-        return nil, err
-    }
+	// 5. IMPORTANT: argument order is (code, ctx)
+	rec, err := cr.vm.Execute(sc.Bytecode, vmCtx)
+	if err != nil {
+		return nil, err
+	}
 
-    // 6. Give back the contract’s return bytes
-    return rec.ReturnData, nil       // change to the actual field name
+	// 6. Give back the contract’s return bytes
+	return rec.ReturnData, nil // change to the actual field name
+}
+
+// Deploy registers a new smart-contract and stores code/metadata on the ledger.
+func (cr *ContractRegistry) Deploy(addr Address, code, ric []byte, gas uint64) error {
+	if len(code) == 0 {
+		return errors.New("empty contract bytecode")
+	}
+
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+
+	if _, exists := cr.byAddr[addr]; exists {
+		return errors.New("contract already deployed")
+	}
+
+	hash := sha256.Sum256(code)
+	sc := &SmartContract{
+		Address:   addr,
+		CodeHash:  hash,
+		Bytecode:  code,
+		GasLimit:  gas,
+		CreatedAt: time.Now().UTC(),
+	}
+	cr.byAddr[addr] = sc
+
+	if cr.ledger != nil {
+		if err := cr.ledger.SetState(contractKey(addr), code); err != nil {
+			return err
+		}
+		if len(ric) > 0 {
+			if err := cr.ledger.SetState(ricardianKey(addr), ric); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Ricardian fetches the ricardian contract JSON for the given address.
+func (cr *ContractRegistry) Ricardian(addr Address) ([]byte, error) {
+	if cr.ledger == nil {
+		return nil, errors.New("ledger not available")
+	}
+	return cr.ledger.GetState(ricardianKey(addr))
+}
+
+// All returns a snapshot of all deployed contracts.
+func (cr *ContractRegistry) All() map[Address]*SmartContract {
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+	out := make(map[Address]*SmartContract, len(cr.byAddr))
+	for a, c := range cr.byAddr {
+		out[a] = c
+	}
+	return out
 }
 
 var zeroHash [32]byte // all-zero value
-
-
-
-
 
 //---------------------------------------------------------------------
 // Helpers
 //---------------------------------------------------------------------
 
-func deriveContractAddress(creator Address, code []byte) Address {
-    pre := append(creator.Bytes(), code...)
-    h := sha256.Sum256(pre)
-    var out Address; copy(out[:], h[:20]); return out
+// DeriveContractAddress deterministically derives the contract address from creator and code.
+func DeriveContractAddress(creator Address, code []byte) Address {
+	pre := append(creator.Bytes(), code...)
+	h := sha256.Sum256(pre)
+	var out Address
+	copy(out[:], h[:20])
+	return out
 }
 
 func contractKey(addr Address) []byte  { return append([]byte("contract:code:"), addr.Bytes()...) }
 func ricardianKey(addr Address) []byte { return append([]byte("contract:ric:"), addr.Bytes()...) }
-
-

--- a/synnergy-network/core/contracts_opcodes.go
+++ b/synnergy-network/core/contracts_opcodes.go
@@ -1,0 +1,6 @@
+package core
+
+// Opcode constants for contract-related actions.
+const (
+	Deploy Opcode = 0x080004
+)

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -50,17 +50,15 @@ var gasTable = map[Opcode]uint64{
 	ReleaseEscrow:  12_000,
 	PredictVolume:  15_000,
 
-
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker
 	// ----------------------------------------------------------------------
-	SwapExactIn:    4_500,
-	AddLiquidity:   5_000,
-	RemoveLiquidity:5_000,
-  Quote:          2_500,
-  AllPairs:       2_000,
-  InitPoolsFromFile: 6_000,
-
+	SwapExactIn:       4_500,
+	AddLiquidity:      5_000,
+	RemoveLiquidity:   5_000,
+	Quote:             2_500,
+	AllPairs:          2_000,
+	InitPoolsFromFile: 6_000,
 
 	// ----------------------------------------------------------------------
 	// Authority / Validator-Set
@@ -106,7 +104,6 @@ var gasTable = map[Opcode]uint64{
 	Compliance_MonitorTx:  5_000,
 	Compliance_VerifyZKP:  12_000,
 
-
 	// ----------------------------------------------------------------------
 	// Consensus Core
 	// ----------------------------------------------------------------------
@@ -135,6 +132,7 @@ var gasTable = map[Opcode]uint64{
 	InitContracts: 15_000,
 	CompileWASM:   45_000,
 	Invoke:        7_000,
+	Deploy:        25_000,
 
 	// ----------------------------------------------------------------------
 	// Cross-Chain

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -135,9 +135,9 @@ var catalogue = []struct {
 	{"SwapExactIn", 0x020001},
 	{"AMM_AddLiquidity", 0x020002},
 	{"AMM_RemoveLiquidity", 0x020003},
-        {"Quote", 0x020004},
-        {"AllPairs", 0x020005},
-        {"InitPoolsFromFile", 0x020006},
+	{"Quote", 0x020004},
+	{"AllPairs", 0x020005},
+	{"InitPoolsFromFile", 0x020006},
 
 	// Authority (0x03)
 	{"NewAuthoritySet", 0x030001},
@@ -200,6 +200,7 @@ var catalogue = []struct {
 	{"InitContracts", 0x080001},
 	{"CompileWASM", 0x080002},
 	{"Invoke", 0x080003},
+	{"Deploy", 0x080004},
 
 	// Cross-Chain (0x09)
 	{"RegisterBridge", 0x090001},

--- a/synnergy-network/tests/contracts_test.go
+++ b/synnergy-network/tests/contracts_test.go
@@ -1,30 +1,32 @@
 package core
 
 import (
-    "crypto/sha256"
-    "os"
-    "path/filepath"
-    "reflect"
-    "testing"
+	"crypto/sha256"
 	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
 )
 
 //------------------------------------------------------------
 // Mock VM implementing Execute
 //------------------------------------------------------------
 
-type mockVM struct{
-    returnData []byte
-    err        error
-    lastGas    uint64
-    lastTxHash [32]byte
+type mockVM struct {
+	returnData []byte
+	err        error
+	lastGas    uint64
+	lastTxHash [32]byte
 }
 
-func (m *mockVM) Execute(code []byte, ctx *VMContext) (*Receipt, error){
-    if m.err!=nil { return nil, m.err }
-    m.lastGas = ctx.GasLimit
-    m.lastTxHash = ctx.TxHash
-    return &Receipt{Status:true, ReturnData:m.returnData}, nil
+func (m *mockVM) Execute(code []byte, ctx *VMContext) (*Receipt, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	m.lastGas = ctx.GasLimit
+	m.lastTxHash = ctx.TxHash
+	return &Receipt{Status: true, ReturnData: m.returnData}, nil
 }
 
 //------------------------------------------------------------
@@ -32,85 +34,125 @@ func (m *mockVM) Execute(code []byte, ctx *VMContext) (*Receipt, error){
 //------------------------------------------------------------
 
 func writeTempWasm(t *testing.T, data []byte) string {
-    tmp, err := os.CreateTemp(t.TempDir(), "*.wasm")
-    if err!=nil { t.Fatalf("temp: %v",err)}
-    if _, err = tmp.Write(data); err!=nil { t.Fatalf("write: %v",err)}
-    tmp.Close()
-    return tmp.Name()
+	tmp, err := os.CreateTemp(t.TempDir(), "*.wasm")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	if _, err = tmp.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	tmp.Close()
+	return tmp.Name()
 }
 
 //------------------------------------------------------------
 // Test CompileWASM
 //------------------------------------------------------------
 
-func TestCompileWASM(t *testing.T){
-    wasmBytes := []byte{0x00,0x61,0x73,0x6d} // \0asm header
-    wasmPath := writeTempWasm(t, wasmBytes)
+func TestCompileWASM(t *testing.T) {
+	wasmBytes := []byte{0x00, 0x61, 0x73, 0x6d} // \0asm header
+	wasmPath := writeTempWasm(t, wasmBytes)
 
-    got, h, err := CompileWASM(wasmPath, t.TempDir())
-    if err!=nil { t.Fatalf("compile err %v",err)}
-    if !reflect.DeepEqual(got, wasmBytes) {
-        t.Fatalf("wasm bytes mismatch")
-    }
-    expHash := sha256.Sum256(wasmBytes)
-    if h!=expHash {
-        t.Fatalf("hash mismatch")
-    }
+	got, h, err := CompileWASM(wasmPath, t.TempDir())
+	if err != nil {
+		t.Fatalf("compile err %v", err)
+	}
+	if !reflect.DeepEqual(got, wasmBytes) {
+		t.Fatalf("wasm bytes mismatch")
+	}
+	expHash := sha256.Sum256(wasmBytes)
+	if h != expHash {
+		t.Fatalf("hash mismatch")
+	}
 
-    // unsupported extension
-    badPath := filepath.Join(t.TempDir(), "bad.txt")
-    os.WriteFile(badPath, []byte("x"), 0o600)
-    if _,_, err := CompileWASM(badPath, t.TempDir()); err==nil {
-        t.Fatalf("expected error on bad ext")
-    }
+	// unsupported extension
+	badPath := filepath.Join(t.TempDir(), "bad.txt")
+	os.WriteFile(badPath, []byte("x"), 0o600)
+	if _, _, err := CompileWASM(badPath, t.TempDir()); err == nil {
+		t.Fatalf("expected error on bad ext")
+	}
 }
 
 //------------------------------------------------------------
 // Test deriveContractAddress deterministic
 //------------------------------------------------------------
 
-func TestDeriveContractAddress(t *testing.T){
-    creator := Address{0xAA}
-    code := []byte{1,2,3}
-    addr1 := deriveContractAddress(creator, code)
-    addr2 := deriveContractAddress(creator, code)
-    if addr1!=addr2 { t.Fatalf("determinism fail") }
+func TestDeriveContractAddress(t *testing.T) {
+	creator := Address{0xAA}
+	code := []byte{1, 2, 3}
+	addr1 := deriveContractAddress(creator, code)
+	addr2 := deriveContractAddress(creator, code)
+	if addr1 != addr2 {
+		t.Fatalf("determinism fail")
+	}
+}
+
+//------------------------------------------------------------
+// Test Deploy and Ricardian retrieval
+//------------------------------------------------------------
+
+func TestDeployAndRicardian(t *testing.T) {
+	led, _ := NewInMemory()
+	InitContracts(led, &mockVM{})
+
+	code := []byte{0x00, 0x61, 0x73, 0x6d}
+	ric := []byte(`{"title":"test"}`)
+	addr := DeriveContractAddress(Address{0x01}, code)
+
+	if err := reg.Deploy(addr, code, ric, 50000); err != nil {
+		t.Fatalf("deploy err %v", err)
+	}
+
+	// deploying again should fail
+	if err := reg.Deploy(addr, code, nil, 0); err == nil {
+		t.Fatalf("expected duplicate deploy error")
+	}
+
+	gotRic, err := reg.Ricardian(addr)
+	if err != nil || string(gotRic) != string(ric) {
+		t.Fatalf("ricardian retrieval failed: %v", err)
+	}
+
+	all := reg.All()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 contract, got %d", len(all))
+	}
 }
 
 //------------------------------------------------------------
 // Test Invoke success & error paths
 //------------------------------------------------------------
 
-func TestInvoke(t *testing.T){
-    // init registry
-    InitContracts(nil, nil) // zero init
+func TestInvoke(t *testing.T) {
+	// init registry
+	InitContracts(nil, nil) // zero init
 
-    // setup mock VM
-    mvm := &mockVM{returnData: []byte("ok")}
-    reg.vm = mvm
+	// setup mock VM
+	mvm := &mockVM{returnData: []byte("ok")}
+	reg.vm = mvm
 
-    // create fake contract
-    sc := &SmartContract{Bytecode: []byte{0x00}, GasLimit: 50000}
-    cAddr := Address{0x01}
-    reg.byAddr[cAddr] = sc
+	// create fake contract
+	sc := &SmartContract{Bytecode: []byte{0x00}, GasLimit: 50000}
+	cAddr := Address{0x01}
+	reg.byAddr[cAddr] = sc
 
-    // pass larger gas should clamp
-    ret, err := reg.Invoke(Address{0x02}, cAddr, "foo", nil, 1_000_000)
-    if err!=nil || string(ret)!="ok" {
-        t.Fatalf("invoke fail %v",err)
-    }
-    if mvm.lastGas != sc.GasLimit {
-        t.Fatalf("gas not clamped got %d want %d", mvm.lastGas, sc.GasLimit)
-    }
+	// pass larger gas should clamp
+	ret, err := reg.Invoke(Address{0x02}, cAddr, "foo", nil, 1_000_000)
+	if err != nil || string(ret) != "ok" {
+		t.Fatalf("invoke fail %v", err)
+	}
+	if mvm.lastGas != sc.GasLimit {
+		t.Fatalf("gas not clamped got %d want %d", mvm.lastGas, sc.GasLimit)
+	}
 
-    // contract not found
-    if _, err := reg.Invoke(Address{0x02}, Address{0xFF}, "foo", nil, 0); err==nil {
-        t.Fatalf("expected not found error")
-    }
+	// contract not found
+	if _, err := reg.Invoke(Address{0x02}, Address{0xFF}, "foo", nil, 0); err == nil {
+		t.Fatalf("expected not found error")
+	}
 
-    // vm error propagation
-    mvm.err = errors.New("vm boom")
-    if _, err := reg.Invoke(Address{0x02}, cAddr, "foo", nil, 0); err==nil {
-        t.Fatalf("expected vm error")
-    }
+	// vm error propagation
+	mvm.err = errors.New("vm boom")
+	if _, err := reg.Invoke(Address{0x02}, cAddr, "foo", nil, 0); err == nil {
+		t.Fatalf("expected vm error")
+	}
 }


### PR DESCRIPTION
## Summary
- add contract registry functions for deploy and metadata retrieval
- expose registry helper and address derivation
- register Deploy opcode and gas cost
- wire CLI deploy command through new registry
- cover deploy & ricardian logic in tests

## Testing
- `go test ./...` *(fails: go mod tidy required)*

------
https://chatgpt.com/codex/tasks/task_e_688ad9e0dea48320959899114e3e875c