### PR TITLE
Fix CLI compile issues for Stage 3

### DIFF
--- a/synnergy-network/cmd/cli/contracts.go
+++ b/synnergy-network/cmd/cli/contracts.go
@@ -42,6 +42,7 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/wasmerio/wasmer-go/wasmer"
 
 	"synnergy-network/core"
 )
@@ -81,7 +82,7 @@ func initContractsMiddleware(cmd *cobra.Command, _ []string) error {
 			return
 		}
 
-		vmSvc = vm.NewEngine(vm.Config{Logger: logger})
+		vmSvc = core.NewHeavyVM(ledger, core.NewGasMeter(8_000_000), wasmer.NewEngine())
 		core.InitContracts(ledger, vmSvc)
 	})
 	return err


### PR DESCRIPTION
## Summary
- add stub security adapter and wire in network, authority, and txpool creation for consensus CLI
- use heavy VM engine in contracts CLI
- update imports

## Testing
- `go vet ./cmd/cli/...` *(fails: cannot use multiaddr.Component)*
- `go build ./cmd/cli/...` *(fails: cannot use multiaddr.Component)*
- `go test ./cmd/cli/...` *(fails: cannot use multiaddr.Component)*

------
https://chatgpt.com/codex/tasks/task_e_688b671500fc83208138feb30c980a7b