### PR TITLE
Implement channel query and CLI enhancements

### DIFF
--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -50,17 +50,15 @@ var gasTable = map[Opcode]uint64{
 	ReleaseEscrow:  12_000,
 	PredictVolume:  15_000,
 
-
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker
 	// ----------------------------------------------------------------------
-	SwapExactIn:    4_500,
-	AddLiquidity:   5_000,
-	RemoveLiquidity:5_000,
-  Quote:          2_500,
-  AllPairs:       2_000,
-  InitPoolsFromFile: 6_000,
-
+	SwapExactIn:       4_500,
+	AddLiquidity:      5_000,
+	RemoveLiquidity:   5_000,
+	Quote:             2_500,
+	AllPairs:          2_000,
+	InitPoolsFromFile: 6_000,
 
 	// ----------------------------------------------------------------------
 	// Authority / Validator-Set
@@ -105,7 +103,6 @@ var gasTable = map[Opcode]uint64{
 	Compliance_AuditTrail: 3_000,
 	Compliance_MonitorTx:  5_000,
 	Compliance_VerifyZKP:  12_000,
-
 
 	// ----------------------------------------------------------------------
 	// Consensus Core
@@ -315,6 +312,8 @@ var gasTable = map[Opcode]uint64{
 	InitiateClose:        3_000,
 	Challenge:            4_000,
 	Finalize:             5_000,
+	GetChannel:           800,
+	ListChannels:         1_200,
 
 	// ----------------------------------------------------------------------
 	// Storage / Marketplace

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -135,9 +135,9 @@ var catalogue = []struct {
 	{"SwapExactIn", 0x020001},
 	{"AMM_AddLiquidity", 0x020002},
 	{"AMM_RemoveLiquidity", 0x020003},
-        {"Quote", 0x020004},
-        {"AllPairs", 0x020005},
-        {"InitPoolsFromFile", 0x020006},
+	{"Quote", 0x020004},
+	{"AllPairs", 0x020005},
+	{"InitPoolsFromFile", 0x020006},
 
 	// Authority (0x03)
 	{"NewAuthoritySet", 0x030001},
@@ -360,6 +360,8 @@ var catalogue = []struct {
 	{"InitiateClose", 0x170005},
 	{"Challenge", 0x170006},
 	{"Finalize", 0x170007},
+	{"GetChannel", 0x170008},
+	{"ListChannels", 0x170009},
 
 	// Storage (0x18)
 	{"NewStorage", 0x180001},

--- a/synnergy-network/core/state_channel.go
+++ b/synnergy-network/core/state_channel.go
@@ -18,16 +18,16 @@ package core
 // -----------------------------------------------------------------------------
 
 import (
-    "crypto/sha256"
-    "encoding/binary"
-    "encoding/json"
-    "errors"
-    "sync"
-    "time"
-    "crypto/ecdsa"
-    "crypto/elliptic"
-    "encoding/asn1"
-    "math/big"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"encoding/asn1"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"sync"
+	"time"
 )
 
 //---------------------------------------------------------------------
@@ -35,7 +35,7 @@ import (
 //---------------------------------------------------------------------
 
 const (
-    ChallengePeriod = 24 * time.Hour
+	ChallengePeriod = 24 * time.Hour
 )
 
 //---------------------------------------------------------------------
@@ -44,39 +44,52 @@ const (
 
 type ChannelID [32]byte
 
-
 //---------------------------------------------------------------------
 // Engine singleton
 //---------------------------------------------------------------------
 
 var (
-    chanOnce sync.Once
-    chEng    *ChannelEngine
+	chanOnce sync.Once
+	chEng    *ChannelEngine
 )
 
-func InitStateChannels(led StateRW) { chanOnce.Do(func(){ chEng=&ChannelEngine{led:led} }) }
-func Channels() *ChannelEngine { return chEng }
+func InitStateChannels(led StateRW) { chanOnce.Do(func() { chEng = &ChannelEngine{led: led} }) }
+func Channels() *ChannelEngine      { return chEng }
 
 //---------------------------------------------------------------------
 // OpenChannel – both parties must have approved token transfer.
 //---------------------------------------------------------------------
 
 func (e *ChannelEngine) OpenChannel(a, b Address, token TokenID, amountA, amountB uint64, nonce uint64) (ChannelID, error) {
-    if amountA==0 && amountB==0 { return ChannelID{}, errors.New("zero amounts") }
-    tok, ok := GetToken(token); if !ok { return ChannelID{}, errors.New("token unknown") }
+	if amountA == 0 && amountB == 0 {
+		return ChannelID{}, errors.New("zero amounts")
+	}
+	tok, ok := GetToken(token)
+	if !ok {
+		return ChannelID{}, errors.New("token unknown")
+	}
 
-    // derive ID
-    h := sha256.Sum256(append(append(a.Bytes(), b.Bytes()...), uint64ToBytes(nonce)...))
-    var id ChannelID; copy(id[:], h[:])
+	// derive ID
+	h := sha256.Sum256(append(append(a.Bytes(), b.Bytes()...), uint64ToBytes(nonce)...))
+	var id ChannelID
+	copy(id[:], h[:])
 
-    // escrow funds into multisig account
-    escrow := escrowAddr(id)
-    if amountA>0 { if err := tok.Transfer(a, escrow, amountA); err!=nil { return id, err } }
-    if amountB>0 { if err := tok.Transfer(b, escrow, amountB); err!=nil { return id, err } }
+	// escrow funds into multisig account
+	escrow := escrowAddr(id)
+	if amountA > 0 {
+		if err := tok.Transfer(a, escrow, amountA); err != nil {
+			return id, err
+		}
+	}
+	if amountB > 0 {
+		if err := tok.Transfer(b, escrow, amountB); err != nil {
+			return id, err
+		}
+	}
 
-    ch := Channel{ID:id, PartyA:a, PartyB:b, Token:token, BalanceA:amountA, BalanceB:amountB, Nonce:0, Closing:0}
-    e.led.SetState(chKey(id), mustJSON(ch))
-    return id, nil
+	ch := Channel{ID: id, PartyA: a, PartyB: b, Token: token, BalanceA: amountA, BalanceB: amountB, Nonce: 0, Closing: 0}
+	e.led.SetState(chKey(id), mustJSON(ch))
+	return id, nil
 }
 
 //---------------------------------------------------------------------
@@ -84,71 +97,80 @@ func (e *ChannelEngine) OpenChannel(a, b Address, token TokenID, amountA, amount
 //---------------------------------------------------------------------
 
 type ECDSASignature struct {
-    R, S *big.Int
+	R, S *big.Int
 }
 
 func VerifyECDSASignature(pubKeyBytes []byte, msgHash []byte, sigBytes []byte) error {
-    if len(pubKeyBytes) != 65 || pubKeyBytes[0] != 0x04 {
-        return errors.New("invalid uncompressed public key format")
-    }
+	if len(pubKeyBytes) != 65 || pubKeyBytes[0] != 0x04 {
+		return errors.New("invalid uncompressed public key format")
+	}
 
-    x := new(big.Int).SetBytes(pubKeyBytes[1:33])
-    y := new(big.Int).SetBytes(pubKeyBytes[33:])
-    pubKey := ecdsa.PublicKey{
-        Curve: elliptic.P256(),
-        X:     x,
-        Y:     y,
-    }
+	x := new(big.Int).SetBytes(pubKeyBytes[1:33])
+	y := new(big.Int).SetBytes(pubKeyBytes[33:])
+	pubKey := ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     x,
+		Y:     y,
+	}
 
-    var sig ECDSASignature
-    _, err := asn1.Unmarshal(sigBytes, &sig)
-    if err != nil {
-        return errors.New("invalid signature encoding")
-    }
+	var sig ECDSASignature
+	_, err := asn1.Unmarshal(sigBytes, &sig)
+	if err != nil {
+		return errors.New("invalid signature encoding")
+	}
 
-    if !ecdsa.Verify(&pubKey, msgHash, sig.R, sig.S) {
-        return errors.New("signature verification failed")
-    }
+	if !ecdsa.Verify(&pubKey, msgHash, sig.R, sig.S) {
+		return errors.New("signature verification failed")
+	}
 
-    return nil
+	return nil
 }
 
 func verifySigs(ss *SignedState) error {
-    raw, _ := json.Marshal(ss.Channel)
-    h := sha256.Sum256(raw)
+	raw, _ := json.Marshal(ss.Channel)
+	h := sha256.Sum256(raw)
 
-    pubA := ss.Channel.PartyA[:] // convert [N]byte → []byte
-    pubB := ss.Channel.PartyB[:]
+	pubA := ss.Channel.PartyA[:] // convert [N]byte → []byte
+	pubB := ss.Channel.PartyB[:]
 
-    if err := VerifyECDSASignature(pubA, h[:], ss.SigA); err != nil {
-        return errors.New("sigA invalid: " + err.Error())
-    }
+	if err := VerifyECDSASignature(pubA, h[:], ss.SigA); err != nil {
+		return errors.New("sigA invalid: " + err.Error())
+	}
 
-    if err := VerifyECDSASignature(pubB, h[:], ss.SigB); err != nil {
-        return errors.New("sigB invalid: " + err.Error())
-    }
+	if err := VerifyECDSASignature(pubB, h[:], ss.SigB); err != nil {
+		return errors.New("sigB invalid: " + err.Error())
+	}
 
-    return nil
+	return nil
 }
-
 
 //---------------------------------------------------------------------
 // InitiateClose – post signed state to ledger
 //---------------------------------------------------------------------
 
 func (e *ChannelEngine) InitiateClose(state SignedState) error {
-    if err:=verifySigs(&state); err!=nil { return err }
-    e.mu.Lock(); defer e.mu.Unlock()
+	if err := verifySigs(&state); err != nil {
+		return err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
 
-    cur, err := e.getChannel(state.Channel.ID); if err!=nil { return err }
-    if cur.Closing!=0 { return errors.New("already closing") }
-    if state.Channel.Nonce < cur.Nonce { return errors.New("stale nonce") }
+	cur, err := e.getChannel(state.Channel.ID)
+	if err != nil {
+		return err
+	}
+	if cur.Closing != 0 {
+		return errors.New("already closing")
+	}
+	if state.Channel.Nonce < cur.Nonce {
+		return errors.New("stale nonce")
+	}
 
-    // store latest state + start timer
-    state.Channel.Closing = time.Now().Unix()
-    e.led.SetState(chKey(state.Channel.ID), mustJSON(state.Channel))
-    e.led.SetState(pendingKey(state.Channel.ID), mustJSON(state))
-    return nil
+	// store latest state + start timer
+	state.Channel.Closing = time.Now().Unix()
+	e.led.SetState(chKey(state.Channel.ID), mustJSON(state.Channel))
+	e.led.SetState(pendingKey(state.Channel.ID), mustJSON(state))
+	return nil
 }
 
 //---------------------------------------------------------------------
@@ -156,17 +178,29 @@ func (e *ChannelEngine) InitiateClose(state SignedState) error {
 //---------------------------------------------------------------------
 
 func (e *ChannelEngine) Challenge(state SignedState) error {
-    if err:=verifySigs(&state); err!=nil { return err }
-    e.mu.Lock(); defer e.mu.Unlock()
-    cur, err := e.getChannel(state.Channel.ID); if err!=nil { return err }
-    if cur.Closing==0 { return errors.New("channel not closing") }
-    if time.Now().Unix() > cur.Closing+int64(ChallengePeriod.Seconds()) { return errors.New("period over") }
-    if state.Channel.Nonce <= cur.Nonce { return errors.New("nonce too low") }
-    // replace pending state
-    state.Channel.Closing = cur.Closing
-    e.led.SetState(chKey(state.Channel.ID), mustJSON(state.Channel))
-    e.led.SetState(pendingKey(state.Channel.ID), mustJSON(state))
-    return nil
+	if err := verifySigs(&state); err != nil {
+		return err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	cur, err := e.getChannel(state.Channel.ID)
+	if err != nil {
+		return err
+	}
+	if cur.Closing == 0 {
+		return errors.New("channel not closing")
+	}
+	if time.Now().Unix() > cur.Closing+int64(ChallengePeriod.Seconds()) {
+		return errors.New("period over")
+	}
+	if state.Channel.Nonce <= cur.Nonce {
+		return errors.New("nonce too low")
+	}
+	// replace pending state
+	state.Channel.Closing = cur.Closing
+	e.led.SetState(chKey(state.Channel.ID), mustJSON(state.Channel))
+	e.led.SetState(pendingKey(state.Channel.ID), mustJSON(state))
+	return nil
 }
 
 //---------------------------------------------------------------------
@@ -174,19 +208,59 @@ func (e *ChannelEngine) Challenge(state SignedState) error {
 //---------------------------------------------------------------------
 
 func (e *ChannelEngine) Finalize(id ChannelID) error {
-    e.mu.Lock(); defer e.mu.Unlock()
-    ch, err := e.getChannel(id); if err!=nil { return err }
-    if ch.Closing==0 { return errors.New("not closing") }
-    if time.Now().Unix()<ch.Closing+int64(ChallengePeriod.Seconds()) { return errors.New("period not over") }
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	ch, err := e.getChannel(id)
+	if err != nil {
+		return err
+	}
+	if ch.Closing == 0 {
+		return errors.New("not closing")
+	}
+	if time.Now().Unix() < ch.Closing+int64(ChallengePeriod.Seconds()) {
+		return errors.New("period not over")
+	}
 
-    tok,_ := GetToken(ch.Token)
-    escrow := escrowAddr(id)
-    if ch.BalanceA>0 { _ = tok.Transfer(escrow, ch.PartyA, ch.BalanceA) }
-    if ch.BalanceB>0 { _ = tok.Transfer(escrow, ch.PartyB, ch.BalanceB) }
+	tok, _ := GetToken(ch.Token)
+	escrow := escrowAddr(id)
+	if ch.BalanceA > 0 {
+		_ = tok.Transfer(escrow, ch.PartyA, ch.BalanceA)
+	}
+	if ch.BalanceB > 0 {
+		_ = tok.Transfer(escrow, ch.PartyB, ch.BalanceB)
+	}
 
-    e.led.DeleteState(chKey(id))
-    e.led.DeleteState(pendingKey(id))
-    return nil
+	e.led.DeleteState(chKey(id))
+	e.led.DeleteState(pendingKey(id))
+	return nil
+}
+
+// GetChannel retrieves the current state of the channel with the provided ID.
+// It acquires a read lock to maintain thread safety.
+func (e *ChannelEngine) GetChannel(id ChannelID) (Channel, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.getChannel(id)
+}
+
+// ListChannels enumerates all channels currently stored in the ledger. Any
+// corrupt entries are skipped but the iterator error is returned.
+func (e *ChannelEngine) ListChannels() ([]Channel, error) {
+	var chans []Channel
+	err := e.led.Snapshot(func() error {
+		it := e.led.PrefixIterator([]byte("chan:"))
+		for it.Next() {
+			var c Channel
+			if err := json.Unmarshal(it.Value(), &c); err == nil {
+				chans = append(chans, c)
+			}
+		}
+		if ierr, ok := it.(interface{ Error() error }); ok {
+			return ierr.Error()
+		}
+		return nil
+	})
+	return chans, err
 }
 
 //---------------------------------------------------------------------
@@ -194,18 +268,25 @@ func (e *ChannelEngine) Finalize(id ChannelID) error {
 //---------------------------------------------------------------------
 
 func (e *ChannelEngine) getChannel(id ChannelID) (Channel, error) {
-    raw,_ := e.led.GetState(chKey(id)); if len(raw)==0 { return Channel{}, errors.New("ch not found") }
-    var c Channel; _=json.Unmarshal(raw,&c); return c,nil
+	raw, _ := e.led.GetState(chKey(id))
+	if len(raw) == 0 {
+		return Channel{}, errors.New("ch not found")
+	}
+	var c Channel
+	_ = json.Unmarshal(raw, &c)
+	return c, nil
 }
 
 func chKey(id ChannelID) []byte      { return append([]byte("chan:"), id[:]...) }
 func pendingKey(id ChannelID) []byte { return append([]byte("chanpend:"), id[:]...) }
 func escrowAddr(id ChannelID) Address {
-    var a Address; copy(a[:4], []byte("ESC1")); copy(a[4:], id[:16])
-    return a
+	var a Address
+	copy(a[:4], []byte("ESC1"))
+	copy(a[4:], id[:16])
+	return a
 }
-func uint64ToBytes(x uint64) []byte { b:=make([]byte,8); binary.BigEndian.PutUint64(b,x); return b }
-func mustJSON(v interface{}) []byte { b,_ := json.Marshal(v); return b }
+func uint64ToBytes(x uint64) []byte { b := make([]byte, 8); binary.BigEndian.PutUint64(b, x); return b }
+func mustJSON(v interface{}) []byte { b, _ := json.Marshal(v); return b }
 
 //---------------------------------------------------------------------
 // END state_channel.go


### PR DESCRIPTION
## Summary
- add `GetChannel` and `ListChannels` to `ChannelEngine`
- expose new `status` and `list` commands in state channel CLI
- map opcodes for channel queries
- add gas table entries for query operations

## Testing
- `go test ./...` *(fails: go mod tidy required)*

------
https://chatgpt.com/codex/tasks/task_e_688ae02d789483208b49c5cc29a84e1d