### PR TITLE
Add rollup batch utilities

### DIFF
--- a/synnergy-network/cmd/cli/rollups.go
+++ b/synnergy-network/cmd/cli/rollups.go
@@ -18,23 +18,23 @@
 package cli
 
 import (
-    "bufio"
-    "context"
-    "encoding/hex"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "io"
-    "net"
-    "os"
-    "strconv"
-    "strings"
-    "time"
+	"bufio"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
 
-    "github.com/spf13/cobra"
-    "github.com/spf13/viper"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
-    core "synnergy-network/core"
+	core "synnergy-network/core"
 )
 
 // -----------------------------------------------------------------------------
@@ -42,32 +42,38 @@ import (
 // -----------------------------------------------------------------------------
 
 type rollClient struct {
-    conn net.Conn
-    rd   *bufio.Reader
+	conn net.Conn
+	rd   *bufio.Reader
 }
 
 func newRollClient(ctx context.Context) (*rollClient, error) {
-    addr := viper.GetString("ROLLUP_API_ADDR")
-    if addr == "" { addr = "127.0.0.1:7960" }
-    d := net.Dialer{}
-    conn, err := d.DialContext(ctx, "tcp", addr)
-    if err != nil { return nil, fmt.Errorf("cannot connect to roll‑up daemon at %s: %w", addr, err) }
-    return &rollClient{conn: conn, rd: bufio.NewReader(conn)}, nil
+	addr := viper.GetString("ROLLUP_API_ADDR")
+	if addr == "" {
+		addr = "127.0.0.1:7960"
+	}
+	d := net.Dialer{}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to roll‑up daemon at %s: %w", addr, err)
+	}
+	return &rollClient{conn: conn, rd: bufio.NewReader(conn)}, nil
 }
 
 func (c *rollClient) Close() { _ = c.conn.Close() }
 
 func (c *rollClient) writeJSON(v any) error {
-    b, err := json.Marshal(v)
-    if err != nil { return err }
-    b = append(b, '\n')
-    _, err = c.conn.Write(b)
-    return err
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	_, err = c.conn.Write(b)
+	return err
 }
 
 func (c *rollClient) readJSON(v any) error {
-    dec := json.NewDecoder(c.rd)
-    return dec.Decode(v)
+	dec := json.NewDecoder(c.rd)
+	return dec.Decode(v)
 }
 
 // -----------------------------------------------------------------------------
@@ -75,77 +81,130 @@ func (c *rollClient) readJSON(v any) error {
 // -----------------------------------------------------------------------------
 
 func submitBatchRPC(ctx context.Context, txHashes [][]byte, preRoot string, submitter string) (uint64, error) {
-    cli, err := newRollClient(ctx)
-    if err != nil { return 0, err }
-    defer cli.Close()
-    return sendAndGetID(cli, map[string]any{
-        "action":    "submit",
-        "tx_hashes": txHashes,
-        "pre_root":  preRoot,
-        "submitter": submitter,
-    })
+	cli, err := newRollClient(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer cli.Close()
+	return sendAndGetID(cli, map[string]any{
+		"action":    "submit",
+		"tx_hashes": txHashes,
+		"pre_root":  preRoot,
+		"submitter": submitter,
+	})
 }
 
 func sendAndGetID(cli *rollClient, payload map[string]any) (uint64, error) {
-    if err := cli.writeJSON(payload); err != nil { return 0, err }
-    var resp struct{ ID uint64 `json:"id"`; Error string `json:"error,omitempty"` }
-    if err := cli.readJSON(&resp); err != nil { return 0, err }
-    if resp.Error != "" { return 0, errors.New(resp.Error) }
-    return resp.ID, nil
+	if err := cli.writeJSON(payload); err != nil {
+		return 0, err
+	}
+	var resp struct {
+		ID    uint64 `json:"id"`
+		Error string `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return 0, err
+	}
+	if resp.Error != "" {
+		return 0, errors.New(resp.Error)
+	}
+	return resp.ID, nil
 }
 
 func challengeRPC(ctx context.Context, batchID uint64, txIdx uint32, proof [][]byte) error {
-    cli, err := newRollClient(ctx)
-    if err != nil { return err }
-    defer cli.Close()
-    return cli.writeJSON(map[string]any{
-        "action":   "challenge",
-        "batch_id": batchID,
-        "tx_idx":   txIdx,
-        "proof":    proof,
-    })
+	cli, err := newRollClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	return cli.writeJSON(map[string]any{
+		"action":   "challenge",
+		"batch_id": batchID,
+		"tx_idx":   txIdx,
+		"proof":    proof,
+	})
 }
 
 func finalizeRPC(ctx context.Context, batchID uint64) error {
-    cli, err := newRollClient(ctx)
-    if err != nil { return err }
-    defer cli.Close()
-    return cli.writeJSON(map[string]any{"action": "finalize", "batch_id": batchID})
+	cli, err := newRollClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	return cli.writeJSON(map[string]any{"action": "finalize", "batch_id": batchID})
 }
 
 func infoRPC(ctx context.Context, batchID uint64) (*core.BatchHeader, core.BatchState, error) {
-    cli, err := newRollClient(ctx)
-    if err != nil { return nil, 0, err }
-    defer cli.Close()
-    if err := cli.writeJSON(map[string]any{"action": "info", "batch_id": batchID}); err != nil { return nil, 0, err }
-    var resp struct {
-        Header core.BatchHeader `json:"header"`
-        State  core.BatchState  `json:"state"`
-        Error  string           `json:"error,omitempty"`
-    }
-    if err := cli.readJSON(&resp); err != nil { return nil, 0, err }
-    if resp.Error != "" { return nil, 0, errors.New(resp.Error) }
-    return &resp.Header, resp.State, nil
+	cli, err := newRollClient(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "info", "batch_id": batchID}); err != nil {
+		return nil, 0, err
+	}
+	var resp struct {
+		Header core.BatchHeader `json:"header"`
+		State  core.BatchState  `json:"state"`
+		Error  string           `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return nil, 0, err
+	}
+	if resp.Error != "" {
+		return nil, 0, errors.New(resp.Error)
+	}
+	return &resp.Header, resp.State, nil
 }
 
 func listRPC(ctx context.Context, limit int) ([]struct {
-    Header core.BatchHeader `json:"header"`
-    State  core.BatchState  `json:"state"`
+	Header core.BatchHeader `json:"header"`
+	State  core.BatchState  `json:"state"`
 }, error) {
-    cli, err := newRollClient(ctx)
-    if err != nil { return nil, err }
-    defer cli.Close()
-    if err := cli.writeJSON(map[string]any{"action": "list", "limit": limit}); err != nil { return nil, err }
-    var resp struct {
-        List  []struct {
-            Header core.BatchHeader `json:"header"`
-            State  core.BatchState  `json:"state"`
-        } `json:"list"`
-        Error string `json:"error,omitempty"`
-    }
-    if err := cli.readJSON(&resp); err != nil { return nil, err }
-    if resp.Error != "" { return nil, errors.New(resp.Error) }
-    return resp.List, nil
+	cli, err := newRollClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "list", "limit": limit}); err != nil {
+		return nil, err
+	}
+	var resp struct {
+		List []struct {
+			Header core.BatchHeader `json:"header"`
+			State  core.BatchState  `json:"state"`
+		} `json:"list"`
+		Error string `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.List, nil
+}
+
+func txsRPC(ctx context.Context, batchID uint64) ([][]byte, error) {
+	cli, err := newRollClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "txs", "batch_id": batchID}); err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Txs   [][]byte `json:"txs"`
+		Error string   `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.Txs, nil
 }
 
 // -----------------------------------------------------------------------------
@@ -153,145 +212,190 @@ func listRPC(ctx context.Context, limit int) ([]struct {
 // -----------------------------------------------------------------------------
 
 var rollCmd = &cobra.Command{
-    Use:     "~rollup",
-    Short:   "Optimistic roll‑up operations",
-    Aliases: []string{"rollup", "rlp"},
-    PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-        cobra.OnInitialize(initRollConfig)
-        return nil
-    },
+	Use:     "~rollup",
+	Short:   "Optimistic roll‑up operations",
+	Aliases: []string{"rollup", "rlp"},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		cobra.OnInitialize(initRollConfig)
+		return nil
+	},
 }
 
 // submit ----------------------------------------------------------------------
 var submitCmd = &cobra.Command{
-    Use:   "submit",
-    Short: "Submit a new batch (reads tx hashes from flags or stdin)",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        preRoot, _ := cmd.Flags().GetString("pre-root")
-        submitter, _ := cmd.Flags().GetString("submitter")
-        txFlag, _ := cmd.Flags().GetString("txs")
+	Use:   "submit",
+	Short: "Submit a new batch (reads tx hashes from flags or stdin)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		preRoot, _ := cmd.Flags().GetString("pre-root")
+		submitter, _ := cmd.Flags().GetString("submitter")
+		txFlag, _ := cmd.Flags().GetString("txs")
 
-        var hashes [][]byte
-        if txFlag != "" {
-            for _, h := range strings.Split(txFlag, ",") {
-                bh, err := hex.DecodeString(strings.TrimSpace(h))
-                if err != nil || len(bh) != 32 {
-                    return fmt.Errorf("invalid tx hash %q", h)
-                }
-                hashes = append(hashes, bh)
-            }
-        } else {
-            // read newline‑separated hex hashes from stdin
-            stdinHashes, err := readHashes(os.Stdin)
-            if err != nil { return err }
-            hashes = stdinHashes
-        }
-        if len(hashes) == 0 { return errors.New("no tx hashes provided") }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 4*time.Second)
-        defer cancel()
-        id, err := submitBatchRPC(ctx, hashes, preRoot, submitter)
-        if err != nil { return err }
-        fmt.Printf("batch submitted: %d\n", id)
-        return nil
-    },
+		var hashes [][]byte
+		if txFlag != "" {
+			for _, h := range strings.Split(txFlag, ",") {
+				bh, err := hex.DecodeString(strings.TrimSpace(h))
+				if err != nil || len(bh) != 32 {
+					return fmt.Errorf("invalid tx hash %q", h)
+				}
+				hashes = append(hashes, bh)
+			}
+		} else {
+			// read newline‑separated hex hashes from stdin
+			stdinHashes, err := readHashes(os.Stdin)
+			if err != nil {
+				return err
+			}
+			hashes = stdinHashes
+		}
+		if len(hashes) == 0 {
+			return errors.New("no tx hashes provided")
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 4*time.Second)
+		defer cancel()
+		id, err := submitBatchRPC(ctx, hashes, preRoot, submitter)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("batch submitted: %d\n", id)
+		return nil
+	},
 }
 
 func readHashes(r io.Reader) ([][]byte, error) {
-    var res [][]byte
-    sc := bufio.NewScanner(r)
-    for sc.Scan() {
-        line := strings.TrimSpace(sc.Text())
-        if line == "" { continue }
-        bh, err := hex.DecodeString(line)
-        if err != nil || len(bh) != 32 {
-            return nil, fmt.Errorf("invalid tx hash %q", line)
-        }
-        res = append(res, bh)
-    }
-    return res, sc.Err()
+	var res [][]byte
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		bh, err := hex.DecodeString(line)
+		if err != nil || len(bh) != 32 {
+			return nil, fmt.Errorf("invalid tx hash %q", line)
+		}
+		res = append(res, bh)
+	}
+	return res, sc.Err()
 }
 
 // challenge -------------------------------------------------------------------
 var challengeCmd = &cobra.Command{
-    Use:   "challenge [batchID] [txIdx] [proof‑hex…]",
-    Short: "Submit a fraud proof for a batch",
-    Args:  cobra.MinimumNArgs(3),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        id, err := strconv.ParseUint(args[0], 10, 64)
-        if err != nil { return fmt.Errorf("invalid batchID: %w", err) }
-        idxU, err := strconv.ParseUint(args[1], 10, 32)
-        if err != nil { return fmt.Errorf("invalid txIdx: %w", err) }
-        var proof [][]byte
-        for _, p := range args[2:] {
-            b, err := hex.DecodeString(p)
-            if err != nil { return fmt.Errorf("invalid proof chunk %q", p) }
-            proof = append(proof, b)
-        }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        return challengeRPC(ctx, id, uint32(idxU), proof)
-    },
+	Use:   "challenge [batchID] [txIdx] [proof‑hex…]",
+	Short: "Submit a fraud proof for a batch",
+	Args:  cobra.MinimumNArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid batchID: %w", err)
+		}
+		idxU, err := strconv.ParseUint(args[1], 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid txIdx: %w", err)
+		}
+		var proof [][]byte
+		for _, p := range args[2:] {
+			b, err := hex.DecodeString(p)
+			if err != nil {
+				return fmt.Errorf("invalid proof chunk %q", p)
+			}
+			proof = append(proof, b)
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		return challengeRPC(ctx, id, uint32(idxU), proof)
+	},
 }
 
 // finalize --------------------------------------------------------------------
 var finalizeCmd = &cobra.Command{
-    Use:   "finalize [batchID]",
-    Short: "Finalize (or revert) a batch after challenge period",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        id, err := strconv.ParseUint(args[0], 10, 64)
-        if err != nil { return fmt.Errorf("invalid batchID: %w", err) }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        return finalizeRPC(ctx, id)
-    },
+	Use:   "finalize [batchID]",
+	Short: "Finalize (or revert) a batch after challenge period",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid batchID: %w", err)
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		return finalizeRPC(ctx, id)
+	},
 }
 
 // info ------------------------------------------------------------------------
 var infoCmd = &cobra.Command{
-    Use:   "info [batchID]",
-    Short: "Display batch header & state",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        id, err := strconv.ParseUint(args[0], 10, 64)
-        if err != nil { return fmt.Errorf("invalid batchID: %w", err) }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
-        defer cancel()
-        hdr, state, err := infoRPC(ctx, id)
-        if err != nil { return err }
-        enc := json.NewEncoder(os.Stdout)
-        enc.SetIndent("", "  ")
-        return enc.Encode(struct {
-            Header core.BatchHeader `json:"header"`
-            State  core.BatchState  `json:"state"`
-        }{*hdr, state})
-    },
+	Use:   "info [batchID]",
+	Short: "Display batch header & state",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid batchID: %w", err)
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
+		defer cancel()
+		hdr, state, err := infoRPC(ctx, id)
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(struct {
+			Header core.BatchHeader `json:"header"`
+			State  core.BatchState  `json:"state"`
+		}{*hdr, state})
+	},
 }
 
 // list ------------------------------------------------------------------------
 var listCmd = &cobra.Command{
-    Use:   "list",
-    Short: "List recent batches",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        limit, _ := cmd.Flags().GetInt("limit")
-        format := viper.GetString("output.format")
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        list, err := listRPC(ctx, limit)
-        if err != nil { return err }
-        switch format {
-        case "json":
-            enc := json.NewEncoder(os.Stdout)
-            enc.SetIndent("", "  ")
-            return enc.Encode(list)
-        default:
-            fmt.Printf("%-5s %-12s %-8s %-10s\n", "ID", "Timestamp", "TXs", "State")
-            for _, e := range list {
-                fmt.Printf("%-5d %-12d %-8d %-10s\n", e.Header.BatchID, e.Header.Timestamp, e.Header.TXCount, e.State)
-            }
-            return nil
-        }
-    },
+	Use:   "list",
+	Short: "List recent batches",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		limit, _ := cmd.Flags().GetInt("limit")
+		format := viper.GetString("output.format")
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		list, err := listRPC(ctx, limit)
+		if err != nil {
+			return err
+		}
+		switch format {
+		case "json":
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(list)
+		default:
+			fmt.Printf("%-5s %-12s %-8s %-10s\n", "ID", "Timestamp", "TXs", "State")
+			for _, e := range list {
+				fmt.Printf("%-5d %-12d %-8d %-10s\n", e.Header.BatchID, e.Header.Timestamp, e.Header.TXCount, e.State)
+			}
+			return nil
+		}
+	},
+}
+
+// txs -------------------------------------------------------------------------
+var txsCmd = &cobra.Command{
+	Use:   "txs [batchID]",
+	Short: "List transactions in a batch",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid batchID: %w", err)
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		txs, err := txsRPC(ctx, id)
+		if err != nil {
+			return err
+		}
+		for _, t := range txs {
+			fmt.Println(hex.EncodeToString(t))
+		}
+		return nil
+	},
 }
 
 // -----------------------------------------------------------------------------
@@ -299,38 +403,39 @@ var listCmd = &cobra.Command{
 // -----------------------------------------------------------------------------
 
 func initRollConfig() {
-    viper.SetEnvPrefix("synnergy")
-    viper.AutomaticEnv()
+	viper.SetEnvPrefix("synnergy")
+	viper.AutomaticEnv()
 
-    cfg := viper.GetString("config")
-    if cfg != "" {
-        viper.SetConfigFile(cfg)
-    } else {
-        viper.SetConfigName("synnergy")
-        viper.AddConfigPath(".")
-        viper.AddConfigPath("$HOME/.config/synnergy")
-    }
-    _ = viper.ReadInConfig()
+	cfg := viper.GetString("config")
+	if cfg != "" {
+		viper.SetConfigFile(cfg)
+	} else {
+		viper.SetConfigName("synnergy")
+		viper.AddConfigPath(".")
+		viper.AddConfigPath("$HOME/.config/synnergy")
+	}
+	_ = viper.ReadInConfig()
 
-    viper.SetDefault("ROLLUP_API_ADDR", "127.0.0.1:7960")
-    viper.SetDefault("output.format", "table")
+	viper.SetDefault("ROLLUP_API_ADDR", "127.0.0.1:7960")
+	viper.SetDefault("output.format", "table")
 }
 
 func init() {
-    submitCmd.Flags().String("pre-root", "", "pre‑state root hex (optional)")
-    submitCmd.Flags().String("txs", "", "comma‑separated list of tx hashes (hex32); omit to read from stdin")
-    submitCmd.Flags().String("submitter", "", "submitter address hex")
+	submitCmd.Flags().String("pre-root", "", "pre‑state root hex (optional)")
+	submitCmd.Flags().String("txs", "", "comma‑separated list of tx hashes (hex32); omit to read from stdin")
+	submitCmd.Flags().String("submitter", "", "submitter address hex")
 
-    listCmd.Flags().Int("limit", 10, "max batches to list")
-    listCmd.Flags().StringP("format", "f", "table", "output format: table|json")
-    _ = viper.BindPFlag("output.format", listCmd.Flags().Lookup("format"))
+	listCmd.Flags().Int("limit", 10, "max batches to list")
+	listCmd.Flags().StringP("format", "f", "table", "output format: table|json")
+	_ = viper.BindPFlag("output.format", listCmd.Flags().Lookup("format"))
 
-    // Register sub‑commands
-    rollCmd.AddCommand(submitCmd)
-    rollCmd.AddCommand(challengeCmd)
-    rollCmd.AddCommand(finalizeCmd)
-    rollCmd.AddCommand(infoCmd)
-    rollCmd.AddCommand(listCmd)
+	// Register sub‑commands
+	rollCmd.AddCommand(submitCmd)
+	rollCmd.AddCommand(challengeCmd)
+	rollCmd.AddCommand(finalizeCmd)
+	rollCmd.AddCommand(infoCmd)
+	rollCmd.AddCommand(listCmd)
+	rollCmd.AddCommand(txsCmd)
 }
 
 // NewRollupCommand exposes the consolidated command tree.

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -50,17 +50,15 @@ var gasTable = map[Opcode]uint64{
 	ReleaseEscrow:  12_000,
 	PredictVolume:  15_000,
 
-
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker
 	// ----------------------------------------------------------------------
-	SwapExactIn:    4_500,
-	AddLiquidity:   5_000,
-	RemoveLiquidity:5_000,
-  Quote:          2_500,
-  AllPairs:       2_000,
-  InitPoolsFromFile: 6_000,
-
+	SwapExactIn:       4_500,
+	AddLiquidity:      5_000,
+	RemoveLiquidity:   5_000,
+	Quote:             2_500,
+	AllPairs:          2_000,
+	InitPoolsFromFile: 6_000,
 
 	// ----------------------------------------------------------------------
 	// Authority / Validator-Set
@@ -105,7 +103,6 @@ var gasTable = map[Opcode]uint64{
 	Compliance_AuditTrail: 3_000,
 	Compliance_MonitorTx:  5_000,
 	Compliance_VerifyZKP:  12_000,
-
 
 	// ----------------------------------------------------------------------
 	// Consensus Core
@@ -265,10 +262,14 @@ var gasTable = map[Opcode]uint64{
 	// ----------------------------------------------------------------------
 	// Roll-ups
 	// ----------------------------------------------------------------------
-	NewAggregator:    15_000,
-	SubmitBatch:      10_000,
-	SubmitFraudProof: 30_000,
-	FinalizeBatch:    10_000,
+	NewAggregator:     15_000,
+	SubmitBatch:       10_000,
+	SubmitFraudProof:  30_000,
+	FinalizeBatch:     10_000,
+	BatchHeader:       500,
+	BatchState:        300,
+	BatchTransactions: 1_000,
+	ListBatches:       2_000,
 
 	// ----------------------------------------------------------------------
 	// Security / Cryptography

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -135,9 +135,9 @@ var catalogue = []struct {
 	{"SwapExactIn", 0x020001},
 	{"AMM_AddLiquidity", 0x020002},
 	{"AMM_RemoveLiquidity", 0x020003},
-        {"Quote", 0x020004},
-        {"AllPairs", 0x020005},
-        {"InitPoolsFromFile", 0x020006},
+	{"Quote", 0x020004},
+	{"AllPairs", 0x020005},
+	{"InitPoolsFromFile", 0x020006},
 
 	// Authority (0x03)
 	{"NewAuthoritySet", 0x030001},
@@ -320,6 +320,10 @@ var catalogue = []struct {
 	{"SubmitBatch", 0x130002},
 	{"SubmitFraudProof", 0x130003},
 	{"FinalizeBatch", 0x130004},
+	{"BatchHeader", 0x130005},
+	{"BatchState", 0x130006},
+	{"BatchTransactions", 0x130007},
+	{"ListBatches", 0x130008},
 
 	// Security (0x14)
 	{"Security_Sign", 0x140001},

--- a/synnergy-network/tests/rollups_test.go
+++ b/synnergy-network/tests/rollups_test.go
@@ -1,61 +1,92 @@
 package core
 
 import (
-    "crypto/sha256"
-    "encoding/json"
-    "sync"
-    "testing"
-    "time"
+	"crypto/sha256"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
 )
 
 //------------------------------------------------------------
 // Mock in‑memory StateRW for Aggregator tests
 //------------------------------------------------------------
 
-type aggLedger struct { mu sync.RWMutex; kv map[string][]byte }
+type aggLedger struct {
+	mu sync.RWMutex
+	kv map[string][]byte
+}
 
 func newAggLedger() *aggLedger { return &aggLedger{kv: make(map[string][]byte)} }
-func (l *aggLedger) SetState(k,v []byte) error { l.mu.Lock(); l.kv[string(k)] = append([]byte(nil), v...); l.mu.Unlock(); return nil }
-func (l *aggLedger) GetState(k []byte) ([]byte,error){ l.mu.RLock(); defer l.mu.RUnlock(); return l.kv[string(k)], nil }
-func (l *aggLedger) HasState(k []byte) (bool,error) { l.mu.RLock(); defer l.mu.RUnlock(); _,ok:=l.kv[string(k)]; return ok,nil }
-func (l *aggLedger) PrefixIterator([]byte) PrefixIterator { return nil }
-func (l *aggLedger) Snapshot(func() error) error { return nil }
-func (l *aggLedger) Transfer(Address,Address,uint64) error { return nil }
-func (l *aggLedger) IsIDTokenHolder(Address) bool { return false }
-func (l *aggLedger) Burn(Address,uint64) error { return nil }
-func (l *aggLedger) BurnLP(Address,PoolID,uint64) error { return nil }
-func (l *aggLedger) MintLP(Address,PoolID,uint64) error { return nil }
-func (l *aggLedger) DeductGas(Address,uint64){}
-func (l *aggLedger) EmitApproval(TokenID,Address,Address,uint64){}
-func (l *aggLedger) EmitTransfer(TokenID,Address,Address,uint64){}
-func (l *aggLedger) BalanceOf(Address) uint64 { return 0 }
-func (l *aggLedger) Mint(Address,uint64) error { return nil }
-func (l *aggLedger) MintToken(Address,string,uint64) error { return nil }
-func (l *aggLedger) WithinBlock(func() error) error { return nil }
-func (l *aggLedger) NonceOf(Address) uint64 { return 0 }
+func (l *aggLedger) SetState(k, v []byte) error {
+	l.mu.Lock()
+	l.kv[string(k)] = append([]byte(nil), v...)
+	l.mu.Unlock()
+	return nil
+}
+func (l *aggLedger) GetState(k []byte) ([]byte, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.kv[string(k)], nil
+}
+func (l *aggLedger) HasState(k []byte) (bool, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	_, ok := l.kv[string(k)]
+	return ok, nil
+}
+func (l *aggLedger) PrefixIterator([]byte) PrefixIterator           { return nil }
+func (l *aggLedger) Snapshot(func() error) error                    { return nil }
+func (l *aggLedger) Transfer(Address, Address, uint64) error        { return nil }
+func (l *aggLedger) IsIDTokenHolder(Address) bool                   { return false }
+func (l *aggLedger) Burn(Address, uint64) error                     { return nil }
+func (l *aggLedger) BurnLP(Address, PoolID, uint64) error           { return nil }
+func (l *aggLedger) MintLP(Address, PoolID, uint64) error           { return nil }
+func (l *aggLedger) DeductGas(Address, uint64)                      {}
+func (l *aggLedger) EmitApproval(TokenID, Address, Address, uint64) {}
+func (l *aggLedger) EmitTransfer(TokenID, Address, Address, uint64) {}
+func (l *aggLedger) BalanceOf(Address) uint64                       { return 0 }
+func (l *aggLedger) Mint(Address, uint64) error                     { return nil }
+func (l *aggLedger) MintToken(Address, string, uint64) error        { return nil }
+func (l *aggLedger) WithinBlock(func() error) error                 { return nil }
+func (l *aggLedger) NonceOf(Address) uint64                         { return 0 }
 
 //------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------
 
-func randHash(b byte) []byte { h:=make([]byte,32); for i:=range h{ h[i]=b }; return h }
+func randHash(b byte) []byte {
+	h := make([]byte, 32)
+	for i := range h {
+		h[i] = b
+	}
+	return h
+}
 
 //------------------------------------------------------------
 // Tests for MerkleRoot utility
 //------------------------------------------------------------
 
-func TestMerkleRoot(t *testing.T){
-    // empty input
-    if _,err:=MerkleRoot(nil); err==nil { t.Fatalf("expected error on empty input") }
-    // wrong size hash
-    badHash := [][]byte{{0x01,0x02}}
-    if _,err:=MerkleRoot(badHash); err==nil { t.Fatalf("expected error on short hash") }
-    // happy path (two leaves identical)
-    h1 := randHash(0xAA)
-    h2 := randHash(0xBB)
-    root, err := MerkleRoot([][]byte{h1,h2})
-    if err!=nil { t.Fatalf("merkle err %v",err) }
-    if root==([32]byte{}) { t.Fatalf("root should not be zero") }
+func TestMerkleRoot(t *testing.T) {
+	// empty input
+	if _, err := MerkleRoot(nil); err == nil {
+		t.Fatalf("expected error on empty input")
+	}
+	// wrong size hash
+	badHash := [][]byte{{0x01, 0x02}}
+	if _, err := MerkleRoot(badHash); err == nil {
+		t.Fatalf("expected error on short hash")
+	}
+	// happy path (two leaves identical)
+	h1 := randHash(0xAA)
+	h2 := randHash(0xBB)
+	root, err := MerkleRoot([][]byte{h1, h2})
+	if err != nil {
+		t.Fatalf("merkle err %v", err)
+	}
+	if root == ([32]byte{}) {
+		t.Fatalf("root should not be zero")
+	}
 }
 
 //------------------------------------------------------------
@@ -64,49 +95,64 @@ func TestMerkleRoot(t *testing.T){
 
 var testCP = 100 * time.Millisecond // short challenge period for tests
 
-func init(){ ChallengePeriod = testCP } // assume var ChallengePeriod time.Duration declared elsewhere
+func init() { ChallengePeriod = testCP } // assume var ChallengePeriod time.Duration declared elsewhere
 
-func TestSubmitBatch_And_Finalize(t *testing.T){
-    led := newAggLedger()
-    ag := NewAggregator(led)
-    pre := [32]byte{}
-    txs := [][]byte{randHash(0x01), randHash(0x02)}
-    id, err := ag.SubmitBatch(Address{0x01}, txs, pre)
-    if err!=nil { t.Fatalf("submit err %v",err) }
+func TestSubmitBatch_And_Finalize(t *testing.T) {
+	led := newAggLedger()
+	ag := NewAggregator(led)
+	pre := [32]byte{}
+	txs := [][]byte{randHash(0x01), randHash(0x02)}
+	id, err := ag.SubmitBatch(Address{0x01}, txs, pre)
+	if err != nil {
+		t.Fatalf("submit err %v", err)
+	}
 
-    // key existence
-    if ok,_ := led.HasState(batchKey(id)); !ok {
-        t.Fatalf("header not stored")
-    }
+	// key existence
+	if ok, _ := led.HasState(batchKey(id)); !ok {
+		t.Fatalf("header not stored")
+	}
 
-    // premature finalize should error
-    if err:= ag.FinalizeBatch(id); err==nil {
-        t.Fatalf("expected challenge period error")
-    }
+	// premature finalize should error
+	if err := ag.FinalizeBatch(id); err == nil {
+		t.Fatalf("expected challenge period error")
+	}
 
-    // move timestamp backwards to simulate passage
-    hdr, _ := ag.batchHeader(id)
-    hdr.Timestamp = hdr.Timestamp - int64(testCP.Seconds()*2)
-    b,_ := json.Marshal(hdr)
-    led.SetState(batchKey(id), b)
+	// move timestamp backwards to simulate passage
+	hdr, _ := ag.BatchHeader(id)
+	hdr.Timestamp = hdr.Timestamp - int64(testCP.Seconds()*2)
+	b, _ := json.Marshal(hdr)
+	led.SetState(batchKey(id), b)
 
-    // finalize pending
-    if err:= ag.FinalizeBatch(id); err!=nil { t.Fatalf("finalize err %v", err) }
-    if st:= ag.batchState(id); st!=Finalised { t.Fatalf("state %d want Finalised", st) }
+	// finalize pending
+	if err := ag.FinalizeBatch(id); err != nil {
+		t.Fatalf("finalize err %v", err)
+	}
+	if st := ag.BatchState(id); st != Finalised {
+		t.Fatalf("state %d want Finalised", st)
+	}
 
-    // second finalize call should error
-    if err:= ag.FinalizeBatch(id); err==nil { t.Fatalf("expected already finalised error") }
+	// second finalize call should error
+	if err := ag.FinalizeBatch(id); err == nil {
+		t.Fatalf("expected already finalised error")
+	}
 }
 
-func TestFinalize_RevertedPath(t *testing.T){
-    led := newAggLedger()
-    ag := NewAggregator(led)
-    txs := [][]byte{randHash(0x05)}
-    id,_ := ag.SubmitBatch(Address{0x02}, txs, [32]byte{})
-    // set state to Challenged manually and timestamp old
-    led.SetState(batchStateKey(id), []byte{byte(Challenged)})
-    hdr,_ := ag.batchHeader(id); hdr.Timestamp -= int64(testCP.Seconds()*2); b,_:=json.Marshal(hdr); led.SetState(batchKey(id), b)
+func TestFinalize_RevertedPath(t *testing.T) {
+	led := newAggLedger()
+	ag := NewAggregator(led)
+	txs := [][]byte{randHash(0x05)}
+	id, _ := ag.SubmitBatch(Address{0x02}, txs, [32]byte{})
+	// set state to Challenged manually and timestamp old
+	led.SetState(batchStateKey(id), []byte{byte(Challenged)})
+	hdr, _ := ag.BatchHeader(id)
+	hdr.Timestamp -= int64(testCP.Seconds() * 2)
+	b, _ := json.Marshal(hdr)
+	led.SetState(batchKey(id), b)
 
-    if err:= ag.FinalizeBatch(id); err!=nil { t.Fatalf("finalize err %v",err) }
-    if st:= ag.batchState(id); st!=Reverted { t.Fatalf("state %d want Reverted", st) }
+	if err := ag.FinalizeBatch(id); err != nil {
+		t.Fatalf("finalize err %v", err)
+	}
+	if st := ag.BatchState(id); st != Reverted {
+		t.Fatalf("state %d want Reverted", st)
+	}
 }


### PR DESCRIPTION
## Summary
- expand rollups API with batch state export and listing helpers
- add transaction storage and new RPC command
- update CLI to query stored transactions
- register new opcodes and gas costs
- update tests for new API names

## Testing
- `go test ./...` *(fails: go mod tidy required)*

------
https://chatgpt.com/codex/tasks/task_e_688adde34c5883208dc62e4a017967c1