### PR TITLE
Enhance sharding module with scaling utilities

### DIFF
--- a/synnergy-network/cmd/cli/sharding.go
+++ b/synnergy-network/cmd/cli/sharding.go
@@ -18,20 +18,20 @@
 package cli
 
 import (
-    "bufio"
-    "context"
-    "encoding/hex"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "net"
-    "os"
-    "strconv"
-    "strings"
-    "time"
+	"bufio"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
 
-    "github.com/spf13/cobra"
-    "github.com/spf13/viper"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // -----------------------------------------------------------------------------
@@ -39,36 +39,38 @@ import (
 // -----------------------------------------------------------------------------
 
 type shardClient struct {
-    conn net.Conn
-    rd   *bufio.Reader
+	conn net.Conn
+	rd   *bufio.Reader
 }
 
 func newShardClient(ctx context.Context) (*shardClient, error) {
-    addr := viper.GetString("SHARD_API_ADDR")
-    if addr == "" {
-        addr = "127.0.0.1:7980"
-    }
-    d := net.Dialer{}
-    conn, err := d.DialContext(ctx, "tcp", addr)
-    if err != nil {
-        return nil, fmt.Errorf("cannot connect to sharding daemon at %s: %w", addr, err)
-    }
-    return &shardClient{conn: conn, rd: bufio.NewReader(conn)}, nil
+	addr := viper.GetString("SHARD_API_ADDR")
+	if addr == "" {
+		addr = "127.0.0.1:7980"
+	}
+	d := net.Dialer{}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to sharding daemon at %s: %w", addr, err)
+	}
+	return &shardClient{conn: conn, rd: bufio.NewReader(conn)}, nil
 }
 
 func (c *shardClient) Close() { _ = c.conn.Close() }
 
 func (c *shardClient) writeJSON(v any) error {
-    data, err := json.Marshal(v)
-    if err != nil { return err }
-    data = append(data, '\n')
-    _, err = c.conn.Write(data)
-    return err
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = c.conn.Write(data)
+	return err
 }
 
 func (c *shardClient) readJSON(v any) error {
-    dec := json.NewDecoder(c.rd)
-    return dec.Decode(v)
+	dec := json.NewDecoder(c.rd)
+	return dec.Decode(v)
 }
 
 // -----------------------------------------------------------------------------
@@ -76,57 +78,118 @@ func (c *shardClient) readJSON(v any) error {
 // -----------------------------------------------------------------------------
 
 func getLeaderRPC(ctx context.Context, shard uint16) (string, error) {
-    cli, err := newShardClient(ctx)
-    if err != nil { return "", err }
-    defer cli.Close()
-    if err := cli.writeJSON(map[string]any{"action": "get_leader", "shard": shard}); err != nil { return "", err }
-    var resp struct{ Addr string `json:"addr"`; Error string `json:"error,omitempty"` }
-    if err := cli.readJSON(&resp); err != nil { return "", err }
-    if resp.Error != "" { return "", errors.New(resp.Error) }
-    return resp.Addr, nil
+	cli, err := newShardClient(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "get_leader", "shard": shard}); err != nil {
+		return "", err
+	}
+	var resp struct {
+		Addr  string `json:"addr"`
+		Error string `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return "", err
+	}
+	if resp.Error != "" {
+		return "", errors.New(resp.Error)
+	}
+	return resp.Addr, nil
 }
 
 func setLeaderRPC(ctx context.Context, shard uint16, addr string) error {
-    cli, err := newShardClient(ctx)
-    if err != nil { return err }
-    defer cli.Close()
-    return cli.writeJSON(map[string]any{"action": "set_leader", "shard": shard, "addr": addr})
+	cli, err := newShardClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	return cli.writeJSON(map[string]any{"action": "set_leader", "shard": shard, "addr": addr})
 }
 
 func mapRPC(ctx context.Context) (map[string]string, error) {
-    cli, err := newShardClient(ctx)
-    if err != nil { return nil, err }
-    defer cli.Close()
-    if err := cli.writeJSON(map[string]any{"action": "map"}); err != nil { return nil, err }
-    var resp struct{ Map map[string]string `json:"map"`; Error string `json:"error,omitempty"` }
-    if err := cli.readJSON(&resp); err != nil { return nil, err }
-    if resp.Error != "" { return nil, errors.New(resp.Error) }
-    return resp.Map, nil
+	cli, err := newShardClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "map"}); err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Map   map[string]string `json:"map"`
+		Error string            `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.Map, nil
 }
 
 func submitXSRPC(ctx context.Context, from, to uint16, hash string) error {
-    cli, err := newShardClient(ctx)
-    if err != nil { return err }
-    defer cli.Close()
-    return cli.writeJSON(map[string]any{"action": "submit_xs", "from": from, "to": to, "hash": hash})
+	cli, err := newShardClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	return cli.writeJSON(map[string]any{"action": "submit_xs", "from": from, "to": to, "hash": hash})
 }
 
 func pullRPC(ctx context.Context, shard uint16, limit int) ([]map[string]any, error) {
-    cli, err := newShardClient(ctx)
-    if err != nil { return nil, err }
-    defer cli.Close()
-    if err := cli.writeJSON(map[string]any{"action": "pull", "shard": shard, "limit": limit}); err != nil { return nil, err }
-    var resp struct{ List []map[string]any `json:"list"`; Error string `json:"error,omitempty"` }
-    if err := cli.readJSON(&resp); err != nil { return nil, err }
-    if resp.Error != "" { return nil, errors.New(resp.Error) }
-    return resp.List, nil
+	cli, err := newShardClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "pull", "shard": shard, "limit": limit}); err != nil {
+		return nil, err
+	}
+	var resp struct {
+		List  []map[string]any `json:"list"`
+		Error string           `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.List, nil
 }
 
 func reshardRPC(ctx context.Context, bits uint8) error {
-    cli, err := newShardClient(ctx)
-    if err != nil { return err }
-    defer cli.Close()
-    return cli.writeJSON(map[string]any{"action": "reshard", "bits": bits})
+	cli, err := newShardClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	return cli.writeJSON(map[string]any{"action": "reshard", "bits": bits})
+}
+
+func rebalanceRPC(ctx context.Context, threshold float64) ([]uint16, error) {
+	cli, err := newShardClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "rebalance", "threshold": threshold}); err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Hot   []uint16 `json:"hot"`
+		Error string   `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.Hot, nil
 }
 
 // -----------------------------------------------------------------------------
@@ -134,125 +197,166 @@ func reshardRPC(ctx context.Context, bits uint8) error {
 // -----------------------------------------------------------------------------
 
 var shardCmd = &cobra.Command{
-    Use:     "~shard",
-    Short:   "Shard coordination & cross‑shard ops",
-    Aliases: []string{"shard", "sharding"},
-    PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-        cobra.OnInitialize(initShardConfig)
-        return nil
-    },
+	Use:     "~shard",
+	Short:   "Shard coordination & cross‑shard ops",
+	Aliases: []string{"shard", "sharding"},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		cobra.OnInitialize(initShardConfig)
+		return nil
+	},
 }
 
 // leader get/set ----------------------------------------------------------------
 var leaderCmd = &cobra.Command{
-    Use:   "leader",
-    Short: "Get or set shard leader",
+	Use:   "leader",
+	Short: "Get or set shard leader",
 }
 
 var leaderGetCmd = &cobra.Command{
-    Use:   "get [shardID]",
-    Short: "Show leader for a shard",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        sidU, err := strconv.ParseUint(args[0], 10, 16)
-        if err != nil { return fmt.Errorf("invalid shardID: %w", err) }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
-        defer cancel()
-        addr, err := getLeaderRPC(ctx, uint16(sidU))
-        if err != nil { return err }
-        if addr == "" {
-            fmt.Println("<none>")
-        } else {
-            fmt.Println(addr)
-        }
-        return nil
-    },
+	Use:   "get [shardID]",
+	Short: "Show leader for a shard",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sidU, err := strconv.ParseUint(args[0], 10, 16)
+		if err != nil {
+			return fmt.Errorf("invalid shardID: %w", err)
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
+		defer cancel()
+		addr, err := getLeaderRPC(ctx, uint16(sidU))
+		if err != nil {
+			return err
+		}
+		if addr == "" {
+			fmt.Println("<none>")
+		} else {
+			fmt.Println(addr)
+		}
+		return nil
+	},
 }
 
 var leaderSetCmd = &cobra.Command{
-    Use:   "set [shardID] [addr]",
-    Short: "Set leader for a shard",
-    Args:  cobra.ExactArgs(2),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        sidU, err := strconv.ParseUint(args[0], 10, 16)
-        if err != nil { return fmt.Errorf("invalid shardID: %w", err) }
-        addr := args[1]
-        if _, err := hex.DecodeString(strings.TrimPrefix(addr, "0x")); err != nil {
-            return fmt.Errorf("invalid addr hex: %w", err)
-        }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
-        defer cancel()
-        return setLeaderRPC(ctx, uint16(sidU), addr)
-    },
+	Use:   "set [shardID] [addr]",
+	Short: "Set leader for a shard",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sidU, err := strconv.ParseUint(args[0], 10, 16)
+		if err != nil {
+			return fmt.Errorf("invalid shardID: %w", err)
+		}
+		addr := args[1]
+		if _, err := hex.DecodeString(strings.TrimPrefix(addr, "0x")); err != nil {
+			return fmt.Errorf("invalid addr hex: %w", err)
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
+		defer cancel()
+		return setLeaderRPC(ctx, uint16(sidU), addr)
+	},
 }
 
 // map -------------------------------------------------------------------------
 var mapCmd = &cobra.Command{
-    Use:   "map",
-    Short: "List shard→leader mapping",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        m, err := mapRPC(ctx)
-        if err != nil { return err }
-        for sid, addr := range m {
-            fmt.Printf("%s → %s\n", sid, addr)
-        }
-        return nil
-    },
+	Use:   "map",
+	Short: "List shard→leader mapping",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		m, err := mapRPC(ctx)
+		if err != nil {
+			return err
+		}
+		for sid, addr := range m {
+			fmt.Printf("%s → %s\n", sid, addr)
+		}
+		return nil
+	},
 }
 
 // submit ----------------------------------------------------------------------
 var submitCmd = &cobra.Command{
-    Use:   "submit [fromShard] [toShard] [txHash]",
-    Short: "Submit cross‑shard tx header (manual)",
-    Args:  cobra.ExactArgs(3),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        fromU, err := strconv.ParseUint(args[0], 10, 16)
-        if err != nil { return fmt.Errorf("invalid fromShard: %w", err) }
-        toU, err := strconv.ParseUint(args[1], 10, 16)
-        if err != nil { return fmt.Errorf("invalid toShard: %w", err) }
-        hash := args[2]
-        if _, err := hex.DecodeString(hash); err != nil || len(hash) != 64 {
-            return errors.New("txHash must be 32‑byte hex")
-        }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        return submitXSRPC(ctx, uint16(fromU), uint16(toU), hash)
-    },
+	Use:   "submit [fromShard] [toShard] [txHash]",
+	Short: "Submit cross‑shard tx header (manual)",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fromU, err := strconv.ParseUint(args[0], 10, 16)
+		if err != nil {
+			return fmt.Errorf("invalid fromShard: %w", err)
+		}
+		toU, err := strconv.ParseUint(args[1], 10, 16)
+		if err != nil {
+			return fmt.Errorf("invalid toShard: %w", err)
+		}
+		hash := args[2]
+		if _, err := hex.DecodeString(hash); err != nil || len(hash) != 64 {
+			return errors.New("txHash must be 32‑byte hex")
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		return submitXSRPC(ctx, uint16(fromU), uint16(toU), hash)
+	},
 }
 
 // pull ------------------------------------------------------------------------
 var pullCmd = &cobra.Command{
-    Use:   "pull [shardID]",
-    Short: "Pull pending receipts for our shard",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        limit, _ := cmd.Flags().GetInt("limit")
-        sidU, err := strconv.ParseUint(args[0], 10, 16)
-        if err != nil { return fmt.Errorf("invalid shardID: %w", err) }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        list, err := pullRPC(ctx, uint16(sidU), limit)
-        if err != nil { return err }
-        enc := json.NewEncoder(os.Stdout)
-        enc.SetIndent("", "  ")
-        return enc.Encode(list)
-    },
+	Use:   "pull [shardID]",
+	Short: "Pull pending receipts for our shard",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		limit, _ := cmd.Flags().GetInt("limit")
+		sidU, err := strconv.ParseUint(args[0], 10, 16)
+		if err != nil {
+			return fmt.Errorf("invalid shardID: %w", err)
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		list, err := pullRPC(ctx, uint16(sidU), limit)
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(list)
+	},
 }
 
 // reshard ---------------------------------------------------------------------
 var reshardCmd = &cobra.Command{
-    Use:   "reshard [newBits]",
-    Short: "Double shard count (bits > current, ≤12)",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        bitsU, err := strconv.ParseUint(args[0], 10, 8)
-        if err != nil { return fmt.Errorf("invalid bits: %w", err) }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
-        defer cancel()
-        return reshardRPC(ctx, uint8(bitsU))
-    },
+	Use:   "reshard [newBits]",
+	Short: "Double shard count (bits > current, ≤12)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bitsU, err := strconv.ParseUint(args[0], 10, 8)
+		if err != nil {
+			return fmt.Errorf("invalid bits: %w", err)
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+		defer cancel()
+		return reshardRPC(ctx, uint8(bitsU))
+	},
+}
+
+// rebalance -------------------------------------------------------------------
+var rebalanceCmd = &cobra.Command{
+	Use:   "rebalance [threshold]",
+	Short: "Show shards exceeding the threshold load",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		th, err := strconv.ParseFloat(args[0], 64)
+		if err != nil {
+			return fmt.Errorf("invalid threshold: %w", err)
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		list, err := rebalanceRPC(ctx, th)
+		if err != nil {
+			return err
+		}
+		for _, id := range list {
+			fmt.Println(id)
+		}
+		return nil
+	},
 }
 
 // -----------------------------------------------------------------------------
@@ -260,35 +364,36 @@ var reshardCmd = &cobra.Command{
 // -----------------------------------------------------------------------------
 
 func initShardConfig() {
-    viper.SetEnvPrefix("synnergy")
-    viper.AutomaticEnv()
+	viper.SetEnvPrefix("synnergy")
+	viper.AutomaticEnv()
 
-    cfg := viper.GetString("config")
-    if cfg != "" {
-        viper.SetConfigFile(cfg)
-    } else {
-        viper.SetConfigName("synnergy")
-        viper.AddConfigPath(".")
-        viper.AddConfigPath("$HOME/.config/synnergy")
-    }
-    _ = viper.ReadInConfig()
+	cfg := viper.GetString("config")
+	if cfg != "" {
+		viper.SetConfigFile(cfg)
+	} else {
+		viper.SetConfigName("synnergy")
+		viper.AddConfigPath(".")
+		viper.AddConfigPath("$HOME/.config/synnergy")
+	}
+	_ = viper.ReadInConfig()
 
-    viper.SetDefault("SHARD_API_ADDR", "127.0.0.1:7980")
+	viper.SetDefault("SHARD_API_ADDR", "127.0.0.1:7980")
 }
 
 func init() {
-    // flags
-    pullCmd.Flags().Int("limit", 0, "max receipts (0=all)")
+	// flags
+	pullCmd.Flags().Int("limit", 0, "max receipts (0=all)")
 
-    // sub‑command tree wiring
-    leaderCmd.AddCommand(leaderGetCmd)
-    leaderCmd.AddCommand(leaderSetCmd)
+	// sub‑command tree wiring
+	leaderCmd.AddCommand(leaderGetCmd)
+	leaderCmd.AddCommand(leaderSetCmd)
 
-    shardCmd.AddCommand(leaderCmd)
-    shardCmd.AddCommand(mapCmd)
-    shardCmd.AddCommand(submitCmd)
-    shardCmd.AddCommand(pullCmd)
-    shardCmd.AddCommand(reshardCmd)
+	shardCmd.AddCommand(leaderCmd)
+	shardCmd.AddCommand(mapCmd)
+	shardCmd.AddCommand(submitCmd)
+	shardCmd.AddCommand(pullCmd)
+	shardCmd.AddCommand(reshardCmd)
+	shardCmd.AddCommand(rebalanceCmd)
 }
 
 // NewShardingCommand exposes the consolidated command tree.

--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -479,6 +479,7 @@ type ShardCoordinator struct {
 	net     Broadcaster
 	mu      sync.RWMutex
 	leaders map[ShardID]Address
+	metrics map[ShardID]*ShardMetrics
 }
 
 //---------------------------------------------------------------------

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -50,17 +50,15 @@ var gasTable = map[Opcode]uint64{
 	ReleaseEscrow:  12_000,
 	PredictVolume:  15_000,
 
-
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker
 	// ----------------------------------------------------------------------
-	SwapExactIn:    4_500,
-	AddLiquidity:   5_000,
-	RemoveLiquidity:5_000,
-  Quote:          2_500,
-  AllPairs:       2_000,
-  InitPoolsFromFile: 6_000,
-
+	SwapExactIn:       4_500,
+	AddLiquidity:      5_000,
+	RemoveLiquidity:   5_000,
+	Quote:             2_500,
+	AllPairs:          2_000,
+	InitPoolsFromFile: 6_000,
 
 	// ----------------------------------------------------------------------
 	// Authority / Validator-Set
@@ -105,7 +103,6 @@ var gasTable = map[Opcode]uint64{
 	Compliance_AuditTrail: 3_000,
 	Compliance_MonitorTx:  5_000,
 	Compliance_VerifyZKP:  12_000,
-
 
 	// ----------------------------------------------------------------------
 	// Consensus Core
@@ -291,6 +288,9 @@ var gasTable = map[Opcode]uint64{
 	Send:                2_000,
 	PullReceipts:        3_000,
 	Reshard:             30_000,
+	GossipTx:            5_000,
+	RebalanceShards:     8_000,
+	VerticalPartition:   2_000,
 	// Broadcast already priced
 
 	// ----------------------------------------------------------------------

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -135,9 +135,9 @@ var catalogue = []struct {
 	{"SwapExactIn", 0x020001},
 	{"AMM_AddLiquidity", 0x020002},
 	{"AMM_RemoveLiquidity", 0x020003},
-        {"Quote", 0x020004},
-        {"AllPairs", 0x020005},
-        {"InitPoolsFromFile", 0x020006},
+	{"Quote", 0x020004},
+	{"AllPairs", 0x020005},
+	{"InitPoolsFromFile", 0x020006},
 
 	// Authority (0x03)
 	{"NewAuthoritySet", 0x030001},
@@ -341,6 +341,9 @@ var catalogue = []struct {
 	{"Send", 0x150006},
 	{"PullReceipts", 0x150007},
 	{"Reshard", 0x150008},
+	{"GossipTx", 0x150009},
+	{"RebalanceShards", 0x15000A},
+	{"VerticalPartition", 0x15000B},
 
 	// Sidechains (0x16)
 	{"InitSidechains", 0x160001},

--- a/synnergy-network/core/sharding.go
+++ b/synnergy-network/core/sharding.go
@@ -19,13 +19,18 @@ package core
 // -----------------------------------------------------------------------------
 
 import (
-    "crypto/sha256"
-    "encoding/binary"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "encoding/gob"
-
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/gob"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"sync"
+	"time"
 )
 
 //---------------------------------------------------------------------
@@ -33,9 +38,9 @@ import (
 //---------------------------------------------------------------------
 
 const (
-    ShardBits        = 10                     // => 1024 shards
-    NumShards        = 1 << ShardBits
-    ReshardEpochSize = 200_000               // blocks per reshard window
+	ShardBits        = 10 // => 1024 shards
+	NumShards        = 1 << ShardBits
+	ReshardEpochSize = 200_000 // blocks per reshard window
 )
 
 //---------------------------------------------------------------------
@@ -45,67 +50,184 @@ const (
 type ShardID uint16
 
 func shardOfAddr(addr Address) ShardID {
-    h := sha256.Sum256(addr.Bytes())
-    idx := binary.BigEndian.Uint16(h[:2])
-    return ShardID(idx >> (16 - ShardBits))
+	h := sha256.Sum256(addr.Bytes())
+	idx := binary.BigEndian.Uint16(h[:2])
+	return ShardID(idx >> (16 - ShardBits))
 }
 
 func (a Address) Bytes() []byte {
-    return a[:]
+	return a[:]
 }
 
+// ShardMetrics tracks runtime load statistics used by the load balancer.
+type ShardMetrics struct {
+	TxCount     int64
+	CPUUsage    float64
+	MemoryUsage float64
+	history     []float64
+}
+
+// shardManager provides load distribution algorithms and dynamic rebalancing.
+type shardManager struct {
+	mu      sync.RWMutex
+	metrics map[ShardID]*ShardMetrics
+	rrIndex int
+}
+
+func newShardManager() *shardManager {
+	return &shardManager{metrics: make(map[ShardID]*ShardMetrics)}
+}
+
+// recordLoad updates metrics for a shard. The load parameter should be a value
+// between 0 and 1 representing relative utilisation.
+func (sm *shardManager) recordLoad(id ShardID, load float64) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	m, ok := sm.metrics[id]
+	if !ok {
+		m = &ShardMetrics{}
+		sm.metrics[id] = m
+	}
+	m.history = append(m.history, load)
+	if len(m.history) > 100 {
+		m.history = m.history[len(m.history)-100:]
+	}
+	m.CPUUsage = load
+}
+
+// roundRobin picks the next shardID in cyclic order for simple scheduling.
+func (sm *shardManager) roundRobin(ids []ShardID) ShardID {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if len(ids) == 0 {
+		return 0
+	}
+	sm.rrIndex = (sm.rrIndex + 1) % len(ids)
+	return ids[sm.rrIndex]
+}
+
+// weighted selects the shard with the lowest current load.
+func (sm *shardManager) weighted(ids []ShardID) ShardID {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	if len(ids) == 0 {
+		return 0
+	}
+	var bestID ShardID
+	bestLoad := 1.1
+	for _, id := range ids {
+		m := sm.metrics[id]
+		if m == nil {
+			return id
+		}
+		if m.CPUUsage < bestLoad {
+			bestLoad = m.CPUUsage
+			bestID = id
+		}
+	}
+	return bestID
+}
+
+// predictive returns the shard predicted to have the lowest load using a simple
+// moving average over the last recorded samples.
+func (sm *shardManager) predictive(ids []ShardID, window int) ShardID {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	if len(ids) == 0 {
+		return 0
+	}
+	if window <= 0 {
+		window = 1
+	}
+	var bestID ShardID
+	bestLoad := 1.1
+	for _, id := range ids {
+		m := sm.metrics[id]
+		if m == nil || len(m.history) == 0 {
+			return id
+		}
+		n := window
+		if len(m.history) < n {
+			n = len(m.history)
+		}
+		var sum float64
+		for i := len(m.history) - n; i < len(m.history); i++ {
+			sum += m.history[i]
+		}
+		avg := sum / float64(n)
+		if avg < bestLoad {
+			bestLoad = avg
+			bestID = id
+		}
+	}
+	return bestID
+}
 
 //---------------------------------------------------------------------
 // Coordinator
 //---------------------------------------------------------------------
 
-
 func NewShardCoordinator(led StateRW, net Broadcaster) *ShardCoordinator {
-    return &ShardCoordinator{led: led, net: net, leaders: make(map[ShardID]Address)}
+	return &ShardCoordinator{
+		led:     led,
+		net:     net,
+		leaders: make(map[ShardID]Address),
+		metrics: make(map[ShardID]*ShardMetrics),
+	}
 }
 
 //---------------------------------------------------------------------
 // Leader management (simplified round‑robin per epoch)
 //---------------------------------------------------------------------
 
-func (sc *ShardCoordinator) SetLeader(id ShardID, addr Address) { sc.mu.Lock(); sc.leaders[id] = addr; sc.mu.Unlock() }
-func (sc *ShardCoordinator) Leader(id ShardID) Address         { sc.mu.RLock(); defer sc.mu.RUnlock(); return sc.leaders[id] }
+func (sc *ShardCoordinator) SetLeader(id ShardID, addr Address) {
+	sc.mu.Lock()
+	sc.leaders[id] = addr
+	sc.mu.Unlock()
+}
+func (sc *ShardCoordinator) Leader(id ShardID) Address {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return sc.leaders[id]
+}
 
 //---------------------------------------------------------------------
 // SubmitCrossShard – called by executor when Tx crosses shard boundary.
 //---------------------------------------------------------------------
 
 func (sc *ShardCoordinator) SubmitCrossShard(tx CrossShardTx) error {
-    if tx.FromShard == tx.ToShard { return errors.New("same shard") }
-    blob, _ := json.Marshal(tx)
-    key := xsPendingKey(tx.ToShard, tx.Hash)
-    sc.led.SetState(key, blob)
-    // gossip header to destination leader
-    return sc.net.Broadcast("xs_receipt", blob)
+	if tx.FromShard == tx.ToShard {
+		return errors.New("same shard")
+	}
+	blob, _ := json.Marshal(tx)
+	key := xsPendingKey(tx.ToShard, tx.Hash)
+	sc.led.SetState(key, blob)
+	// gossip header to destination leader
+	return sc.net.Broadcast("xs_receipt", blob)
 }
 
 func (b *Broadcaster) Broadcast(topic string, msg interface{}) error {
-    for _, peer := range b.peers {
-        if err := peer.Send(topic, msg); err != nil {
-            return err
-        }
-    }
-    return nil
+	for _, peer := range b.peers {
+		if err := peer.Send(topic, msg); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type Broadcaster struct {
-    peers []Peer
+	peers []Peer
 }
 
 func (p *Peer) Send(topic string, msg interface{}) error {
-    encoder := gob.NewEncoder(p.Conn)
-    if err := encoder.Encode(topic); err != nil {
-        return fmt.Errorf("send topic failed: %w", err)
-    }
-    if err := encoder.Encode(msg); err != nil {
-        return fmt.Errorf("send message failed: %w", err)
-    }
-    return nil
+	encoder := gob.NewEncoder(p.Conn)
+	if err := encoder.Encode(topic); err != nil {
+		return fmt.Errorf("send topic failed: %w", err)
+	}
+	if err := encoder.Encode(msg); err != nil {
+		return fmt.Errorf("send message failed: %w", err)
+	}
+	return nil
 }
 
 //---------------------------------------------------------------------
@@ -113,14 +235,15 @@ func (p *Peer) Send(topic string, msg interface{}) error {
 //---------------------------------------------------------------------
 
 func (sc *ShardCoordinator) PullReceipts(self ShardID, limit int) ([]CrossShardTx, error) {
-    iter := sc.led.PrefixIterator([]byte(fmt.Sprintf("xs:pending:%d:", self)))
-    var out []CrossShardTx
-    for iter.Next() && (limit==0 || len(out)<limit) {
-        var tx CrossShardTx; _ = json.Unmarshal(iter.Value(), &tx)
-        out = append(out, tx)
-        sc.led.DeleteState(iter.Key())
-    }
-    return out, nil
+	iter := sc.led.PrefixIterator([]byte(fmt.Sprintf("xs:pending:%d:", self)))
+	var out []CrossShardTx
+	for iter.Next() && (limit == 0 || len(out) < limit) {
+		var tx CrossShardTx
+		_ = json.Unmarshal(iter.Value(), &tx)
+		out = append(out, tx)
+		sc.led.DeleteState(iter.Key())
+	}
+	return out, nil
 }
 
 //---------------------------------------------------------------------
@@ -128,23 +251,26 @@ func (sc *ShardCoordinator) PullReceipts(self ShardID, limit int) ([]CrossShardT
 //---------------------------------------------------------------------
 
 func (sc *ShardCoordinator) Reshard(newBits uint8) error {
-    if newBits <= ShardBits || newBits > 12 { return errors.New("invalid bits") }
-    // iterate over all accounts and copy to new shard‑prefixed bucket
-    it := sc.led.PrefixIterator([]byte("acct:"))
-    for it.Next() {
-        addrBytes := it.Key()[5:25] // skip prefix
-        var addr Address; copy(addr[:], addrBytes)
-        newShard := shardOfAddrNewBits(addr, newBits)
-        newKey := append([]byte(fmt.Sprintf("%d:" , newShard)), addrBytes...)
-        sc.led.SetState(append([]byte("acct2:"), newKey...), it.Value())
-    }
-    return nil
+	if newBits <= ShardBits || newBits > 12 {
+		return errors.New("invalid bits")
+	}
+	// iterate over all accounts and copy to new shard‑prefixed bucket
+	it := sc.led.PrefixIterator([]byte("acct:"))
+	for it.Next() {
+		addrBytes := it.Key()[5:25] // skip prefix
+		var addr Address
+		copy(addr[:], addrBytes)
+		newShard := shardOfAddrNewBits(addr, newBits)
+		newKey := append([]byte(fmt.Sprintf("%d:", newShard)), addrBytes...)
+		sc.led.SetState(append([]byte("acct2:"), newKey...), it.Value())
+	}
+	return nil
 }
 
 func shardOfAddrNewBits(addr Address, bits uint8) ShardID {
-    h := sha256.Sum256(addr.Bytes())
-    idx := binary.BigEndian.Uint16(h[:2])
-    return ShardID(idx >> (16 - bits))
+	h := sha256.Sum256(addr.Bytes())
+	idx := binary.BigEndian.Uint16(h[:2])
+	return ShardID(idx >> (16 - bits))
 }
 
 //---------------------------------------------------------------------
@@ -152,7 +278,119 @@ func shardOfAddrNewBits(addr Address, bits uint8) ShardID {
 //---------------------------------------------------------------------
 
 func xsPendingKey(to ShardID, h Hash) []byte {
-    return append([]byte(fmt.Sprintf("xs:pending:%d:", to)), h[:]...)
+	return append([]byte(fmt.Sprintf("xs:pending:%d:", to)), h[:]...)
+}
+
+// VerticalPartition extracts selected columns from a key/value map. Missing
+// columns are ignored. It is used when only specific attributes of a record are
+// required.
+func VerticalPartition(data map[string][]byte, cols []string) map[string][]byte {
+	out := make(map[string][]byte, len(cols))
+	for _, c := range cols {
+		if v, ok := data[c]; ok {
+			out[c] = append([]byte(nil), v...)
+		}
+	}
+	return out
+}
+
+// compressBlock applies gzip compression to arbitrary byte slices. It returns
+// the compressed form or an error if compression failed.
+func compressBlock(in []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(in); err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// decompressBlock reverses compressBlock.
+func decompressBlock(in []byte) ([]byte, error) {
+	zr, err := gzip.NewReader(bytes.NewReader(in))
+	if err != nil {
+		return nil, err
+	}
+	defer zr.Close()
+	var out bytes.Buffer
+	if _, err := io.Copy(&out, zr); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+// GossipTx broadcasts a cross-shard transaction to all known peers.
+func (sc *ShardCoordinator) GossipTx(tx CrossShardTx) error {
+	blob, err := json.Marshal(tx)
+	if err != nil {
+		return err
+	}
+	return sc.net.Broadcast("xs_tx", blob)
+}
+
+// mergeShards combines the metrics of two shards and assigns the leader of the
+// secondary shard to the primary. It does not modify ledger state but is used by
+// dynamic shard management logic.
+func (sc *ShardCoordinator) mergeShards(primary, secondary ShardID) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	if m, ok := sc.metrics[secondary]; ok {
+		if base, ok2 := sc.metrics[primary]; ok2 {
+			base.TxCount += m.TxCount
+			base.CPUUsage = (base.CPUUsage + m.CPUUsage) / 2
+			base.MemoryUsage = (base.MemoryUsage + m.MemoryUsage) / 2
+		}
+		delete(sc.metrics, secondary)
+	}
+	if addr, ok := sc.leaders[secondary]; ok {
+		sc.leaders[primary] = addr
+		delete(sc.leaders, secondary)
+	}
+}
+
+// splitShard creates a new shard ID and moves half the metrics to it. Ledger
+// state migration must be handled separately.
+func (sc *ShardCoordinator) splitShard(id ShardID, newID ShardID) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	if m, ok := sc.metrics[id]; ok {
+		half := m.TxCount / 2
+		m.TxCount -= half
+		sc.metrics[newID] = &ShardMetrics{TxCount: half, CPUUsage: m.CPUUsage, MemoryUsage: m.MemoryUsage}
+	} else {
+		sc.metrics[newID] = &ShardMetrics{}
+	}
+	if leader, ok := sc.leaders[id]; ok {
+		sc.leaders[newID] = leader
+	}
+}
+
+// rebalance analyses the current metrics and flags shards that exceed the
+// specified threshold over the average load. The caller can then decide how to
+// migrate data. It returns the list of hot shards.
+// RebalanceShards analyses the current metrics and returns IDs that exceed the
+// provided threshold relative to the average load.
+func (sc *ShardCoordinator) RebalanceShards(threshold float64) []ShardID {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	if len(sc.metrics) == 0 {
+		return nil
+	}
+	var total float64
+	for _, m := range sc.metrics {
+		total += m.CPUUsage
+	}
+	avg := total / float64(len(sc.metrics))
+	var hot []ShardID
+	for id, m := range sc.metrics {
+		if m.CPUUsage > avg*threshold {
+			hot = append(hot, id)
+		}
+	}
+	return hot
 }
 
 //---------------------------------------------------------------------

--- a/synnergy-network/tests/sharding_test.go
+++ b/synnergy-network/tests/sharding_test.go
@@ -1,66 +1,111 @@
 package core
 
 import (
-    "bytes"
-    "encoding/json"
-    "fmt"
-    "sync"
-    "testing"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
 )
 
 //------------------------------------------------------------
 // Minimal in‑memory StateRW mock for sharding tests
 //------------------------------------------------------------
 
-type shardMem struct { mu sync.RWMutex; kv map[string][]byte }
+type shardMem struct {
+	mu sync.RWMutex
+	kv map[string][]byte
+}
 
 func newShardMem() *shardMem { return &shardMem{kv: make(map[string][]byte)} }
 
-func (s *shardMem) SetState(k,v []byte) error { s.mu.Lock(); s.kv[string(k)] = append([]byte(nil), v...); s.mu.Unlock(); return nil }
-func (s *shardMem) GetState(k []byte) ([]byte,error){ s.mu.RLock(); defer s.mu.RUnlock(); return s.kv[string(k)], nil }
-func (s *shardMem) DeleteState(k []byte) error { s.mu.Lock(); delete(s.kv,string(k)); s.mu.Unlock(); return nil }
-func (s *shardMem) Snapshot(fn func() error) error { return fn() }
-func (s *shardMem) Transfer(from,to Address,amt uint64) error { return nil }
-func (s *shardMem) PrefixIterator(prefix []byte) StateIterator {
-    s.mu.RLock(); defer s.mu.RUnlock()
-    var keys, vals [][]byte
-    for k,v := range s.kv {
-        if bytes.HasPrefix([]byte(k), prefix) {
-            keys = append(keys, []byte(k)); vals = append(vals, v)
-        }
-    }
-    return &smIter{keys: keys, vals: vals, idx: -1}
+func (s *shardMem) SetState(k, v []byte) error {
+	s.mu.Lock()
+	s.kv[string(k)] = append([]byte(nil), v...)
+	s.mu.Unlock()
+	return nil
 }
-func (s *shardMem) HasState(k []byte) (bool,error){ s.mu.RLock(); defer s.mu.RUnlock(); _,ok:=s.kv[string(k)]; return ok,nil }
-func (s *shardMem) Burn(Address,uint64) error { return nil }
-func (s *shardMem) BurnLP(Address,PoolID,uint64) error { return nil }
-func (s *shardMem) MintLP(Address,PoolID,uint64) error { return nil }
-func (s *shardMem) Mint(Address,uint64) error { return nil }
-func (s *shardMem) MintToken(Address,string,uint64) error { return nil }
-func (s *shardMem) DeductGas(Address,uint64){}
-func (s *shardMem) EmitApproval(TokenID,Address,Address,uint64){}
-func (s *shardMem) EmitTransfer(TokenID,Address,Address,uint64){}
-func (s *shardMem) BalanceOf(Address) uint64 { return 0 }
-func (s *shardMem) WithinBlock(fn func() error) error { return fn() }
-func (s *shardMem) NonceOf(Address) uint64 { return 0 }
+func (s *shardMem) GetState(k []byte) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.kv[string(k)], nil
+}
+func (s *shardMem) DeleteState(k []byte) error {
+	s.mu.Lock()
+	delete(s.kv, string(k))
+	s.mu.Unlock()
+	return nil
+}
+func (s *shardMem) Snapshot(fn func() error) error              { return fn() }
+func (s *shardMem) Transfer(from, to Address, amt uint64) error { return nil }
+func (s *shardMem) PrefixIterator(prefix []byte) StateIterator {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var keys, vals [][]byte
+	for k, v := range s.kv {
+		if bytes.HasPrefix([]byte(k), prefix) {
+			keys = append(keys, []byte(k))
+			vals = append(vals, v)
+		}
+	}
+	return &smIter{keys: keys, vals: vals, idx: -1}
+}
+func (s *shardMem) HasState(k []byte) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.kv[string(k)]
+	return ok, nil
+}
+func (s *shardMem) Burn(Address, uint64) error                     { return nil }
+func (s *shardMem) BurnLP(Address, PoolID, uint64) error           { return nil }
+func (s *shardMem) MintLP(Address, PoolID, uint64) error           { return nil }
+func (s *shardMem) Mint(Address, uint64) error                     { return nil }
+func (s *shardMem) MintToken(Address, string, uint64) error        { return nil }
+func (s *shardMem) DeductGas(Address, uint64)                      {}
+func (s *shardMem) EmitApproval(TokenID, Address, Address, uint64) {}
+func (s *shardMem) EmitTransfer(TokenID, Address, Address, uint64) {}
+func (s *shardMem) BalanceOf(Address) uint64                       { return 0 }
+func (s *shardMem) WithinBlock(fn func() error) error              { return fn() }
+func (s *shardMem) NonceOf(Address) uint64                         { return 0 }
 
 // iterator impl
 
-type smIter struct { keys [][]byte; vals [][]byte; idx int }
+type smIter struct {
+	keys [][]byte
+	vals [][]byte
+	idx  int
+}
+
 func (it *smIter) Next() bool { it.idx++; return it.idx < len(it.keys) }
-func (it *smIter) Key() []byte { if it.idx>=0 && it.idx<len(it.keys){ return it.keys[it.idx]} ; return nil }
-func (it *smIter) Value() []byte { if it.idx>=0 && it.idx<len(it.vals){ return it.vals[it.idx]} ; return nil }
+func (it *smIter) Key() []byte {
+	if it.idx >= 0 && it.idx < len(it.keys) {
+		return it.keys[it.idx]
+	}
+	return nil
+}
+func (it *smIter) Value() []byte {
+	if it.idx >= 0 && it.idx < len(it.vals) {
+		return it.vals[it.idx]
+	}
+	return nil
+}
 func (it *smIter) Error() error { return nil }
 
 //------------------------------------------------------------
 // Dummy Broadcaster (no network) that counts messages
 //------------------------------------------------------------
 
-type stubBC struct { cnt int; last []byte }
+type stubBC struct {
+	cnt  int
+	last []byte
+}
+
 func (b *stubBC) Broadcast(topic string, msg interface{}) error {
-    b.cnt++
-    if raw, ok := msg.([]byte); ok { b.last = raw }
-    return nil
+	b.cnt++
+	if raw, ok := msg.([]byte); ok {
+		b.last = raw
+	}
+	return nil
 }
 
 //------------------------------------------------------------
@@ -68,77 +113,128 @@ func (b *stubBC) Broadcast(topic string, msg interface{}) error {
 //------------------------------------------------------------
 
 type CrossShardTx struct {
-    FromShard ShardID `json:"from"`
-    ToShard   ShardID `json:"to"`
-    Hash      Hash    `json:"hash"`
+	FromShard ShardID `json:"from"`
+	ToShard   ShardID `json:"to"`
+	Hash      Hash    `json:"hash"`
 }
 
 //------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------
 
-func addrWithByte(b byte) Address { var a Address; for i:=0;i<20;i++{ a[i]=b }; return a }
+func addrWithByte(b byte) Address {
+	var a Address
+	for i := 0; i < 20; i++ {
+		a[i] = b
+	}
+	return a
+}
 
 //------------------------------------------------------------
 // Tests
 //------------------------------------------------------------
 
-func TestShardOfAddr_Deterministic(t *testing.T){
-    a := addrWithByte(0xAA)
-    id1 := shardOfAddr(a)
-    id2 := shardOfAddr(a)
-    if id1 != id2 { t.Fatalf("non‑deterministic shard mapping") }
+func TestShardOfAddr_Deterministic(t *testing.T) {
+	a := addrWithByte(0xAA)
+	id1 := shardOfAddr(a)
+	id2 := shardOfAddr(a)
+	if id1 != id2 {
+		t.Fatalf("non‑deterministic shard mapping")
+	}
 }
 
-func TestSubmitCrossShard_And_Pull(t *testing.T){
-    led := newShardMem()
-    bc := stubBC{}
-    sc := NewShardCoordinator(led, Broadcaster{}) // use empty broadcaster – we will call stub manually
-    // override internal broadcaster with stub using reflection-hack (since field exported). simpler: create coordinator then assign
-    sc.net = Broadcaster{} // zero peers, Broadcast returns nil
-    fromAddr := addrWithByte(0x01)
-    toAddr := addrWithByte(0x02)
-    fromShard := shardOfAddr(fromAddr)
-    toShard := shardOfAddr(toAddr)
-    if fromShard == toShard { t.Skip("generated same shard; rerun") }
+func TestSubmitCrossShard_And_Pull(t *testing.T) {
+	led := newShardMem()
+	bc := stubBC{}
+	sc := NewShardCoordinator(led, Broadcaster{}) // use empty broadcaster – we will call stub manually
+	// override internal broadcaster with stub using reflection-hack (since field exported). simpler: create coordinator then assign
+	sc.net = Broadcaster{} // zero peers, Broadcast returns nil
+	fromAddr := addrWithByte(0x01)
+	toAddr := addrWithByte(0x02)
+	fromShard := shardOfAddr(fromAddr)
+	toShard := shardOfAddr(toAddr)
+	if fromShard == toShard {
+		t.Skip("generated same shard; rerun")
+	}
 
-    var h Hash; for i:=0;i<32;i++{ h[i]=0xFF }
+	var h Hash
+	for i := 0; i < 32; i++ {
+		h[i] = 0xFF
+	}
 
-    tx := CrossShardTx{FromShard: fromShard, ToShard: toShard, Hash: h}
+	tx := CrossShardTx{FromShard: fromShard, ToShard: toShard, Hash: h}
 
-    // same‑shard error
-    bad := CrossShardTx{FromShard: fromShard, ToShard: fromShard, Hash: h}
-    if err := sc.SubmitCrossShard(bad); err==nil { t.Fatalf("expected same‑shard error") }
+	// same‑shard error
+	bad := CrossShardTx{FromShard: fromShard, ToShard: fromShard, Hash: h}
+	if err := sc.SubmitCrossShard(bad); err == nil {
+		t.Fatalf("expected same‑shard error")
+	}
 
-    if err := sc.SubmitCrossShard(tx); err!=nil { t.Fatalf("submit xs err %v",err) }
-    key := xsPendingKey(toShard, h)
-    if ok,_ := led.HasState(key); !ok { t.Fatalf("pending receipt not stored") }
+	if err := sc.SubmitCrossShard(tx); err != nil {
+		t.Fatalf("submit xs err %v", err)
+	}
+	key := xsPendingKey(toShard, h)
+	if ok, _ := led.HasState(key); !ok {
+		t.Fatalf("pending receipt not stored")
+	}
 
-    recs, err := sc.PullReceipts(toShard, 10)
-    if err != nil { t.Fatalf("pull err %v",err) }
-    if len(recs)!=1 { t.Fatalf("pull len %d", len(recs)) }
-    if ok,_ := led.HasState(key); ok { t.Fatalf("receipt key should be deleted after pull") }
+	recs, err := sc.PullReceipts(toShard, 10)
+	if err != nil {
+		t.Fatalf("pull err %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("pull len %d", len(recs))
+	}
+	if ok, _ := led.HasState(key); ok {
+		t.Fatalf("receipt key should be deleted after pull")
+	}
 }
 
-func TestReshard(t *testing.T){
-    led := newShardMem()
-    sc := NewShardCoordinator(led, Broadcaster{})
+func TestReshard(t *testing.T) {
+	led := newShardMem()
+	sc := NewShardCoordinator(led, Broadcaster{})
 
-    // create dummy account state
-    acc := addrWithByte(0xAB)
-    key := append([]byte("acct:"), acc[:]...)
-    led.SetState(key, []byte("balance"))
+	// create dummy account state
+	acc := addrWithByte(0xAB)
+	key := append([]byte("acct:"), acc[:]...)
+	led.SetState(key, []byte("balance"))
 
-    // invalid bits cases
-    if err := sc.Reshard(ShardBits); err==nil { t.Fatalf("expect error when newBits<=ShardBits") }
-    if err := sc.Reshard(13); err==nil { t.Fatalf("expect error when newBits>12") }
+	// invalid bits cases
+	if err := sc.Reshard(ShardBits); err == nil {
+		t.Fatalf("expect error when newBits<=ShardBits")
+	}
+	if err := sc.Reshard(13); err == nil {
+		t.Fatalf("expect error when newBits>12")
+	}
 
-    // valid reshard
-    newBits := uint8(ShardBits+1)
-    if err := sc.Reshard(newBits); err!=nil { t.Fatalf("reshard err %v",err) }
+	// valid reshard
+	newBits := uint8(ShardBits + 1)
+	if err := sc.Reshard(newBits); err != nil {
+		t.Fatalf("reshard err %v", err)
+	}
 
-    newShard := shardOfAddrNewBits(acc, newBits)
-    expKey := append([]byte("acct2:"), []byte(fmt.Sprintf("%d:", newShard))...)
-    expKey = append(expKey, acc[:]...)
-    if ok,_ := led.HasState(expKey); !ok { t.Fatalf("reshard did not copy state to new key") }
+	newShard := shardOfAddrNewBits(acc, newBits)
+	expKey := append([]byte("acct2:"), []byte(fmt.Sprintf("%d:", newShard))...)
+	expKey = append(expKey, acc[:]...)
+	if ok, _ := led.HasState(expKey); !ok {
+		t.Fatalf("reshard did not copy state to new key")
+	}
+}
+
+func TestVerticalPartition(t *testing.T) {
+	data := map[string][]byte{"a": []byte{1}, "b": []byte{2}, "c": []byte{3}}
+	res := VerticalPartition(data, []string{"a", "c"})
+	if len(res) != 2 || res["a"][0] != 1 || res["c"][0] != 3 {
+		t.Fatalf("partition result unexpected: %#v", res)
+	}
+}
+
+func TestRebalanceShards(t *testing.T) {
+	sc := NewShardCoordinator(newShardMem(), Broadcaster{})
+	sc.metrics[1] = &ShardMetrics{CPUUsage: 0.9}
+	sc.metrics[2] = &ShardMetrics{CPUUsage: 0.1}
+	hot := sc.RebalanceShards(1.2)
+	if len(hot) != 1 || hot[0] != 1 {
+		t.Fatalf("unexpected hot shards: %v", hot)
+	}
 }


### PR DESCRIPTION
## Summary
- expand sharding module with load metrics, round‑robin/weighted/predictive load balancing
- add compression helpers and vertical partitioning
- introduce gossip and rebalance helpers to ShardCoordinator
- expose rebalance command in CLI
- wire new opcodes and gas schedule entries
- update unit tests for new functionality

## Testing
- `go test ./...` *(fails: missing go.sum entries / module fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688ade9c24108320b2875682bf86ab26