### PR TITLE
Fix libp2p host import

### DIFF
--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -17,8 +17,8 @@ import (
 	"time"
 	// Logging & P2P
 	"github.com/ethereum/go-ethereum/accounts/abi"
-	host "github.com/libp2p/go-libp2p-core/host"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	host "github.com/libp2p/go-libp2p/core/host"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )

--- a/synnergy-network/go.mod
+++ b/synnergy-network/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/ipfs/go-cid v0.5.0
 	github.com/joho/godotenv v1.5.1
 	github.com/libp2p/go-libp2p v0.42.0
-	github.com/libp2p/go-libp2p-core v0.20.1
 	github.com/libp2p/go-libp2p-pubsub v0.14.2
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/sirupsen/logrus v1.9.3

--- a/synnergy-network/go.sum
+++ b/synnergy-network/go.sum
@@ -149,8 +149,6 @@ github.com/libp2p/go-libp2p v0.42.0 h1:A8foZk+ZEhZTv0Jb++7xUFlrFhBDv4j2Vh/uq4YX+
 github.com/libp2p/go-libp2p v0.42.0/go.mod h1:4NGcjbD9OIvFiSRb0XueCO19zJ4kSPK5vkyyOUYmMro=
 github.com/libp2p/go-libp2p-asn-util v0.4.1 h1:xqL7++IKD9TBFMgnLPZR6/6iYhawHKHl950SO9L6n94=
 github.com/libp2p/go-libp2p-asn-util v0.4.1/go.mod h1:d/NI6XZ9qxw67b4e+NgpQexCIiFYJjErASrYW4PFDN8=
-github.com/libp2p/go-libp2p-core v0.20.1 h1:fQz4BJyIFmSZAiTbKV8qoYhEH5Dtv/cVhZbG3Ib/+Cw=
-github.com/libp2p/go-libp2p-core v0.20.1/go.mod h1:6zR8H7CvQWgYLsbG4on6oLNSGcyKaYFSEYyDt51+bIY=
 github.com/libp2p/go-libp2p-pubsub v0.14.2 h1:nT5lFHPQOFJcp9CW8hpKtvbpQNdl2udJuzLQWbgRum8=
 github.com/libp2p/go-libp2p-pubsub v0.14.2/go.mod h1:MKPU5vMI8RRFyTP0HfdsF9cLmL1nHAeJm44AxJGJx44=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=


### PR DESCRIPTION
## Summary
- remove deprecated `go-libp2p-core/host` import
- drop unused libp2p-core dependency

## Testing
- `go vet ./core` *(fails: Context redeclared)*
- `go build ./core` *(fails: Context redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_688b677b0b8483209f6dbd674a880abd