### PR TITLE
Add proposal query support

### DIFF
--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -50,17 +50,15 @@ var gasTable = map[Opcode]uint64{
 	ReleaseEscrow:  12_000,
 	PredictVolume:  15_000,
 
-
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker
 	// ----------------------------------------------------------------------
-	SwapExactIn:    4_500,
-	AddLiquidity:   5_000,
-	RemoveLiquidity:5_000,
-  Quote:          2_500,
-  AllPairs:       2_000,
-  InitPoolsFromFile: 6_000,
-
+	SwapExactIn:       4_500,
+	AddLiquidity:      5_000,
+	RemoveLiquidity:   5_000,
+	Quote:             2_500,
+	AllPairs:          2_000,
+	InitPoolsFromFile: 6_000,
 
 	// ----------------------------------------------------------------------
 	// Authority / Validator-Set
@@ -105,7 +103,6 @@ var gasTable = map[Opcode]uint64{
 	Compliance_AuditTrail: 3_000,
 	Compliance_MonitorTx:  5_000,
 	Compliance_VerifyZKP:  12_000,
-
 
 	// ----------------------------------------------------------------------
 	// Consensus Core
@@ -181,6 +178,8 @@ var gasTable = map[Opcode]uint64{
 	BalanceOfAsset:  600,
 	CastVote:        3_000,
 	ExecuteProposal: 15_000,
+	GetProposal:     1_000,
+	ListProposals:   2_000,
 
 	// ----------------------------------------------------------------------
 	// Green Technology

--- a/synnergy-network/core/governance.go
+++ b/synnergy-network/core/governance.go
@@ -1,385 +1,400 @@
 package core
 
 import (
-    "encoding/json"
-    "fmt"
-    "time"
-	"errors"
-    "github.com/google/uuid"
-    "go.uber.org/zap"
-	"strconv"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+	"strconv"
+	"time"
 )
 
 // GovProposal represents a protocol parameter change proposal
 type GovProposal struct {
-    ID      string            `json:"id"`
-    Changes map[string]string `json:"changes"` // key: param name, value: new setting
-    Votes   map[string]bool   `json:"votes"`   // voter address -> approve/deny
-    Created time.Time         `json:"created"`
-    Enacted bool              `json:"enacted"`
-    Creator      Address `json:"creator"`
-    Description  string         `json:"description"`
-    VotesFor     int            `json:"votes_for"`
-    VotesAgainst int            `json:"votes_against"`
-    Deadline     time.Time      `json:"deadline"`
-    Executed     bool           `json:"executed"`
+	ID           string            `json:"id"`
+	Changes      map[string]string `json:"changes"` // key: param name, value: new setting
+	Votes        map[string]bool   `json:"votes"`   // voter address -> approve/deny
+	Created      time.Time         `json:"created"`
+	Enacted      bool              `json:"enacted"`
+	Creator      Address           `json:"creator"`
+	Description  string            `json:"description"`
+	VotesFor     int               `json:"votes_for"`
+	VotesAgainst int               `json:"votes_against"`
+	Deadline     time.Time         `json:"deadline"`
+	Executed     bool              `json:"executed"`
 }
 
 var BlockGasLimit = uint64(1000000)
 
 func UpdateParam(key, value string) error {
-    switch key {
-    case "block_gas_limit":
-        v, err := strconv.ParseUint(value, 10, 64)
-        if err != nil {
-            return fmt.Errorf("invalid uint: %w", err)
-        }
-        BlockGasLimit = v
-        return nil
-    default:
-        return fmt.Errorf("unknown param: %s", key)
-    }
+	switch key {
+	case "block_gas_limit":
+		v, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid uint: %w", err)
+		}
+		BlockGasLimit = v
+		return nil
+	default:
+		return fmt.Errorf("unknown param: %s", key)
+	}
 }
-
 
 // applyParams applies protocol parameter changes. This should only be called once consensus is reached.
 func applyParams(changes map[string]string) error {
-    // This would interact with consensus module to update runtime parameters
-    for k, v := range changes {
-        if err := UpdateParam(k, v); err != nil {
-            return fmt.Errorf("failed to apply param %s: %w", k, err)
-        }
-    }
-    return nil
+	// This would interact with consensus module to update runtime parameters
+	for k, v := range changes {
+		if err := UpdateParam(k, v); err != nil {
+			return fmt.Errorf("failed to apply param %s: %w", k, err)
+		}
+	}
+	return nil
 }
 
-
-
 func (a *AuthoritySet) Nodes() []Address {
-    var out []Address
-    for addr := range a.members {
-        out = append(out, addr)
-    }
-    return out
+	var out []Address
+	for addr := range a.members {
+		out = append(out, addr)
+	}
+	return out
 }
 
 func (a *AuthoritySet) IsMember(addr Address) bool {
-    _, ok := a.members[addr]
-    return ok
+	_, ok := a.members[addr]
+	return ok
 }
 
 var authoritySet = &AuthoritySet{
-    members: map[Address]struct{}{
-        // manually populate with initial authority nodes
-    },
+	members: map[Address]struct{}{
+		// manually populate with initial authority nodes
+	},
 }
 
 func CurrentSet() *AuthoritySet {
-    return authoritySet
+	return authoritySet
 }
-
 
 // quorumReached checks if >50% of authority nodes approved
 func quorumReached(p *GovProposal) bool {
-    authSet := CurrentSet()
-    total := len(authSet.Nodes())
-    if total == 0 {
-        return false
-    }
+	authSet := CurrentSet()
+	total := len(authSet.Nodes())
+	if total == 0 {
+		return false
+	}
 
-    approves := 0
-    for voter, ok := range p.Votes {
-        if ok {
-            addr, err := ParseAddress(voter)
-            if err == nil && authSet.IsMember(addr) {
-                approves++
-            }
-        }
-    }
-    return approves*2 > total
+	approves := 0
+	for voter, ok := range p.Votes {
+		if ok {
+			addr, err := ParseAddress(voter)
+			if err == nil && authSet.IsMember(addr) {
+				approves++
+			}
+		}
+	}
+	return approves*2 > total
 }
-
 
 func ParseAddress(s string) (Address, error) {
-    b, err := hex.DecodeString(s)
-    if err != nil || len(b) != 20 {
-        return Address{}, fmt.Errorf("invalid address: %s", s)
-    }
-    var a Address
-    copy(a[:], b)
-    return a, nil
+	b, err := hex.DecodeString(s)
+	if err != nil || len(b) != 20 {
+		return Address{}, fmt.Errorf("invalid address: %s", s)
+	}
+	var a Address
+	copy(a[:], b)
+	return a, nil
 }
-
 
 // ProposeChange submits a new governance proposal
 func ProposeChange(p GovProposal) error {
-    logger := zap.L().Sugar()
-    p.ID = uuid.New().String()
-    p.Created = time.Now().UTC()
-    p.Votes = make(map[string]bool)
-    p.Enacted = false
-    key := fmt.Sprintf("governance:proposal:%s", p.ID)
+	logger := zap.L().Sugar()
+	p.ID = uuid.New().String()
+	p.Created = time.Now().UTC()
+	p.Votes = make(map[string]bool)
+	p.Enacted = false
+	key := fmt.Sprintf("governance:proposal:%s", p.ID)
 
-    raw, err := json.Marshal(p)
-    if err != nil {
-        logger.Errorf("marshal proposal failed: %v", err)
-        return err
-    }
-    if err := CurrentStore().Set([]byte(key), raw); err != nil {
-        logger.Errorf("ledger write failed: %v", err)
-        return err
-    }
-    logger.Infof("Governance proposal %s created", p.ID)
-    return nil
+	raw, err := json.Marshal(p)
+	if err != nil {
+		logger.Errorf("marshal proposal failed: %v", err)
+		return err
+	}
+	if err := CurrentStore().Set([]byte(key), raw); err != nil {
+		logger.Errorf("ledger write failed: %v", err)
+		return err
+	}
+	logger.Infof("Governance proposal %s created", p.ID)
+	return nil
 }
 
 func VoteChange(proposalID string, voter Address, approve bool) error {
-    logger := zap.L().Sugar()
-    key := fmt.Sprintf("governance:proposal:%s", proposalID)
-    store := CurrentStore()
+	logger := zap.L().Sugar()
+	key := fmt.Sprintf("governance:proposal:%s", proposalID)
+	store := CurrentStore()
 
-    raw, err := store.Get([]byte(key))
-    if err != nil {
-        logger.Errorf("proposal lookup failed: %v", err)
-        return ErrNotFound
-    }
+	raw, err := store.Get([]byte(key))
+	if err != nil {
+		logger.Errorf("proposal lookup failed: %v", err)
+		return ErrNotFound
+	}
 
-    var p GovProposal
-    if err := json.Unmarshal(raw, &p); err != nil {
-        logger.Errorf("unmarshal proposal failed: %v", err)
-        return err
-    }
+	var p GovProposal
+	if err := json.Unmarshal(raw, &p); err != nil {
+		logger.Errorf("unmarshal proposal failed: %v", err)
+		return err
+	}
 
-    if p.Enacted {
-        return ErrInvalidState
-    }
+	if p.Enacted {
+		return ErrInvalidState
+	}
 
-    if !CurrentSet().IsMember(voter) {
-        return ErrUnauthorized
-    }
+	if !CurrentSet().IsMember(voter) {
+		return ErrUnauthorized
+	}
 
-    addrStr := hex.EncodeToString(voter[:])
-    p.Votes[addrStr] = approve
+	addrStr := hex.EncodeToString(voter[:])
+	p.Votes[addrStr] = approve
 
-    updated, _ := json.Marshal(p)
-    if err := store.Set([]byte(key), updated); err != nil {
-        logger.Errorf("ledger update failed: %v", err)
-        return err
-    }
+	updated, _ := json.Marshal(p)
+	if err := store.Set([]byte(key), updated); err != nil {
+		logger.Errorf("ledger update failed: %v", err)
+		return err
+	}
 
-    logger.Infof("Voter %s cast vote %v on proposal %s", addrStr, approve, proposalID)
+	logger.Infof("Voter %s cast vote %v on proposal %s", addrStr, approve, proposalID)
 
-    if quorumReached(&p) {
-        if err := EnactChange(proposalID); err != nil {
-            logger.Errorf("auto enact failed: %v", err)
-        }
-    }
+	if quorumReached(&p) {
+		if err := EnactChange(proposalID); err != nil {
+			logger.Errorf("auto enact failed: %v", err)
+		}
+	}
 
-    return nil
+	return nil
 }
-
 
 // EnactChange enacts a proposal if quorum is reached
 func EnactChange(proposalID string) error {
-    logger := zap.L().Sugar()
-    key := fmt.Sprintf("governance:proposal:%s", proposalID)
-    store := CurrentStore()
+	logger := zap.L().Sugar()
+	key := fmt.Sprintf("governance:proposal:%s", proposalID)
+	store := CurrentStore()
 
-    raw, err := store.Get([]byte(key))
-    if err != nil {
-        logger.Errorf("proposal lookup failed: %v", err)
-        return ErrNotFound
-    }
-    var p GovProposal
-    if err := json.Unmarshal(raw, &p); err != nil {
-        logger.Errorf("unmarshal proposal failed: %v", err)
-        return err
-    }
-    if p.Enacted {
-        return ErrInvalidState
-    }
-    if !quorumReached(&p) {
-        return ErrInvalidState
-    }
-    // apply parameters
-    if err := applyParams(p.Changes); err != nil {
-        logger.Errorf("apply params failed: %v", err)
-        return err
-    }
-    p.Enacted = true
-    updated, _ := json.Marshal(p)
-    if err := store.Set([]byte(key), updated); err != nil {
-        logger.Errorf("ledger update failed: %v", err)
-        return err
-    }
-    logger.Infof("Proposal %s enacted", proposalID)
-    return nil
+	raw, err := store.Get([]byte(key))
+	if err != nil {
+		logger.Errorf("proposal lookup failed: %v", err)
+		return ErrNotFound
+	}
+	var p GovProposal
+	if err := json.Unmarshal(raw, &p); err != nil {
+		logger.Errorf("unmarshal proposal failed: %v", err)
+		return err
+	}
+	if p.Enacted {
+		return ErrInvalidState
+	}
+	if !quorumReached(&p) {
+		return ErrInvalidState
+	}
+	// apply parameters
+	if err := applyParams(p.Changes); err != nil {
+		logger.Errorf("apply params failed: %v", err)
+		return err
+	}
+	p.Enacted = true
+	updated, _ := json.Marshal(p)
+	if err := store.Set([]byte(key), updated); err != nil {
+		logger.Errorf("ledger update failed: %v", err)
+		return err
+	}
+	logger.Infof("Proposal %s enacted", proposalID)
+	return nil
 }
-
-
-
 
 // Vote represents a vote on a proposal
 type Vote struct {
-    ProposalID Address `json:"proposal_id"`
-    Voter      Address `json:"voter"`
-    Approve    bool           `json:"approve"`
+	ProposalID Address `json:"proposal_id"`
+	Voter      Address `json:"voter"`
+	Approve    bool    `json:"approve"`
 }
-
 
 // SubmitProposal allows any token-holder to create a proposal
 func SubmitProposal(p *GovProposal) error {
-    logger := zap.L().Sugar()
-    logger.Infof("Submitting proposal by %s", p.Creator)
+	logger := zap.L().Sugar()
+	logger.Infof("Submitting proposal by %s", p.Creator)
 
-    // Check creator has tokens staked
-    balance := ledger.BalanceOf(p.Creator[:]) // p.Creator is [20]byte → []byte
+	// Check creator has tokens staked
+	balance := ledger.BalanceOf(p.Creator[:]) // p.Creator is [20]byte → []byte
 
-    if balance == 0 {
-        return ErrUnauthorized
-    }
+	if balance == 0 {
+		return ErrUnauthorized
+	}
 
-    // Set defaults
-    p.ID = uuid.New().String()
-    p.Created = time.Now().UTC()
-    p.Deadline = p.Created.Add(72 * time.Hour) // 3-day voting period
-    p.Executed = false
+	// Set defaults
+	p.ID = uuid.New().String()
+	p.Created = time.Now().UTC()
+	p.Deadline = p.Created.Add(72 * time.Hour) // 3-day voting period
+	p.Executed = false
 
-    raw, err := json.Marshal(p)
-    if err != nil {
-        logger.Errorf("Marshal proposal failed: %v", err)
-        return err
-    }
-    key := fmt.Sprintf("dao:proposal:%s", p.ID)
-    if err := CurrentStore().Set([]byte(key), raw); err != nil {
-        logger.Errorf("Ledger write failed: %v", err)
-        return err
-    }
+	raw, err := json.Marshal(p)
+	if err != nil {
+		logger.Errorf("Marshal proposal failed: %v", err)
+		return err
+	}
+	key := fmt.Sprintf("dao:proposal:%s", p.ID)
+	if err := CurrentStore().Set([]byte(key), raw); err != nil {
+		logger.Errorf("Ledger write failed: %v", err)
+		return err
+	}
 
-    // Broadcast proposal event
-    Broadcast("dao:proposal", raw)
-    logger.Infof("Proposal %s registered", p.ID)
-    return nil
+	// Broadcast proposal event
+	Broadcast("dao:proposal", raw)
+	logger.Infof("Proposal %s registered", p.ID)
+	return nil
 }
-
 
 func BalanceOfAsset(asset AssetRef, addr Address) (uint64, error) {
-    switch asset.Kind {
-    case AssetCoin:
-        return ledger.BalanceOf(addr[:]), nil // Ledger must be *Ledger
-    case AssetToken:
-        tok, ok := TokenLedger[asset.TokenID]
-        if !ok {
-            return 0, ErrInvalidAsset
-        }
-        return tok.balances.Get(asset.TokenID, addr), nil
-    default:
-        return 0, fmt.Errorf("unknown asset type: %v", asset.Kind)
-    }
+	switch asset.Kind {
+	case AssetCoin:
+		return ledger.BalanceOf(addr[:]), nil // Ledger must be *Ledger
+	case AssetToken:
+		tok, ok := TokenLedger[asset.TokenID]
+		if !ok {
+			return 0, ErrInvalidAsset
+		}
+		return tok.balances.Get(asset.TokenID, addr), nil
+	default:
+		return 0, fmt.Errorf("unknown asset type: %v", asset.Kind)
+	}
 }
-
 
 var ledger *Ledger
 
-
-
 // CastVote records a vote on a proposal
 func CastVote(v *Vote) error {
-    logger := zap.L().Sugar()
-    logger.Infof("Vote by %s on proposal %s", v.Voter, v.ProposalID)
+	logger := zap.L().Sugar()
+	logger.Infof("Vote by %s on proposal %s", v.Voter, v.ProposalID)
 
-    key := fmt.Sprintf("dao:proposal:%s", v.ProposalID)
-    raw, err := CurrentStore().Get([]byte(key))
-    if err != nil || raw == nil {
-        logger.Errorf("Proposal lookup failed: %v", err)
-        return ErrNotFound
-    }
+	key := fmt.Sprintf("dao:proposal:%s", v.ProposalID)
+	raw, err := CurrentStore().Get([]byte(key))
+	if err != nil || raw == nil {
+		logger.Errorf("Proposal lookup failed: %v", err)
+		return ErrNotFound
+	}
 
-    var p GovProposal
-    if err := json.Unmarshal(raw, &p); err != nil {
-        logger.Errorf("Unmarshal proposal failed: %v", err)
-        return err
-    }
+	var p GovProposal
+	if err := json.Unmarshal(raw, &p); err != nil {
+		logger.Errorf("Unmarshal proposal failed: %v", err)
+		return err
+	}
 
-    if time.Now().UTC().After(p.Deadline) {
-        return ErrExpired
-    }
+	if time.Now().UTC().After(p.Deadline) {
+		return ErrExpired
+	}
 
-    voteKey := fmt.Sprintf("dao:vote:%s:%s", v.ProposalID, v.Voter)
-    if val, _ := CurrentStore().Get([]byte(voteKey)); val != nil {
-        return ErrInvalidState
-    }
+	voteKey := fmt.Sprintf("dao:vote:%s:%s", v.ProposalID, v.Voter)
+	if val, _ := CurrentStore().Get([]byte(voteKey)); val != nil {
+		return ErrInvalidState
+	}
 
-    if v.Approve {
-        p.VotesFor++
-    } else {
-        p.VotesAgainst++
-    }
+	if v.Approve {
+		p.VotesFor++
+	} else {
+		p.VotesAgainst++
+	}
 
-    if err := CurrentStore().Set([]byte(voteKey), []byte{1}); err != nil {
-        logger.Errorf("Ledger vote write failed: %v", err)
-        return err
-    }
+	if err := CurrentStore().Set([]byte(voteKey), []byte{1}); err != nil {
+		logger.Errorf("Ledger vote write failed: %v", err)
+		return err
+	}
 
-    updated, _ := json.Marshal(&p)
-    if err := CurrentStore().Set([]byte(key), updated); err != nil {
-        logger.Errorf("Ledger update failed: %v", err)
-        return err
-    }
+	updated, _ := json.Marshal(&p)
+	if err := CurrentStore().Set([]byte(key), updated); err != nil {
+		logger.Errorf("Ledger update failed: %v", err)
+		return err
+	}
 
-    logger.Infof("Vote recorded: %s approves=%v", v.Voter, v.Approve)
-    return nil
+	logger.Infof("Vote recorded: %s approves=%v", v.Voter, v.Approve)
+	return nil
 }
 
 var (
-    ErrExpired       = errors.New("proposal has expired")
+	ErrExpired = errors.New("proposal has expired")
 )
-
 
 // ExecuteProposal finalizes a proposal if quorum reached and deadline passed
 func ExecuteProposal(id string) error {
-    logger := zap.L().Sugar()
-    key := fmt.Sprintf("dao:proposal:%s", id)
-    raw, err := CurrentStore().Get([]byte(key))
-    if err != nil {
-        logger.Errorf("Proposal lookup failed: %v", err)
-        return ErrNotFound
-    }
-    var p GovProposal
-    if err := json.Unmarshal(raw, &p); err != nil {
-        logger.Errorf("Unmarshal proposal failed: %v", err)
-        return err
-    }
+	logger := zap.L().Sugar()
+	key := fmt.Sprintf("dao:proposal:%s", id)
+	raw, err := CurrentStore().Get([]byte(key))
+	if err != nil {
+		logger.Errorf("Proposal lookup failed: %v", err)
+		return ErrNotFound
+	}
+	var p GovProposal
+	if err := json.Unmarshal(raw, &p); err != nil {
+		logger.Errorf("Unmarshal proposal failed: %v", err)
+		return err
+	}
 
-    if p.Executed {
-        return ErrInvalidState
-    }
-    if time.Now().UTC().Before(p.Deadline) {
-        return ErrNotReady
-    }
+	if p.Executed {
+		return ErrInvalidState
+	}
+	if time.Now().UTC().Before(p.Deadline) {
+		return ErrNotReady
+	}
 
-    if !quorumReached(&p) {
-        logger.Infof("Proposal %s failed quorum", id)
-        p.Executed = true
-    } else {
-        logger.Infof("Proposal %s passed, executing", id)
-        // Example treasury transfer: coin.Transfer from DAO treasury to creator
-        // Here, proposal execution logic would be extended per proposal type
-        // For now, emit event
-    }
-    p.Executed = true
+	if !quorumReached(&p) {
+		logger.Infof("Proposal %s failed quorum", id)
+		p.Executed = true
+	} else {
+		logger.Infof("Proposal %s passed, executing", id)
+		// Example treasury transfer: coin.Transfer from DAO treasury to creator
+		// Here, proposal execution logic would be extended per proposal type
+		// For now, emit event
+	}
+	p.Executed = true
 
-    updated, _ := json.Marshal(&p)
-    if err := CurrentStore().Set([]byte(key), updated); err != nil {
-        logger.Errorf("Ledger update failed: %v", err)
-        return err
-    }
+	updated, _ := json.Marshal(&p)
+	if err := CurrentStore().Set([]byte(key), updated); err != nil {
+		logger.Errorf("Ledger update failed: %v", err)
+		return err
+	}
 
-    Broadcast("dao:executed", updated)
-    return nil
+	Broadcast("dao:executed", updated)
+	return nil
 }
 
 var (
-    ErrNotReady     = errors.New("proposal not ready for execution") // ✅ Add this
+	ErrNotReady = errors.New("proposal not ready for execution") // ✅ Add this
 )
+
+// GetProposal retrieves a DAO proposal by its ID. Returns ErrNotFound if
+// not present.
+func GetProposal(id string) (GovProposal, error) {
+	raw, err := CurrentStore().Get([]byte(fmt.Sprintf("dao:proposal:%s", id)))
+	if err != nil {
+		return GovProposal{}, ErrNotFound
+	}
+	var p GovProposal
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return GovProposal{}, err
+	}
+	return p, nil
+}
+
+// ListProposals returns all DAO proposals from the store.
+func ListProposals() ([]GovProposal, error) {
+	it := CurrentStore().Iterator([]byte("dao:proposal:"), nil)
+	var out []GovProposal
+	for it.Next() {
+		var p GovProposal
+		if err := json.Unmarshal(it.Value(), &p); err != nil {
+			continue
+		}
+		out = append(out, p)
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	return out, it.Close()
+}

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -135,9 +135,9 @@ var catalogue = []struct {
 	{"SwapExactIn", 0x020001},
 	{"AMM_AddLiquidity", 0x020002},
 	{"AMM_RemoveLiquidity", 0x020003},
-        {"Quote", 0x020004},
-        {"AllPairs", 0x020005},
-        {"InitPoolsFromFile", 0x020006},
+	{"Quote", 0x020004},
+	{"AllPairs", 0x020005},
+	{"InitPoolsFromFile", 0x020006},
 
 	// Authority (0x03)
 	{"NewAuthoritySet", 0x030001},
@@ -238,6 +238,8 @@ var catalogue = []struct {
 	{"BalanceOfAsset", 0x0C0006},
 	{"CastVote", 0x0C0007},
 	{"ExecuteProposal", 0x0C0008},
+	{"GetProposal", 0x0C0009},
+	{"ListProposals", 0x0C000A},
 
 	// GreenTech (0x0D)
 	{"InitGreenTech", 0x0D0001},

--- a/synnergy-network/tests/governance_test.go
+++ b/synnergy-network/tests/governance_test.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestProposalLifecycle(t *testing.T) {
+	// init in-memory store and ledger
+	appStore = &InMemoryStore{data: make(map[string][]byte)}
+	ledger = &Ledger{TokenBalances: map[string]uint64{fmt.Sprintf("%x", []byte{1}): 1}}
+
+	creator := Address{1}
+	prop := &GovProposal{Creator: creator, Description: "test"}
+	if err := SubmitProposal(prop); err != nil {
+		t.Fatalf("SubmitProposal err: %v", err)
+	}
+
+	// fetch by ID
+	got, err := GetProposal(prop.ID)
+	if err != nil {
+		t.Fatalf("GetProposal err: %v", err)
+	}
+	if got.Description != "test" {
+		t.Fatalf("unexpected description %q", got.Description)
+	}
+
+	list, err := ListProposals()
+	if err != nil {
+		t.Fatalf("ListProposals err: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 proposal, got %d", len(list))
+	}
+}


### PR DESCRIPTION
## Summary
- implement `GetProposal` and `ListProposals` in governance module
- register new opcodes and gas costs
- test proposal lifecycle

## Testing
- `go test ./...` *(fails: missing go.sum entries and duplicate test helpers)*

------
https://chatgpt.com/codex/tasks/task_e_688adbb4429c8320be2a7b732605652d