### PR TITLE
Update module guide reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ This file tracks compile errors between CLI commands and core modules of the Syn
 30. [ ] wallet.go
 
 ## Module Files
+All modules live under `synnergy-network/core`. For a short description of each
+file, see [`synnergy-network/core/module_guide.md`](synnergy-network/core/module_guide.md).
 1. [ ] ai.go
 2. [ ] amm.go
 3. [ ] authority_nodes.go


### PR DESCRIPTION
## Summary
- clarify where the module files live in `AGENTS.md`

## Testing
- `go vet ./...` *(fails: missing go.sum entry)*
- `go build ./...` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_e_688b5eac56a0832082aa9673430fb19c