### PR TITLE
Improve CLI registration

### DIFF
--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -38,3 +38,9 @@ The following command groups expose the same functionality available in the core
 
 
 To use these groups, import the corresponding command constructor (e.g. `ledger.NewLedgerCommand()`) in your main program and attach it to the root `cobra.Command`.
+
+If you want to enable **all** CLI modules with a single call, use `cli.RegisterRoutes(rootCmd)` from the `cli` package. This helper mounts every exported command group so routes can be invoked like:
+
+```bash
+$ synnergy ~network ~start
+```

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -1,0 +1,47 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+// RegisterRoutes attaches every command group defined in the cli package
+// to the provided root command. Each module exposes its own root command
+// (e.g. NetworkCmd) which aggregates all micro routes such as ~start and
+// ~stop. Calling RegisterRoutes(root) makes all commands available from
+// the main binary so they can be invoked like `synnergy ~network ~start`.
+func RegisterRoutes(root *cobra.Command) {
+	// modules with exported command variables
+	root.AddCommand(
+		NetworkCmd,
+		ConsensusCmd,
+		TokensCmd,
+		CoinCmd,
+		ContractsCmd,
+		VMCmd,
+		TransactionsCmd,
+		WalletCmd,
+		AICmd,
+		AMMCmd,
+		PoolsCmd,
+		AuthCmd,
+		CharityCmd,
+		LoanCmd,
+		ComplianceCmd,
+		CrossChainCmd,
+		DataCmd,
+		ChannelRoute,
+		StorageRoute,
+		UtilityRoute,
+	)
+
+	// modules that expose constructors
+	root.AddCommand(
+		NewFaultToleranceCommand(),
+		NewGovernanceCommand(),
+		NewGreenCommand(),
+		NewLedgerCommand(),
+		NewReplicationCommand(),
+		NewRollupCommand(),
+		NewSecurityCommand(),
+		NewShardingCommand(),
+		NewSidechainCommand(),
+	)
+}

--- a/synnergy-network/cmd/synnergy/main.go
+++ b/synnergy-network/cmd/synnergy/main.go
@@ -12,40 +12,8 @@ func main() {
 		Short: "Synnergy network command line interface",
 	}
 
-	// Register sub‑commands exposed via helper functions.
-	cli.RegisterNetwork(rootCmd)
-	cli.RegisterConsensus(rootCmd)
-	cli.RegisterTokens(rootCmd)
-	cli.RegisterCoin(rootCmd)
-	cli.RegisterContracts(rootCmd)
-	cli.RegisterVM(rootCmd)
-	cli.RegisterTransactions(rootCmd)
-	cli.RegisterWallet(rootCmd)
-
-	// Add commands exported as variables or factories.
-	rootCmd.AddCommand(
-		cli.AICmd,
-		cli.AMMCmd,
-		cli.PoolsCmd,
-		cli.AuthCmd,
-		cli.CharityCmd,
-		cli.LoanCmd,
-		cli.ComplianceCmd,
-		cli.CrossChainCmd,
-		cli.DataCmd,
-		cli.NewFaultToleranceCommand(),
-		cli.NewGovernanceCommand(),
-		cli.NewGreenCommand(),
-		cli.NewLedgerCommand(),
-		cli.NewReplicationCommand(),
-		cli.NewRollupCommand(),
-		cli.NewSecurityCommand(),
-		cli.NewShardingCommand(),
-		cli.NewSidechainCommand(),
-		cli.ChannelRoute,
-		cli.StorageRoute,
-		cli.UtilityRoute,
-	)
+	// Attach all CLI modules via the consolidated registration helper.
+	cli.RegisterRoutes(rootCmd)
 
 	cobra.CheckErr(rootCmd.Execute())
 }


### PR DESCRIPTION
## Summary
- add a `RegisterRoutes` helper in `cmd/cli` to consolidate CLI module wiring
- update the main program to use the new helper
- document the new helper in `cli_guide.md`

## Testing
- `go test ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_688b53d2b8288320bb3d60f074878bd2