### PR TITLE
Fix CLI imports and add docs

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -1,0 +1,67 @@
+# Synnergy Network
+
+Synnergy is a modular blockchain framework written in Go. This repository contains
+multiple command line utilities as well as the core libraries that power the
+network. The primary entrypoint is the `synnergy` binary which exposes a large
+set of sub‑commands through the [Cobra](https://github.com/spf13/cobra)
+framework.
+
+## Building
+
+Go 1.20 or newer is recommended. Clone the repository and run the build command
+from the repository root:
+
+```bash
+cd synnergy-network
+go build ./cmd/synnergy
+```
+
+The resulting binary `synnergy` can then be executed with any of the available
+sub‑commands.
+
+## Command Groups
+
+Each file in `cmd/cli` registers its own group of commands with the root
+`cobra.Command`. The main program consolidates them so the CLI surface mirrors
+all modules from the core library. Highlights include:
+
+- `ai` – publish models and run inference jobs
+- `amm` – swap tokens and manage liquidity pools
+- `authority_node` – validator registration and voting
+- `charity_pool` – query and disburse community funds
+- `coin` – mint and transfer the native SYNN coin
+- `compliance` – perform KYC/AML checks
+- `consensus` – control the consensus engine
+- `contracts` – deploy and invoke smart contracts
+- `cross_chain` – configure asset bridges
+- `data` – inspect and manage raw data storage
+- `fault_tolerance` – simulate faults and backups
+- `governance` – DAO style governance commands
+- `green_technology` – sustainability features
+- `ledger` – low level ledger inspection
+- `network` – libp2p networking helpers
+- `replication` – snapshot and replicate data
+- `rollups` – manage rollup batches
+- `security` – cryptographic utilities
+- `sharding` – shard management
+- `sidechain` – launch and interact with sidechains
+- `state_channel` – open and settle payment channels
+- `storage` – interact with on‑chain storage providers
+- `tokens` – ERC‑20 style token commands
+- `transactions` – build and sign transactions
+- `utility_functions` – assorted helpers
+- `virtual_machine` – run the on‑chain VM service
+- `wallet` – mnemonic generation and signing
+
+More details for each command can be found in `cmd/cli/cli_guide.md`.
+
+## Testing
+
+Unit tests are located in the `tests` directory. Run them using:
+
+```bash
+go test ./...
+```
+
+Some tests rely on running services such as the network or security daemon. They
+may require additional environment variables or mock implementations.

--- a/synnergy-network/cmd/cli/compliance.go
+++ b/synnergy-network/cmd/cli/compliance.go
@@ -28,8 +28,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-        core "synnergy-network/core" // module local import
-
+	core "synnergy-network/core" // module local import
+)
 
 //---------------------------------------------------------------------
 // Middleware – executed for every ~compliance command

--- a/synnergy-network/cmd/cli/security.go
+++ b/synnergy-network/cmd/cli/security.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	core "github.com/synnergy-network/core"
+	core "synnergy-network/core"
 )
 
 // -----------------------------------------------------------------------------

--- a/synnergy-network/cmd/synnergy/synnergy_set_up.md
+++ b/synnergy-network/cmd/synnergy/synnergy_set_up.md
@@ -1,0 +1,58 @@
+# Synnergy CLI Setup
+
+This document describes how to build the `synnergy` command line interface and
+run a small local network for development.
+
+## Requirements
+
+- Go 1.20 or newer
+- Git
+- Optional: Docker for running auxiliary services
+
+## Building the CLI
+
+```bash
+git clone <repo-url>
+cd synnergy-network
+# fetch Go modules
+go mod tidy
+# build the binary
+go build ./cmd/synnergy
+```
+
+The resulting executable `synnergy` will be placed in the current directory.
+You can move it anywhere in your `$PATH` for convenience.
+
+## Environment Variables
+
+Many commands rely on services running in the background. The most common
+environment variables are:
+
+- `LEDGER_PATH` – path to the ledger database
+- `P2P_LISTEN_ADDR` – multiaddr for the libp2p node
+- `P2P_BOOTSTRAP` – comma‑separated list of bootstrap peers
+- `KEYSTORE_PATH` – directory containing node and validator keys
+- `SECURITY_API_ADDR` – host:port of the security daemon
+
+Create a `.env` file with these values or export them before running commands.
+
+## Starting a Local Node
+
+1. Initialise the ledger:
+   ```bash
+   synnergy ledger init --path ./ledger.db
+   ```
+2. Start the network stack:
+   ```bash
+   synnergy network start
+   ```
+3. In a new terminal, create a wallet and fund it:
+   ```bash
+   synnergy wallet create --out wallet.json
+   synnergy coin mint $(cat wallet.json | jq -r .address) 1000
+   ```
+
+From here you can experiment with the various command groups such as
+`contracts` for deploying Wasm code or `tokens` for managing ERC‑20 assets.
+
+Consult `cmd/cli/cli_guide.md` for a description of every available command.


### PR DESCRIPTION
## Summary
- fix import paths and missing parenthesis in CLI
- add project README
- provide setup instructions for the CLI

## Testing
- `go build ./cmd/synnergy` *(fails: undefined host.IntrospectableHost)*
- `go test ./...` *(fails to compile: undefined host.IntrospectableHost)*

------
https://chatgpt.com/codex/tasks/task_e_688b50c60eb08320bd9e8622bd6bfd3f