### PR TITLE
Enhance sidechain module with query APIs

### DIFF
--- a/synnergy-network/cmd/cli/sidechain.go
+++ b/synnergy-network/cmd/cli/sidechain.go
@@ -19,20 +19,20 @@
 package cli
 
 import (
-    "bufio"
-    "context"
-    "encoding/hex"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "net"
-    "os"
-    "strconv"
-    "strings"
-    "time"
+	"bufio"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
 
-    "github.com/spf13/cobra"
-    "github.com/spf13/viper"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // -----------------------------------------------------------------------------
@@ -40,32 +40,38 @@ import (
 // -----------------------------------------------------------------------------
 
 type scClient struct {
-    conn net.Conn
-    rd   *bufio.Reader
+	conn net.Conn
+	rd   *bufio.Reader
 }
 
 func newSCClient(ctx context.Context) (*scClient, error) {
-    addr := viper.GetString("SIDECHAIN_API_ADDR")
-    if addr == "" { addr = "127.0.0.1:7990" }
-    d := net.Dialer{}
-    conn, err := d.DialContext(ctx, "tcp", addr)
-    if err != nil { return nil, fmt.Errorf("cannot connect to sidechain daemon at %s: %w", addr, err) }
-    return &scClient{conn: conn, rd: bufio.NewReader(conn)}, nil
+	addr := viper.GetString("SIDECHAIN_API_ADDR")
+	if addr == "" {
+		addr = "127.0.0.1:7990"
+	}
+	d := net.Dialer{}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to sidechain daemon at %s: %w", addr, err)
+	}
+	return &scClient{conn: conn, rd: bufio.NewReader(conn)}, nil
 }
 
 func (c *scClient) Close() { _ = c.conn.Close() }
 
 func (c *scClient) writeJSON(v any) error {
-    b, err := json.Marshal(v)
-    if err != nil { return err }
-    b = append(b, '\n')
-    _, err = c.conn.Write(b)
-    return err
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	_, err = c.conn.Write(b)
+	return err
 }
 
 func (c *scClient) readJSON(v any) error {
-    dec := json.NewDecoder(c.rd)
-    return dec.Decode(v)
+	dec := json.NewDecoder(c.rd)
+	return dec.Decode(v)
 }
 
 // -----------------------------------------------------------------------------
@@ -73,57 +79,118 @@ func (c *scClient) readJSON(v any) error {
 // -----------------------------------------------------------------------------
 
 func registerRPC(ctx context.Context, id uint32, name string, threshold uint8, vals []string) error {
-    cli, err := newSCClient(ctx)
-    if err != nil { return err }
-    defer cli.Close()
-    return cli.writeJSON(map[string]any{"action": "register", "id": id, "name": name, "threshold": threshold, "validators": vals})
+	cli, err := newSCClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	return cli.writeJSON(map[string]any{"action": "register", "id": id, "name": name, "threshold": threshold, "validators": vals})
 }
 
 func headerRPC(ctx context.Context, payload map[string]any) error {
-    cli, err := newSCClient(ctx)
-    if err != nil { return err }
-    defer cli.Close()
-    return cli.writeJSON(payload)
+	cli, err := newSCClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	return cli.writeJSON(payload)
+}
+
+func getHeaderRPC(ctx context.Context, chain uint32, height uint64) (map[string]any, error) {
+	cli, err := newSCClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "get_header", "chain": chain, "height": height}); err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Header map[string]any `json:"header"`
+		Error  string         `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.Header, nil
 }
 
 func depositRPC(ctx context.Context, chain uint32, from string, to string, token string, amt uint64) (uint64, error) {
-    cli, err := newSCClient(ctx)
-    if err != nil { return 0, err }
-    defer cli.Close()
-    if err := cli.writeJSON(map[string]any{"action": "deposit", "chain": chain, "from": from, "to": to, "token": token, "amount": amt}); err != nil { return 0, err }
-    var resp struct{ Nonce uint64 `json:"nonce"`; Error string `json:"error,omitempty"` }
-    if err := cli.readJSON(&resp); err != nil { return 0, err }
-    if resp.Error != "" { return 0, errors.New(resp.Error) }
-    return resp.Nonce, nil
+	cli, err := newSCClient(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "deposit", "chain": chain, "from": from, "to": to, "token": token, "amount": amt}); err != nil {
+		return 0, err
+	}
+	var resp struct {
+		Nonce uint64 `json:"nonce"`
+		Error string `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return 0, err
+	}
+	if resp.Error != "" {
+		return 0, errors.New(resp.Error)
+	}
+	return resp.Nonce, nil
 }
 
 func withdrawRPC(ctx context.Context, proofHex string) error {
-    cli, err := newSCClient(ctx)
-    if err != nil { return err }
-    defer cli.Close()
-    return cli.writeJSON(map[string]any{"action": "withdraw", "proof": proofHex})
+	cli, err := newSCClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	return cli.writeJSON(map[string]any{"action": "withdraw", "proof": proofHex})
 }
 
 func metaRPC(ctx context.Context, id uint32) (map[string]any, error) {
-    cli, err := newSCClient(ctx)
-    if err != nil { return nil, err }
-    defer cli.Close()
-    if err := cli.writeJSON(map[string]any{"action": "meta", "id": id}); err != nil { return nil, err }
-    var resp struct{ Meta map[string]any `json:"meta"`; Error string `json:"error,omitempty"` }
-    if err := cli.readJSON(&resp); err != nil { return nil, err }
-    if resp.Error != "" { return nil, errors.New(resp.Error) }
-    return resp.Meta, nil
+	cli, err := newSCClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "meta", "id": id}); err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Meta  map[string]any `json:"meta"`
+		Error string         `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.Meta, nil
 }
 
 func listRPC(ctx context.Context) ([]map[string]any, error) {
-    cli, err := newSCClient(ctx)
-    if err != nil { return nil, err }
-    defer cli.Close()
-    if err := cli.writeJSON(map[string]any{"action": "list"}); err != nil { return nil, err }
-    var resp struct{ List []map[string]any `json:"list"`; Error string `json:"error,omitempty"` }
-    if err := cli.readJSON(&resp); err != nil { return nil, err }
-    if resp.Error != "" { return nil, errors.New(resp.Error) }
-    return resp.List, nil
+	cli, err := newSCClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "list"}); err != nil {
+		return nil, err
+	}
+	var resp struct {
+		List  []map[string]any `json:"list"`
+		Error string           `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.List, nil
 }
 
 // -----------------------------------------------------------------------------
@@ -131,141 +198,184 @@ func listRPC(ctx context.Context) ([]map[string]any, error) {
 // -----------------------------------------------------------------------------
 
 var scCmd = &cobra.Command{
-    Use:     "~sc",
-    Short:   "Side‑chain bridge operations",
-    Aliases: []string{"sc", "sidechain"},
-    PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-        cobra.OnInitialize(initSCConfig)
-        return nil
-    },
+	Use:     "~sc",
+	Short:   "Side‑chain bridge operations",
+	Aliases: []string{"sc", "sidechain"},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		cobra.OnInitialize(initSCConfig)
+		return nil
+	},
 }
 
 // register --------------------------------------------------------------------
 var registerCmd = &cobra.Command{
-    Use:   "register",
-    Short: "Register new side‑chain (governance only)",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        idU, _ := cmd.Flags().GetUint32("id")
-        name, _ := cmd.Flags().GetString("name")
-        thrU, _ := cmd.Flags().GetUint("threshold")
-        valsStr, _ := cmd.Flags().GetString("validators")
-        if name == "" || valsStr == "" { return errors.New("--name and --validators required") }
-        vals := strings.Split(valsStr, ",")
-        for _, v := range vals {
-            if _, err := hex.DecodeString(v); err != nil { return fmt.Errorf("invalid validator pubkey: %w", err) }
-        }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        return registerRPC(ctx, idU, name, uint8(thrU), vals)
-    },
+	Use:   "register",
+	Short: "Register new side‑chain (governance only)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		idU, _ := cmd.Flags().GetUint32("id")
+		name, _ := cmd.Flags().GetString("name")
+		thrU, _ := cmd.Flags().GetUint("threshold")
+		valsStr, _ := cmd.Flags().GetString("validators")
+		if name == "" || valsStr == "" {
+			return errors.New("--name and --validators required")
+		}
+		vals := strings.Split(valsStr, ",")
+		for _, v := range vals {
+			if _, err := hex.DecodeString(v); err != nil {
+				return fmt.Errorf("invalid validator pubkey: %w", err)
+			}
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		return registerRPC(ctx, idU, name, uint8(thrU), vals)
+	},
 }
 
 // header ----------------------------------------------------------------------
 var headerCmd = &cobra.Command{
-    Use:   "header",
-    Short: "Submit side‑chain header (JSON via --file or flags)",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        file, _ := cmd.Flags().GetString("file")
-        var payload map[string]any
-        if file != "" {
-            f, err := os.ReadFile(file)
-            if err != nil { return err }
-            if err := json.Unmarshal(f, &payload); err != nil { return err }
-        } else {
-            // gather required fields via flags
-            chain, _ := cmd.Flags().GetUint32("chain")
-            height, _ := cmd.Flags().GetUint64("height")
-            blockRoot, _ := cmd.Flags().GetString("blockroot")
-            txRoot, _ := cmd.Flags().GetString("txroot")
-            stateRoot, _ := cmd.Flags().GetString("stateroot")
-            sigAgg, _ := cmd.Flags().GetString("sig")
-            for _, fld := range []string{blockRoot, txRoot, stateRoot, sigAgg} {
-                if fld == "" { return errors.New("missing header field") }
-            }
-            payload = map[string]any{
-                "action":     "header",
-                "chain":      chain,
-                "height":     height,
-                "block_root": blockRoot,
-                "tx_root":    txRoot,
-                "state_root": stateRoot,
-                "sig_agg":    sigAgg,
-            }
-        }
-        if payload["action"] == nil { payload["action"] = "header" }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        return headerRPC(ctx, payload)
-    },
+	Use:   "header",
+	Short: "Submit side‑chain header (JSON via --file or flags)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		file, _ := cmd.Flags().GetString("file")
+		var payload map[string]any
+		if file != "" {
+			f, err := os.ReadFile(file)
+			if err != nil {
+				return err
+			}
+			if err := json.Unmarshal(f, &payload); err != nil {
+				return err
+			}
+		} else {
+			// gather required fields via flags
+			chain, _ := cmd.Flags().GetUint32("chain")
+			height, _ := cmd.Flags().GetUint64("height")
+			blockRoot, _ := cmd.Flags().GetString("blockroot")
+			txRoot, _ := cmd.Flags().GetString("txroot")
+			stateRoot, _ := cmd.Flags().GetString("stateroot")
+			sigAgg, _ := cmd.Flags().GetString("sig")
+			for _, fld := range []string{blockRoot, txRoot, stateRoot, sigAgg} {
+				if fld == "" {
+					return errors.New("missing header field")
+				}
+			}
+			payload = map[string]any{
+				"action":     "header",
+				"chain":      chain,
+				"height":     height,
+				"block_root": blockRoot,
+				"tx_root":    txRoot,
+				"state_root": stateRoot,
+				"sig_agg":    sigAgg,
+			}
+		}
+		if payload["action"] == nil {
+			payload["action"] = "header"
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		return headerRPC(ctx, payload)
+	},
 }
 
 // deposit ---------------------------------------------------------------------
 var depositCmd = &cobra.Command{
-    Use:   "deposit",
-    Short: "Deposit tokens to side‑chain escrow",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        chain, _ := cmd.Flags().GetUint32("chain")
-        from, _ := cmd.Flags().GetString("from")
-        to, _ := cmd.Flags().GetString("to")
-        token, _ := cmd.Flags().GetString("token")
-        amtU, _ := cmd.Flags().GetUint64("amount")
-        for _, fld := range []string{from, to, token} {
-            if fld == "" { return errors.New("--from --to --token required") }
-        }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        nonce, err := depositRPC(ctx, chain, from, to, token, amtU)
-        if err != nil { return err }
-        fmt.Printf("deposit nonce: %d\n", nonce)
-        return nil
-    },
+	Use:   "deposit",
+	Short: "Deposit tokens to side‑chain escrow",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		chain, _ := cmd.Flags().GetUint32("chain")
+		from, _ := cmd.Flags().GetString("from")
+		to, _ := cmd.Flags().GetString("to")
+		token, _ := cmd.Flags().GetString("token")
+		amtU, _ := cmd.Flags().GetUint64("amount")
+		for _, fld := range []string{from, to, token} {
+			if fld == "" {
+				return errors.New("--from --to --token required")
+			}
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		nonce, err := depositRPC(ctx, chain, from, to, token, amtU)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("deposit nonce: %d\n", nonce)
+		return nil
+	},
 }
 
 // withdraw --------------------------------------------------------------------
 var withdrawCmd = &cobra.Command{
-    Use:   "withdraw [proofHex]",
-    Short: "Verify L2→L1 withdrawal proof",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        proof := args[0]
-        if _, err := hex.DecodeString(proof); err != nil { return fmt.Errorf("invalid proof hex: %w", err) }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 4*time.Second)
-        defer cancel()
-        return withdrawRPC(ctx, proof)
-    },
+	Use:   "withdraw [proofHex]",
+	Short: "Verify L2→L1 withdrawal proof",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		proof := args[0]
+		if _, err := hex.DecodeString(proof); err != nil {
+			return fmt.Errorf("invalid proof hex: %w", err)
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 4*time.Second)
+		defer cancel()
+		return withdrawRPC(ctx, proof)
+	},
+}
+
+// get-header -----------------------------------------------------------------
+var getHeaderCmd = &cobra.Command{
+	Use:   "get-header",
+	Short: "Fetch a submitted side-chain header",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		chain, _ := cmd.Flags().GetUint32("chain")
+		height, _ := cmd.Flags().GetUint64("height")
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		hdr, err := getHeaderRPC(ctx, chain, height)
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(hdr)
+	},
 }
 
 // meta ------------------------------------------------------------------------
 var metaCmd = &cobra.Command{
-    Use:   "meta [chainID]",
-    Short: "Show side‑chain metadata",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        idU, err := strconv.ParseUint(args[0], 10, 32)
-        if err != nil { return fmt.Errorf("invalid chainID: %w", err) }
-        ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
-        defer cancel()
-        meta, err := metaRPC(ctx, uint32(idU))
-        if err != nil { return err }
-        enc := json.NewEncoder(os.Stdout)
-        enc.SetIndent("", "  ")
-        return enc.Encode(meta)
-    },
+	Use:   "meta [chainID]",
+	Short: "Show side‑chain metadata",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		idU, err := strconv.ParseUint(args[0], 10, 32)
+		if err != nil {
+			return fmt.Errorf("invalid chainID: %w", err)
+		}
+		ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
+		defer cancel()
+		meta, err := metaRPC(ctx, uint32(idU))
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(meta)
+	},
 }
 
 // list ------------------------------------------------------------------------
 var listCmd = &cobra.Command{
-    Use:   "list",
-    Short: "List all registered side‑chains",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        list, err := listRPC(ctx)
-        if err != nil { return err }
-        enc := json.NewEncoder(os.Stdout)
-        enc.SetIndent("", "  ")
-        return enc.Encode(list)
-    },
+	Use:   "list",
+	Short: "List all registered side‑chains",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		list, err := listRPC(ctx)
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(list)
+	},
 }
 
 // -----------------------------------------------------------------------------
@@ -273,50 +383,54 @@ var listCmd = &cobra.Command{
 // -----------------------------------------------------------------------------
 
 func initSCConfig() {
-    viper.SetEnvPrefix("synnergy")
-    viper.AutomaticEnv()
+	viper.SetEnvPrefix("synnergy")
+	viper.AutomaticEnv()
 
-    cfg := viper.GetString("config")
-    if cfg != "" {
-        viper.SetConfigFile(cfg)
-    } else {
-        viper.SetConfigName("synnergy")
-        viper.AddConfigPath(".")
-        viper.AddConfigPath("$HOME/.config/synnergy")
-    }
-    _ = viper.ReadInConfig()
+	cfg := viper.GetString("config")
+	if cfg != "" {
+		viper.SetConfigFile(cfg)
+	} else {
+		viper.SetConfigName("synnergy")
+		viper.AddConfigPath(".")
+		viper.AddConfigPath("$HOME/.config/synnergy")
+	}
+	_ = viper.ReadInConfig()
 
-    viper.SetDefault("SIDECHAIN_API_ADDR", "127.0.0.1:7990")
+	viper.SetDefault("SIDECHAIN_API_ADDR", "127.0.0.1:7990")
 }
 
 func init() {
-    // register flags
-    registerCmd.Flags().Uint32("id", 0, "side‑chain ID")
-    registerCmd.Flags().String("name", "", "human name")
-    registerCmd.Flags().Uint("threshold", 67, "BLS threshold percent")
-    registerCmd.Flags().String("validators", "", "comma‑separated BLS pubkeys hex")
+	// register flags
+	registerCmd.Flags().Uint32("id", 0, "side‑chain ID")
+	registerCmd.Flags().String("name", "", "human name")
+	registerCmd.Flags().Uint("threshold", 67, "BLS threshold percent")
+	registerCmd.Flags().String("validators", "", "comma‑separated BLS pubkeys hex")
 
-    headerCmd.Flags().String("file", "", "path to header JSON file")
-    headerCmd.Flags().Uint32("chain", 0, "chainID")
-    headerCmd.Flags().Uint64("height", 0, "header height")
-    headerCmd.Flags().String("blockroot", "", "blockRoot hex")
-    headerCmd.Flags().String("txroot", "", "txRoot hex")
-    headerCmd.Flags().String("stateroot", "", "stateRoot hex")
-    headerCmd.Flags().String("sig", "", "aggregate signature hex")
+	headerCmd.Flags().String("file", "", "path to header JSON file")
+	headerCmd.Flags().Uint32("chain", 0, "chainID")
+	headerCmd.Flags().Uint64("height", 0, "header height")
+	headerCmd.Flags().String("blockroot", "", "blockRoot hex")
+	headerCmd.Flags().String("txroot", "", "txRoot hex")
+	headerCmd.Flags().String("stateroot", "", "stateRoot hex")
+	headerCmd.Flags().String("sig", "", "aggregate signature hex")
 
-    depositCmd.Flags().Uint32("chain", 0, "chainID")
-    depositCmd.Flags().String("from", "", "sender address hex")
-    depositCmd.Flags().String("to", "", "L2 recipient bytes hex")
-    depositCmd.Flags().String("token", "", "token ID / symbol")
-    depositCmd.Flags().Uint64("amount", 0, "amount")
+	depositCmd.Flags().Uint32("chain", 0, "chainID")
+	depositCmd.Flags().String("from", "", "sender address hex")
+	depositCmd.Flags().String("to", "", "L2 recipient bytes hex")
+	depositCmd.Flags().String("token", "", "token ID / symbol")
+	depositCmd.Flags().Uint64("amount", 0, "amount")
 
-    // route wiring
-    scCmd.AddCommand(registerCmd)
-    scCmd.AddCommand(headerCmd)
-    scCmd.AddCommand(depositCmd)
-    scCmd.AddCommand(withdrawCmd)
-    scCmd.AddCommand(metaCmd)
-    scCmd.AddCommand(listCmd)
+	getHeaderCmd.Flags().Uint32("chain", 0, "chainID")
+	getHeaderCmd.Flags().Uint64("height", 0, "header height")
+
+	// route wiring
+	scCmd.AddCommand(registerCmd)
+	scCmd.AddCommand(headerCmd)
+	scCmd.AddCommand(depositCmd)
+	scCmd.AddCommand(withdrawCmd)
+	scCmd.AddCommand(getHeaderCmd)
+	scCmd.AddCommand(metaCmd)
+	scCmd.AddCommand(listCmd)
 }
 
 // NewSidechainCommand exposes the consolidated CLI route.

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -50,17 +50,15 @@ var gasTable = map[Opcode]uint64{
 	ReleaseEscrow:  12_000,
 	PredictVolume:  15_000,
 
-
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker
 	// ----------------------------------------------------------------------
-	SwapExactIn:    4_500,
-	AddLiquidity:   5_000,
-	RemoveLiquidity:5_000,
-  Quote:          2_500,
-  AllPairs:       2_000,
-  InitPoolsFromFile: 6_000,
-
+	SwapExactIn:       4_500,
+	AddLiquidity:      5_000,
+	RemoveLiquidity:   5_000,
+	Quote:             2_500,
+	AllPairs:          2_000,
+	InitPoolsFromFile: 6_000,
 
 	// ----------------------------------------------------------------------
 	// Authority / Validator-Set
@@ -105,7 +103,6 @@ var gasTable = map[Opcode]uint64{
 	Compliance_AuditTrail: 3_000,
 	Compliance_MonitorTx:  5_000,
 	Compliance_VerifyZKP:  12_000,
-
 
 	// ----------------------------------------------------------------------
 	// Consensus Core
@@ -303,6 +300,9 @@ var gasTable = map[Opcode]uint64{
 	VerifyWithdraw:     4_000,
 	VerifyAggregateSig: 8_000,
 	VerifyMerkleProof:  1_200,
+	GetSidechainMeta:   1_000,
+	ListSidechains:     1_200,
+	GetSidechainHeader: 1_000,
 	// Deposit already priced
 
 	// ----------------------------------------------------------------------

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -135,9 +135,9 @@ var catalogue = []struct {
 	{"SwapExactIn", 0x020001},
 	{"AMM_AddLiquidity", 0x020002},
 	{"AMM_RemoveLiquidity", 0x020003},
-        {"Quote", 0x020004},
-        {"AllPairs", 0x020005},
-        {"InitPoolsFromFile", 0x020006},
+	{"Quote", 0x020004},
+	{"AllPairs", 0x020005},
+	{"InitPoolsFromFile", 0x020006},
 
 	// Authority (0x03)
 	{"NewAuthoritySet", 0x030001},
@@ -351,6 +351,9 @@ var catalogue = []struct {
 	{"VerifyWithdraw", 0x160006},
 	{"VerifyAggregateSig", 0x160007},
 	{"VerifyMerkleProof", 0x160008},
+	{"GetSidechainMeta", 0x160009},
+	{"ListSidechains", 0x16000A},
+	{"GetSidechainHeader", 0x16000B},
 
 	// StateChannel (0x17)
 	{"InitStateChannels", 0x170001},

--- a/synnergy-network/core/sidechains.go
+++ b/synnergy-network/core/sidechains.go
@@ -24,16 +24,16 @@ package core
 // -----------------------------------------------------------------------------
 
 import (
-    "crypto/sha256"
-    "encoding/binary"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "sync"
-    "time"
-    "bytes"
-    bls "github.com/herumi/bls-eth-go-binary/bls"
-    "log"
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	bls "github.com/herumi/bls-eth-go-binary/bls"
+	"log"
+	"sync"
+	"time"
 )
 
 //---------------------------------------------------------------------
@@ -42,19 +42,18 @@ import (
 
 type SidechainID uint32
 
-
-
 //---------------------------------------------------------------------
 // Coordinator singleton
 //---------------------------------------------------------------------
 
-
 var (
-    scOnce sync.Once
-    coord  *SidechainCoordinator
+	scOnce sync.Once
+	coord  *SidechainCoordinator
 )
 
-func InitSidechains(led StateRW, net Broadcaster) { scOnce.Do(func(){ coord = &SidechainCoordinator{Ledger: led, Net: net} }) }
+func InitSidechains(led StateRW, net Broadcaster) {
+	scOnce.Do(func() { coord = &SidechainCoordinator{Ledger: led, Net: net} })
+}
 func Sidechains() *SidechainCoordinator { return coord }
 
 //---------------------------------------------------------------------
@@ -62,11 +61,15 @@ func Sidechains() *SidechainCoordinator { return coord }
 //---------------------------------------------------------------------
 
 func (sc *SidechainCoordinator) Register(id SidechainID, name string, threshold uint8, validators [][]byte) error {
-    if threshold==0 || threshold>100 { return errors.New("invalid threshold") }
-    meta := Sidechain{ID:id,Name:name,Threshold:threshold,Validators:validators,Registered:time.Now().Unix()}
-    if exists,_ := sc.Ledger.HasState(metaKey(id)); exists { return errors.New("duplicate id") }
-    sc.Ledger.SetState(metaKey(id), mustJSON(meta))
-    return nil
+	if threshold == 0 || threshold > 100 {
+		return errors.New("invalid threshold")
+	}
+	meta := Sidechain{ID: id, Name: name, Threshold: threshold, Validators: validators, Registered: time.Now().Unix()}
+	if exists, _ := sc.Ledger.HasState(metaKey(id)); exists {
+		return errors.New("duplicate id")
+	}
+	sc.Ledger.SetState(metaKey(id), mustJSON(meta))
+	return nil
 }
 
 //---------------------------------------------------------------------
@@ -74,109 +77,152 @@ func (sc *SidechainCoordinator) Register(id SidechainID, name string, threshold 
 //---------------------------------------------------------------------
 
 func (sc *SidechainCoordinator) SubmitHeader(h SidechainHeader) error {
-    meta, err := sc.getMeta(h.ChainID)
-    if err != nil {
-        return err
-    }
+	meta, err := sc.getMeta(h.ChainID)
+	if err != nil {
+		return err
+	}
 
-    if h.Height != meta.LastHeight+1 {
-        return fmt.Errorf("non‑sequential height: got %d want %d", h.Height, meta.LastHeight+1)
-    }
+	if h.Height != meta.LastHeight+1 {
+		return fmt.Errorf("non‑sequential height: got %d want %d", h.Height, meta.LastHeight+1)
+	}
 
-    hdrBytes, err := json.Marshal(h)
-    if err != nil {
-        return fmt.Errorf("failed to encode header: %w", err)
-    }
+	hdrBytes, err := json.Marshal(h)
+	if err != nil {
+		return fmt.Errorf("failed to encode header: %w", err)
+	}
 
-    hdrHash := hashHeader(hdrBytes)
-    if !VerifyAggregateSig(meta.Validators, h.SigAgg, hdrHash[:]) {
-        return errors.New("bad aggregate sig")
-    }
+	hdrHash := hashHeader(hdrBytes)
+	if !VerifyAggregateSig(meta.Validators, h.SigAgg, hdrHash[:]) {
+		return errors.New("bad aggregate sig")
+	}
 
-    sc.Ledger.SetState(headerKey(h.ChainID, h.Height), mustJSON(h))
-    meta.LastHeight = h.Height
-    meta.LastRoot = h.StateRoot
-    sc.Ledger.SetState(metaKey(h.ChainID), mustJSON(meta))
+	sc.Ledger.SetState(headerKey(h.ChainID, h.Height), mustJSON(h))
+	meta.LastHeight = h.Height
+	meta.LastRoot = h.StateRoot
+	sc.Ledger.SetState(metaKey(h.ChainID), mustJSON(meta))
 
-    return nil
+	return nil
 }
-
 
 //---------------------------------------------------------------------
 // Deposits
 //---------------------------------------------------------------------
 
 func (sc *SidechainCoordinator) Deposit(chain SidechainID, from Address, to []byte, token TokenID, amount uint64) (DepositReceipt, error) {
-    if amount==0 { return DepositReceipt{}, errors.New("zero amount") }
-    // escrow: transfer from user to bridge account
-    bridgeAcct := bridgeAccount(chain, token)
-    tok, ok := GetToken(token); if !ok { return DepositReceipt{}, errors.New("token unknown") }
-    if err := tok.Transfer(from, bridgeAcct, amount); err!=nil { return DepositReceipt{}, err }
+	if amount == 0 {
+		return DepositReceipt{}, errors.New("zero amount")
+	}
+	// escrow: transfer from user to bridge account
+	bridgeAcct := bridgeAccount(chain, token)
+	tok, ok := GetToken(token)
+	if !ok {
+		return DepositReceipt{}, errors.New("token unknown")
+	}
+	if err := tok.Transfer(from, bridgeAcct, amount); err != nil {
+		return DepositReceipt{}, err
+	}
 
-    sc.mu.Lock(); sc.Nonce++; nonce := sc.Nonce; sc.mu.Unlock()
-    rec := DepositReceipt{Nonce:nonce,ChainID:chain,From:from,To:to,Amount:amount,Token:token,Timestamp:time.Now().Unix()}
-    rec.Hash = hashDeposit(rec)
-    sc.Ledger.SetState(depositKey(chain, nonce), mustJSON(rec))
-    sc.Net.Broadcast("bridge_deposit", mustJSON(rec))
-    return rec, nil
+	sc.mu.Lock()
+	sc.Nonce++
+	nonce := sc.Nonce
+	sc.mu.Unlock()
+	rec := DepositReceipt{Nonce: nonce, ChainID: chain, From: from, To: to, Amount: amount, Token: token, Timestamp: time.Now().Unix()}
+	rec.Hash = hashDeposit(rec)
+	sc.Ledger.SetState(depositKey(chain, nonce), mustJSON(rec))
+	sc.Net.Broadcast("bridge_deposit", mustJSON(rec))
+	return rec, nil
 }
 
+//---------------------------------------------------------------------
+// Query helpers
+//---------------------------------------------------------------------
+
+// GetMeta returns metadata for the specified sidechain.
+func (sc *SidechainCoordinator) GetMeta(id SidechainID) (Sidechain, error) {
+	return sc.getMeta(id)
+}
+
+// ListSidechains returns metadata for all registered sidechains.
+func (sc *SidechainCoordinator) ListSidechains() ([]Sidechain, error) {
+	it := sc.Ledger.PrefixIterator([]byte("sc:meta:"))
+	var out []Sidechain
+	for it.Next() {
+		var m Sidechain
+		if err := json.Unmarshal(it.Value(), &m); err != nil {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+// GetHeader fetches a previously submitted sidechain header.
+func (sc *SidechainCoordinator) GetHeader(id SidechainID, height uint64) (SidechainHeader, error) {
+	raw, _ := sc.Ledger.GetState(headerKey(id, height))
+	if len(raw) == 0 {
+		return SidechainHeader{}, errors.New("header not found")
+	}
+	var h SidechainHeader
+	if err := json.Unmarshal(raw, &h); err != nil {
+		return SidechainHeader{}, err
+	}
+	return h, nil
+}
 
 //---------------------------------------------------------------------
 // Withdraw verification (L2 → L1)
 //---------------------------------------------------------------------
 
 func (sc *SidechainCoordinator) VerifyWithdraw(p WithdrawProof) error {
-    // 1. fetch side‑chain meta + header
-    meta, err := sc.getMeta(p.Header.ChainID)
-    if err != nil {
-        return err
-    }
+	// 1. fetch side‑chain meta + header
+	meta, err := sc.getMeta(p.Header.ChainID)
+	if err != nil {
+		return err
+	}
 
-    hdrBytes, err := json.Marshal(p.Header)
-    if err != nil {
-        return fmt.Errorf("failed to encode header: %w", err)
-    }
+	hdrBytes, err := json.Marshal(p.Header)
+	if err != nil {
+		return fmt.Errorf("failed to encode header: %w", err)
+	}
 
-    hdrHash := hashHeader(hdrBytes)
-    if !VerifyAggregateSig(meta.Validators, p.Header.SigAgg, hdrHash[:]) {
-        return errors.New("sig")
-    }
+	hdrHash := hashHeader(hdrBytes)
+	if !VerifyAggregateSig(meta.Validators, p.Header.SigAgg, hdrHash[:]) {
+		return errors.New("sig")
+	}
 
-    // 2. Merkle proof inclusion
-    if !VerifyMerkleProof(p.Header.TxRoot[:], p.TxData, p.Proof, p.TxIndex) {
-        return errors.New("merkle fail")
-    }
+	// 2. Merkle proof inclusion
+	if !VerifyMerkleProof(p.Header.TxRoot[:], p.TxData, p.Proof, p.TxIndex) {
+		return errors.New("merkle fail")
+	}
 
-    // simplistic: assume TxData packed as {recipient, tokenID, amount}
-    var payload struct {
-        Recipient Address
-        Token     TokenID
-        Amount    uint64
-    }
-    if err := json.Unmarshal(p.TxData, &payload); err != nil {
-        return err
-    }
-    if payload.Recipient != p.Recipient {
-        return errors.New("recipient mismatch")
-    }
+	// simplistic: assume TxData packed as {recipient, tokenID, amount}
+	var payload struct {
+		Recipient Address
+		Token     TokenID
+		Amount    uint64
+	}
+	if err := json.Unmarshal(p.TxData, &payload); err != nil {
+		return err
+	}
+	if payload.Recipient != p.Recipient {
+		return errors.New("recipient mismatch")
+	}
 
-    // replay protection
-    if exists, _ := sc.Ledger.HasState(withdrawnKey(hashBytes(p.TxData))); exists {
-        return errors.New("already claimed")
-    }
+	// replay protection
+	if exists, _ := sc.Ledger.HasState(withdrawnKey(hashBytes(p.TxData))); exists {
+		return errors.New("already claimed")
+	}
 
-    // release funds from escrow
-    bridgeAcct := bridgeAccount(p.Header.ChainID, payload.Token)
-    tok, _ := GetToken(payload.Token)
-    if err := tok.Transfer(bridgeAcct, p.Recipient, payload.Amount); err != nil {
-        return err
-    }
+	// release funds from escrow
+	bridgeAcct := bridgeAccount(p.Header.ChainID, payload.Token)
+	tok, _ := GetToken(payload.Token)
+	if err := tok.Transfer(bridgeAcct, p.Recipient, payload.Amount); err != nil {
+		return err
+	}
 
-    sc.Ledger.SetState(withdrawnKey(hashBytes(p.TxData)), []byte{1})
-    return nil
+	sc.Ledger.SetState(withdrawnKey(hashBytes(p.TxData)), []byte{1})
+	return nil
 }
-
 
 func init() {
 	if err := bls.Init(0); err != nil {
@@ -184,31 +230,27 @@ func init() {
 	}
 }
 
-
 func VerifyAggregateSig(pubkeys [][]byte, aggSig []byte, msg []byte) bool {
-    var agg bls.Sign
-    if err := agg.Deserialize(aggSig); err != nil {
-        return false
-    }
+	var agg bls.Sign
+	if err := agg.Deserialize(aggSig); err != nil {
+		return false
+	}
 
-    var aggPub bls.PublicKey
-    for i, pk := range pubkeys {
-        var p bls.PublicKey
-        if err := p.Deserialize(pk); err != nil {
-            return false
-        }
-        if i == 0 {
-            aggPub = p
-        } else {
-            aggPub.Add(&p)
-        }
-    }
+	var aggPub bls.PublicKey
+	for i, pk := range pubkeys {
+		var p bls.PublicKey
+		if err := p.Deserialize(pk); err != nil {
+			return false
+		}
+		if i == 0 {
+			aggPub = p
+		} else {
+			aggPub.Add(&p)
+		}
+	}
 
-    return agg.VerifyByte(&aggPub, msg)
+	return agg.VerifyByte(&aggPub, msg)
 }
-
-
-
 
 func VerifyMerkleProof(root []byte, leaf []byte, proof [][]byte, index uint32) bool {
 	hash := leaf
@@ -231,33 +273,42 @@ func HashConcat(a, b []byte) []byte {
 	return h.Sum(nil)
 }
 
-
 //---------------------------------------------------------------------
 // Helpers
 //---------------------------------------------------------------------
 
 func (sc *SidechainCoordinator) getMeta(id SidechainID) (Sidechain, error) {
-    raw,_ := sc.Ledger.GetState(metaKey(id)); if len(raw)==0 { return Sidechain{}, errors.New("unknown sidechain") }
-    var m Sidechain; _=json.Unmarshal(raw,&m); return m,nil
+	raw, _ := sc.Ledger.GetState(metaKey(id))
+	if len(raw) == 0 {
+		return Sidechain{}, errors.New("unknown sidechain")
+	}
+	var m Sidechain
+	_ = json.Unmarshal(raw, &m)
+	return m, nil
 }
 
-func metaKey(id SidechainID) []byte          { return append([]byte("sc:meta:"), uint32ToBytes(uint32(id))...) }
-func headerKey(id SidechainID, h uint64) []byte { b:=append(uint32ToBytes(uint32(id)), uint64ToBytes(h)...); return append([]byte("sc:hdr:"), b...) }
-func depositKey(id SidechainID, n uint64) []byte { b:=append(uint32ToBytes(uint32(id)), uint64ToBytes(n)...); return append([]byte("sc:dep:"), b...) }
-func withdrawnKey(hash [32]byte) []byte      { return append([]byte("sc:wd:"), hash[:]...) }
+func metaKey(id SidechainID) []byte { return append([]byte("sc:meta:"), uint32ToBytes(uint32(id))...) }
+func headerKey(id SidechainID, h uint64) []byte {
+	b := append(uint32ToBytes(uint32(id)), uint64ToBytes(h)...)
+	return append([]byte("sc:hdr:"), b...)
+}
+func depositKey(id SidechainID, n uint64) []byte {
+	b := append(uint32ToBytes(uint32(id)), uint64ToBytes(n)...)
+	return append([]byte("sc:dep:"), b...)
+}
+func withdrawnKey(hash [32]byte) []byte { return append([]byte("sc:wd:"), hash[:]...) }
 func bridgeAccount(id SidechainID, token TokenID) Address {
-    var a Address
-    copy(a[:4], []byte("BRG1"))
-    binary.BigEndian.PutUint32(a[4:], uint32(id))
-    binary.BigEndian.PutUint32(a[8:], uint32(token))
-    return a
+	var a Address
+	copy(a[:4], []byte("BRG1"))
+	binary.BigEndian.PutUint32(a[4:], uint32(id))
+	binary.BigEndian.PutUint32(a[8:], uint32(token))
+	return a
 }
 
-func hashDeposit(d DepositReceipt) [32]byte { b,_ := json.Marshal(d); return sha256.Sum256(b) }
-func hashBytes(b []byte) [32]byte          { return sha256.Sum256(b) }
+func hashDeposit(d DepositReceipt) [32]byte { b, _ := json.Marshal(d); return sha256.Sum256(b) }
+func hashBytes(b []byte) [32]byte           { return sha256.Sum256(b) }
 
-func uint32ToBytes(x uint32) []byte { b:=make([]byte,4); binary.BigEndian.PutUint32(b,x); return b }
-
+func uint32ToBytes(x uint32) []byte { b := make([]byte, 4); binary.BigEndian.PutUint32(b, x); return b }
 
 //---------------------------------------------------------------------
 // END sidechains.go


### PR DESCRIPTION
## Summary
- add sidechain query functions to coordinator
- extend CLI with `get-header` command
- expose opcodes for sidechain queries
- define gas costs for new operations

## Testing
- `go mod tidy` *(fails: cannot access github.com/synnergy-network/core)*
- `go test ./...` *(fails: go.mod updates needed)*

------
https://chatgpt.com/codex/tasks/task_e_688adf0921b483209571020a041b7763