### PR TITLE
Enhance green tech module with certificate listings

### DIFF
--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -279,6 +279,15 @@ type nodeSummary struct {
 	Cert    Certificate
 }
 
+// CertificateInfo provides a consumable view of a validator's sustainability
+// certificate and score. It is used by API callers and CLI tooling to present
+// network‑wide environmental metrics.
+type CertificateInfo struct {
+	Address Address     `json:"address"`
+	Score   float64     `json:"score"`
+	Cert    Certificate `json:"cert"`
+}
+
 type GreenTechEngine struct {
 	led StateRW
 	mu  sync.RWMutex

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -50,17 +50,15 @@ var gasTable = map[Opcode]uint64{
 	ReleaseEscrow:  12_000,
 	PredictVolume:  15_000,
 
-
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker
 	// ----------------------------------------------------------------------
-	SwapExactIn:    4_500,
-	AddLiquidity:   5_000,
-	RemoveLiquidity:5_000,
-  Quote:          2_500,
-  AllPairs:       2_000,
-  InitPoolsFromFile: 6_000,
-
+	SwapExactIn:       4_500,
+	AddLiquidity:      5_000,
+	RemoveLiquidity:   5_000,
+	Quote:             2_500,
+	AllPairs:          2_000,
+	InitPoolsFromFile: 6_000,
 
 	// ----------------------------------------------------------------------
 	// Authority / Validator-Set
@@ -105,7 +103,6 @@ var gasTable = map[Opcode]uint64{
 	Compliance_AuditTrail: 3_000,
 	Compliance_MonitorTx:  5_000,
 	Compliance_VerifyZKP:  12_000,
-
 
 	// ----------------------------------------------------------------------
 	// Consensus Core
@@ -185,13 +182,14 @@ var gasTable = map[Opcode]uint64{
 	// ----------------------------------------------------------------------
 	// Green Technology
 	// ----------------------------------------------------------------------
-	InitGreenTech:  8_000,
-	Green:          2_000,
-	RecordUsage:    3_000,
-	RecordOffset:   3_000,
-	Certify:        7_000,
-	CertificateOf:  500,
-	ShouldThrottle: 200,
+	InitGreenTech:    8_000,
+	Green:            2_000,
+	RecordUsage:      3_000,
+	RecordOffset:     3_000,
+	Certify:          7_000,
+	CertificateOf:    500,
+	ShouldThrottle:   200,
+	ListCertificates: 1_000,
 
 	// ----------------------------------------------------------------------
 	// Ledger / UTXO / Account-Model

--- a/synnergy-network/core/green_technology.go
+++ b/synnergy-network/core/green_technology.go
@@ -19,54 +19,58 @@ package core
 // -----------------------------------------------------------------------------
 
 import (
-    "crypto/sha256"
-    "encoding/json"
-    "errors"
-    "sync"
-    "time"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
 )
 
 //---------------------------------------------------------------------
 // Data structs
 //---------------------------------------------------------------------
 
-
 const (
-    CertGold   Certificate = "Gold"
-    CertSilver Certificate = "Silver"
-    CertBronze Certificate = "Bronze"
-    CertNone   Certificate = "None"
+	CertGold   Certificate = "Gold"
+	CertSilver Certificate = "Silver"
+	CertBronze Certificate = "Bronze"
+	CertNone   Certificate = "None"
 )
 
 //---------------------------------------------------------------------
 // Engine singleton
 //---------------------------------------------------------------------
 
-
 var green *GreenTechEngine
 var once sync.Once
 
-func InitGreenTech(led StateRW) { once.Do(func(){ green=&GreenTechEngine{led:led} }) }
-func Green() *GreenTechEngine { return green }
+func InitGreenTech(led StateRW) { once.Do(func() { green = &GreenTechEngine{led: led} }) }
+func Green() *GreenTechEngine   { return green }
 
 //---------------------------------------------------------------------
 // Recorders
 //---------------------------------------------------------------------
 
 func (g *GreenTechEngine) RecordUsage(v Address, energyKWh, carbonKg float64) error {
-    if energyKWh<=0||carbonKg<=0 { return errors.New("usage >0") }
-    rec := UsageRecord{v, energyKWh, carbonKg, time.Now().Unix()}
-    b,_:=json.Marshal(rec); h:=sha256.Sum256(b)
-    g.led.SetState(append([]byte("usage:"),h[:]...), b)
-    return nil
+	if energyKWh <= 0 || carbonKg <= 0 {
+		return errors.New("usage >0")
+	}
+	rec := UsageRecord{v, energyKWh, carbonKg, time.Now().Unix()}
+	b, _ := json.Marshal(rec)
+	h := sha256.Sum256(b)
+	g.led.SetState(append([]byte("usage:"), h[:]...), b)
+	return nil
 }
 
 func (g *GreenTechEngine) RecordOffset(v Address, offsetKg float64) error {
-    if offsetKg<=0 { return errors.New("offset>0") }
-    rec := OffsetRecord{v, offsetKg, time.Now().Unix()}
-    b,_:=json.Marshal(rec); h:=sha256.Sum256(b)
-    g.led.SetState(append([]byte("offset:"),h[:]...), b)
-    return nil
+	if offsetKg <= 0 {
+		return errors.New("offset>0")
+	}
+	rec := OffsetRecord{v, offsetKg, time.Now().Unix()}
+	b, _ := json.Marshal(rec)
+	h := sha256.Sum256(b)
+	g.led.SetState(append([]byte("offset:"), h[:]...), b)
+	return nil
 }
 
 //---------------------------------------------------------------------
@@ -74,23 +78,50 @@ func (g *GreenTechEngine) RecordOffset(v Address, offsetKg float64) error {
 //---------------------------------------------------------------------
 
 func (g *GreenTechEngine) Certify() {
-    sums := make(map[Address]*nodeSummary)
-    iter := g.led.PrefixIterator([]byte("usage:"))
-    for iter.Next(){ var u UsageRecord; _=json.Unmarshal(iter.Value(),&u); s:=sums[u.Validator]; if s==nil {s=&nodeSummary{}; sums[u.Validator]=s}; s.Energy+=u.EnergyKWh; s.Emitted+=u.CarbonKg }
-    iter = g.led.PrefixIterator([]byte("offset:"))
-    for iter.Next(){ var o OffsetRecord; _=json.Unmarshal(iter.Value(),&o); s:=sums[o.Validator]; if s==nil {s=&nodeSummary{}; sums[o.Validator]=s}; s.Offset+=o.OffsetKg }
-    for addr, s := range sums {
-        s.Score = (s.Offset - s.Emitted)/s.Emitted
-        switch {
-        case s.Score >= 0.5: s.Cert = CertGold
-        case s.Score >= 0.0: s.Cert = CertSilver
-        case s.Score >= -0.25: s.Cert = CertBronze
-        default: s.Cert = CertNone
-        }
-        key := append([]byte("cert:"), addr.Bytes()...)
-        blob,_ := json.Marshal(struct{Score float64 `json:"score"`; Cert Certificate `json:"cert"`; TS int64`json:"ts"`}{s.Score,s.Cert,time.Now().Unix()})
-        g.led.SetState(key, blob)
-    }
+	sums := make(map[Address]*nodeSummary)
+	iter := g.led.PrefixIterator([]byte("usage:"))
+	for iter.Next() {
+		var u UsageRecord
+		_ = json.Unmarshal(iter.Value(), &u)
+		s := sums[u.Validator]
+		if s == nil {
+			s = &nodeSummary{}
+			sums[u.Validator] = s
+		}
+		s.Energy += u.EnergyKWh
+		s.Emitted += u.CarbonKg
+	}
+	iter = g.led.PrefixIterator([]byte("offset:"))
+	for iter.Next() {
+		var o OffsetRecord
+		_ = json.Unmarshal(iter.Value(), &o)
+		s := sums[o.Validator]
+		if s == nil {
+			s = &nodeSummary{}
+			sums[o.Validator] = s
+		}
+		s.Offset += o.OffsetKg
+	}
+	for addr, s := range sums {
+		s.Score = (s.Offset - s.Emitted) / s.Emitted
+		switch {
+		case s.Score >= 0.5:
+			s.Cert = CertGold
+		case s.Score >= 0.0:
+			s.Cert = CertSilver
+		case s.Score >= -0.25:
+			s.Cert = CertBronze
+		default:
+			s.Cert = CertNone
+		}
+		key := append([]byte("cert:"), addr.Bytes()...)
+		blob, _ := json.Marshal(struct {
+			Score float64     `json:"score"`
+			Cert  Certificate `json:"cert"`
+			TS    int64       `json:"ts"`
+		}{s.Score, s.Cert, time.Now().Unix()})
+		g.led.SetState(key, blob)
+	}
 }
 
 //---------------------------------------------------------------------
@@ -98,21 +129,54 @@ func (g *GreenTechEngine) Certify() {
 //---------------------------------------------------------------------
 
 func (g *GreenTechEngine) CertificateOf(addr Address) Certificate {
-    key := append([]byte("cert:"), addr.Bytes()...)
-    blob,_ := g.led.GetState(key)
-    if len(blob)==0 { return CertNone }
-    var tmp struct{ Cert Certificate `json:"cert"` }
-    _ = json.Unmarshal(blob,&tmp)
-    return tmp.Cert
+	key := append([]byte("cert:"), addr.Bytes()...)
+	blob, _ := g.led.GetState(key)
+	if len(blob) == 0 {
+		return CertNone
+	}
+	var tmp struct {
+		Cert Certificate `json:"cert"`
+	}
+	_ = json.Unmarshal(blob, &tmp)
+	return tmp.Cert
 }
 
 func (g *GreenTechEngine) ShouldThrottle(addr Address) bool {
-    key := append([]byte("cert:"), addr.Bytes()...)
-    blob,_ := g.led.GetState(key)
-    if len(blob)==0 { return false }
-    var tmp struct{ Score float64 `json:"score"` }
-    _ = json.Unmarshal(blob,&tmp)
-    return tmp.Score < -0.5
+	key := append([]byte("cert:"), addr.Bytes()...)
+	blob, _ := g.led.GetState(key)
+	if len(blob) == 0 {
+		return false
+	}
+	var tmp struct {
+		Score float64 `json:"score"`
+	}
+	_ = json.Unmarshal(blob, &tmp)
+	return tmp.Score < -0.5
+}
+
+// ListCertificates returns all stored certificates with their scores. It is
+// primarily used by monitoring dashboards and CLI tooling.
+func (g *GreenTechEngine) ListCertificates() ([]CertificateInfo, error) {
+	iter := g.led.PrefixIterator([]byte("cert:"))
+	var list []CertificateInfo
+	for iter.Next() {
+		key := iter.Key()
+		if len(key) < len("cert:")+20 {
+			continue
+		}
+		var addr Address
+		copy(addr[:], key[len("cert:"):len("cert:")+20])
+
+		var tmp struct {
+			Score float64     `json:"score"`
+			Cert  Certificate `json:"cert"`
+		}
+		if err := json.Unmarshal(iter.Value(), &tmp); err != nil {
+			continue
+		}
+		list = append(list, CertificateInfo{Address: addr, Score: tmp.Score, Cert: tmp.Cert})
+	}
+	return list, nil
 }
 
 //---------------------------------------------------------------------

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -135,9 +135,9 @@ var catalogue = []struct {
 	{"SwapExactIn", 0x020001},
 	{"AMM_AddLiquidity", 0x020002},
 	{"AMM_RemoveLiquidity", 0x020003},
-        {"Quote", 0x020004},
-        {"AllPairs", 0x020005},
-        {"InitPoolsFromFile", 0x020006},
+	{"Quote", 0x020004},
+	{"AllPairs", 0x020005},
+	{"InitPoolsFromFile", 0x020006},
 
 	// Authority (0x03)
 	{"NewAuthoritySet", 0x030001},
@@ -247,6 +247,7 @@ var catalogue = []struct {
 	{"Certify", 0x0D0005},
 	{"CertificateOf", 0x0D0006},
 	{"ShouldThrottle", 0x0D0007},
+	{"ListCertificates", 0x0D0008},
 
 	// Ledger (0x0E)
 	{"NewLedger", 0x0E0001},

--- a/synnergy-network/tests/green_technology_test.go
+++ b/synnergy-network/tests/green_technology_test.go
@@ -1,11 +1,11 @@
 package core
 
 import (
-    "encoding/json"
-    "errors"
-    "sync"
-    "testing"
-    "time"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
 )
 
 //------------------------------------------------------------
@@ -13,108 +13,178 @@ import (
 //------------------------------------------------------------
 
 type greenMockLedger struct {
-    mu    sync.RWMutex
-    state map[string][]byte
+	mu    sync.RWMutex
+	state map[string][]byte
 }
 
 func newGreenLedger() *greenMockLedger { return &greenMockLedger{state: make(map[string][]byte)} }
 
 func (m *greenMockLedger) SetState(k, v []byte) error {
-    m.mu.Lock(); defer m.mu.Unlock(); m.state[string(k)] = append([]byte(nil), v...); return nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.state[string(k)] = append([]byte(nil), v...)
+	return nil
 }
 
 func (m *greenMockLedger) GetState(k []byte) ([]byte, error) {
-    m.mu.RLock(); defer m.mu.RUnlock(); return m.state[string(k)], nil
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.state[string(k)], nil
 }
 
-func (m *greenMockLedger) HasState(k []byte) (bool, error) { m.mu.RLock(); defer m.mu.RUnlock(); _, ok := m.state[string(k)]; return ok, nil }
+func (m *greenMockLedger) HasState(k []byte) (bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, ok := m.state[string(k)]
+	return ok, nil
+}
 
 func (m *greenMockLedger) PrefixIterator(pref []byte) PrefixIterator {
-    m.mu.RLock(); defer m.mu.RUnlock()
-    var kvs []KV
-    for k, v := range m.state {
-        if len(k) >= len(pref) && k[:len(pref)] == string(pref) {
-            kvs = append(kvs, KV{k: []byte(k), v: v})
-        }
-    }
-    return &sliceIterG{items: kvs}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var kvs []KV
+	for k, v := range m.state {
+		if len(k) >= len(pref) && k[:len(pref)] == string(pref) {
+			kvs = append(kvs, KV{k: []byte(k), v: v})
+		}
+	}
+	return &sliceIterG{items: kvs}
 }
 
 // slice iterator for tests
 
-type sliceIterG struct{ items []KV; idx int }
-func (s *sliceIterG) Next() bool { s.idx++; return s.idx <= len(s.items) }
-func (s *sliceIterG) Key() []byte { return s.items[s.idx-1].k }
+type sliceIterG struct {
+	items []KV
+	idx   int
+}
+
+func (s *sliceIterG) Next() bool    { s.idx++; return s.idx <= len(s.items) }
+func (s *sliceIterG) Key() []byte   { return s.items[s.idx-1].k }
 func (s *sliceIterG) Value() []byte { return s.items[s.idx-1].v }
 
 // no-op funcs to satisfy the interface not used here
-func (m *greenMockLedger) Burn(Address,uint64) error{return nil}
-func (m *greenMockLedger) BurnLP(Address,PoolID,uint64) error{return nil}
-func (m *greenMockLedger) MintLP(Address,PoolID,uint64) error{return nil}
-func (m *greenMockLedger) Transfer(Address,Address,uint64) error{return nil}
-func (m *greenMockLedger) Snapshot(func()error) error{return nil}
-func (m *greenMockLedger) NonceOf(Address) uint64{return 0}
-func (m *greenMockLedger) IsIDTokenHolder(Address) bool{return false}
-func (m *greenMockLedger) BalanceOf(Address) uint64{return 0}
-func (m *greenMockLedger) Mint(Address,uint64) error{return nil}
-func (m *greenMockLedger) MintToken(Address,uint64) error{return nil}
-func (m *greenMockLedger) DeductGas(Address,uint64){}
-func (m *greenMockLedger) EmitApproval(TokenID,Address,Address,uint64){}
-func (m *greenMockLedger) EmitTransfer(TokenID,Address,Address,uint64){}
-func (m *greenMockLedger) WithinBlock(func()error) error{return nil}
+func (m *greenMockLedger) Burn(Address, uint64) error                     { return nil }
+func (m *greenMockLedger) BurnLP(Address, PoolID, uint64) error           { return nil }
+func (m *greenMockLedger) MintLP(Address, PoolID, uint64) error           { return nil }
+func (m *greenMockLedger) Transfer(Address, Address, uint64) error        { return nil }
+func (m *greenMockLedger) Snapshot(func() error) error                    { return nil }
+func (m *greenMockLedger) NonceOf(Address) uint64                         { return 0 }
+func (m *greenMockLedger) IsIDTokenHolder(Address) bool                   { return false }
+func (m *greenMockLedger) BalanceOf(Address) uint64                       { return 0 }
+func (m *greenMockLedger) Mint(Address, uint64) error                     { return nil }
+func (m *greenMockLedger) MintToken(Address, uint64) error                { return nil }
+func (m *greenMockLedger) DeductGas(Address, uint64)                      {}
+func (m *greenMockLedger) EmitApproval(TokenID, Address, Address, uint64) {}
+func (m *greenMockLedger) EmitTransfer(TokenID, Address, Address, uint64) {}
+func (m *greenMockLedger) WithinBlock(func() error) error                 { return nil }
 
 //------------------------------------------------------------
 // Tests
 //------------------------------------------------------------
 
-func TestRecordUsageAndOffset(t *testing.T){
-    led := newGreenLedger(); InitGreenTech(led)
-    v := Address{0x01}
+func TestRecordUsageAndOffset(t *testing.T) {
+	led := newGreenLedger()
+	InitGreenTech(led)
+	v := Address{0x01}
 
-    // invalid params
-    if err:=Green().RecordUsage(v, 0, 10); err==nil { t.Fatalf("expected error for zero energy") }
-    if err:=Green().RecordOffset(v, 0); err==nil { t.Fatalf("expected error offset") }
+	// invalid params
+	if err := Green().RecordUsage(v, 0, 10); err == nil {
+		t.Fatalf("expected error for zero energy")
+	}
+	if err := Green().RecordOffset(v, 0); err == nil {
+		t.Fatalf("expected error offset")
+	}
 
-    if err:=Green().RecordUsage(v, 100, 50); err!=nil { t.Fatalf("record usage %v",err) }
-    if err:=Green().RecordOffset(v, 40); err!=nil { t.Fatalf("offset %v",err) }
+	if err := Green().RecordUsage(v, 100, 50); err != nil {
+		t.Fatalf("record usage %v", err)
+	}
+	if err := Green().RecordOffset(v, 40); err != nil {
+		t.Fatalf("offset %v", err)
+	}
 
-    // ensure states written
-    if ok,_:=led.HasState([]byte("usage:")); !ok { t.Errorf("usage not stored") }
-    if ok,_:=led.HasState([]byte("offset:")); !ok { t.Errorf("offset not stored") }
+	// ensure states written
+	if ok, _ := led.HasState([]byte("usage:")); !ok {
+		t.Errorf("usage not stored")
+	}
+	if ok, _ := led.HasState([]byte("offset:")); !ok {
+		t.Errorf("offset not stored")
+	}
 }
 
-func TestCertifyAndThrottle(t *testing.T){
-    led := newGreenLedger(); InitGreenTech(led)
-    vGold := Address{0x10}
-    vSilver := Address{0x20}
-    vBronze := Address{0x30}
-    vNone := Address{0x40}
+func TestCertifyAndThrottle(t *testing.T) {
+	led := newGreenLedger()
+	InitGreenTech(led)
+	vGold := Address{0x10}
+	vSilver := Address{0x20}
+	vBronze := Address{0x30}
+	vNone := Address{0x40}
 
-    // helper to write records quickly
-    recUsage := func(a Address, kg float64){ Green().RecordUsage(a, 100, kg) } // energy not used in score
-    Green().RecordOffset(vGold, 75)   // emitted 50 later -> score 0.5
-    recUsage(vGold,50)
+	// helper to write records quickly
+	recUsage := func(a Address, kg float64) { Green().RecordUsage(a, 100, kg) } // energy not used in score
+	Green().RecordOffset(vGold, 75)                                             // emitted 50 later -> score 0.5
+	recUsage(vGold, 50)
 
-    Green().RecordOffset(vSilver, 50) // emitted 50 -> score 0
-    recUsage(vSilver,50)
+	Green().RecordOffset(vSilver, 50) // emitted 50 -> score 0
+	recUsage(vSilver, 50)
 
-    Green().RecordOffset(vBronze, 40) // emitted 50 -> -0.2
-    recUsage(vBronze,50)
+	Green().RecordOffset(vBronze, 40) // emitted 50 -> -0.2
+	recUsage(vBronze, 50)
 
-    recUsage(vNone,50) // no offset -> -1.0
+	recUsage(vNone, 50) // no offset -> -1.0
 
-    Green().Certify()
+	Green().Certify()
 
-    tests:=[]struct{addr Address; want Certificate; throttle bool}{
-        {vGold, CertGold, false},
-        {vSilver, CertSilver, false},
-        {vBronze, CertBronze, false},
-        {vNone, CertNone, true},
-    }
-    for _,tc:=range tests{
-        got := Green().CertificateOf(tc.addr)
-        if got!=tc.want { t.Fatalf("cert of %x got %s want %s", tc.addr, got, tc.want) }
-        th := Green().ShouldThrottle(tc.addr)
-        if th!=tc.throttle { t.Fatalf("throttle of %x got %v want %v", tc.addr, th, tc.throttle) }
-    }
+	tests := []struct {
+		addr     Address
+		want     Certificate
+		throttle bool
+	}{
+		{vGold, CertGold, false},
+		{vSilver, CertSilver, false},
+		{vBronze, CertBronze, false},
+		{vNone, CertNone, true},
+	}
+	for _, tc := range tests {
+		got := Green().CertificateOf(tc.addr)
+		if got != tc.want {
+			t.Fatalf("cert of %x got %s want %s", tc.addr, got, tc.want)
+		}
+		th := Green().ShouldThrottle(tc.addr)
+		if th != tc.throttle {
+			t.Fatalf("throttle of %x got %v want %v", tc.addr, th, tc.throttle)
+		}
+	}
+}
+
+func TestListCertificates(t *testing.T) {
+	led := newGreenLedger()
+	InitGreenTech(led)
+	a1 := Address{0x01}
+	a2 := Address{0x02}
+
+	Green().RecordUsage(a1, 100, 40)
+	Green().RecordOffset(a1, 50) // score 0.25 -> Bronze
+	Green().RecordUsage(a2, 100, 60)
+	Green().RecordOffset(a2, 90) // score 0.5 -> Gold
+
+	Green().Certify()
+
+	list, err := Green().ListCertificates()
+	if err != nil {
+		t.Fatalf("list certs error: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 certs got %d", len(list))
+	}
+	// ensure entries contain expected certificates
+	m := map[Address]Certificate{}
+	for _, c := range list {
+		m[c.Address] = c.Cert
+	}
+	if m[a1] != CertBronze {
+		t.Errorf("a1 cert %s", m[a1])
+	}
+	if m[a2] != CertGold {
+		t.Errorf("a2 cert %s", m[a2])
+	}
 }


### PR DESCRIPTION
## Summary
- extend GreenTech structures with `CertificateInfo`
- implement `ListCertificates` to enumerate sustainability certificates
- add opcode and gas cost for `ListCertificates`
- test certificate listing functionality

## Testing
- `go test ./...` *(fails: go mod tidy required)*

------
https://chatgpt.com/codex/tasks/task_e_688adc300c788320a3eb6f4383f61de3