### PR TITLE
Implement wallet seed accessor

### DIFF
--- a/synnergy-network/cmd/cli/authority_node.go
+++ b/synnergy-network/cmd/cli/authority_node.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	core "github.com/synnergy-network/core" // adjust to your go.mod root
+        core "synnergy-network/core" // module local import
 )
 
 

--- a/synnergy-network/cmd/cli/compliance.go
+++ b/synnergy-network/cmd/cli/compliance.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	core "github.com/synnergy-network/core" // update if go.mod root differs
+        core "synnergy-network/core" // module local import
 
 
 //---------------------------------------------------------------------

--- a/synnergy-network/core/wallet.go
+++ b/synnergy-network/core/wallet.go
@@ -58,6 +58,14 @@ var globalLogger = log.New()
 //
 // This keeps derivation simple (ed25519 does not support unhardened children).
 
+// Seed returns a copy of the wallet's master seed. Callers should securely wipe
+// the returned slice after use.
+func (w *HDWallet) Seed() []byte {
+    out := make([]byte, len(w.seed))
+    copy(out, w.seed)
+    return out
+}
+
 
 
 //---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `Seed()` method to HDWallet for retrieving a copy of the seed
- adjust CLI packages to use local module imports

## Testing
- `go vet ./...` *(fails: go mod tidy required)*
- `go test ./...` *(fails: go mod tidy required)*

------
https://chatgpt.com/codex/tasks/task_e_688ae2f0eae0832084193c2712587247