### PR TITLE
Enhance storage module with listing utilities

### DIFF
--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -50,17 +50,15 @@ var gasTable = map[Opcode]uint64{
 	ReleaseEscrow:  12_000,
 	PredictVolume:  15_000,
 
-
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker
 	// ----------------------------------------------------------------------
-	SwapExactIn:    4_500,
-	AddLiquidity:   5_000,
-	RemoveLiquidity:5_000,
-  Quote:          2_500,
-  AllPairs:       2_000,
-  InitPoolsFromFile: 6_000,
-
+	SwapExactIn:       4_500,
+	AddLiquidity:      5_000,
+	RemoveLiquidity:   5_000,
+	Quote:             2_500,
+	AllPairs:          2_000,
+	InitPoolsFromFile: 6_000,
 
 	// ----------------------------------------------------------------------
 	// Authority / Validator-Set
@@ -105,7 +103,6 @@ var gasTable = map[Opcode]uint64{
 	Compliance_AuditTrail: 3_000,
 	Compliance_MonitorTx:  5_000,
 	Compliance_VerifyZKP:  12_000,
-
 
 	// ----------------------------------------------------------------------
 	// Consensus Core
@@ -326,6 +323,10 @@ var gasTable = map[Opcode]uint64{
 	Create:        8_000, // generic create (non-AMM/non-contract)
 	CloseDeal:     5_000,
 	Release:       2_000,
+	GetListing:    1_000,
+	ListListings:  1_000,
+	GetDeal:       1_000,
+	ListDeals:     1_000,
 	// Pin & Retrieve already priced
 
 	// ----------------------------------------------------------------------

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -135,9 +135,9 @@ var catalogue = []struct {
 	{"SwapExactIn", 0x020001},
 	{"AMM_AddLiquidity", 0x020002},
 	{"AMM_RemoveLiquidity", 0x020003},
-        {"Quote", 0x020004},
-        {"AllPairs", 0x020005},
-        {"InitPoolsFromFile", 0x020006},
+	{"Quote", 0x020004},
+	{"AllPairs", 0x020005},
+	{"InitPoolsFromFile", 0x020006},
 
 	// Authority (0x03)
 	{"NewAuthoritySet", 0x030001},
@@ -371,6 +371,10 @@ var catalogue = []struct {
 	{"Storage_Create", 0x180007},
 	{"CloseDeal", 0x180008},
 	{"Release", 0x180009},
+	{"GetListing", 0x18000A},
+	{"ListListings", 0x18000B},
+	{"GetDeal", 0x18000C},
+	{"ListDeals", 0x18000D},
 
 	// Tokens (0x19)
 	{"ID", 0x190001},


### PR DESCRIPTION
## Summary
- add storage listing and deal query helpers
- expose new CLI commands for storage listings/deals
- register opcodes and gas costs
- include unit tests for listing helpers

## Testing
- `go test ./...` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_688ae06bee448320a40e54f78d65d574