### PR TITLE
Fix import paths

### DIFF
--- a/synnergy-network/cmd/cli/compliance.go
+++ b/synnergy-network/cmd/cli/compliance.go
@@ -28,8 +28,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-        core "synnergy-network/core" // module local import
-
+	core "synnergy-network/core" // module local import
+)
 
 //---------------------------------------------------------------------
 // Middleware – executed for every ~compliance command

--- a/synnergy-network/cmd/cli/security.go
+++ b/synnergy-network/cmd/cli/security.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	core "github.com/synnergy-network/core"
+	core "synnergy-network/core"
 )
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure imports reference module path `synnergy-network`
- close the import block in `compliance.go`

## Testing
- `go vet ./...` *(fails: context deadline)*
- `go test ./...` *(fails: context deadline)*

------
https://chatgpt.com/codex/tasks/task_e_688b50f1baa08320969ae532ead45a93