### PR TITLE
Resolve CLI name conflicts

### DIFF
--- a/synnergy-network/cmd/cli/ai.go
+++ b/synnergy-network/cmd/cli/ai.go
@@ -152,7 +152,7 @@ var aiCmd = &cobra.Command{
 }
 
 // predict --------------------------------------------------------------------
-var predictCmd = &cobra.Command{
+var aiPredictCmd = &cobra.Command{
 	Use:   "predict [tx.json]",
 	Short: "Predict fraud probability for a transaction",
 	Args:  cobra.ExactArgs(1),
@@ -234,7 +234,7 @@ var fetchCmd = &cobra.Command{
 }
 
 // list -----------------------------------------------------------------------
-var listCmd = &cobra.Command{
+var aiListCmd = &cobra.Command{
 	Use:   "list [price] [cid]",
 	Short: "Create a marketplace listing for a model",
 	Args:  cobra.ExactArgs(2),
@@ -317,12 +317,12 @@ func init() {
 	publishCmd.Flags().Uint16("royalty", 0, "royalty basis points (max 1000 = 10%)")
 
 	// attach sub‑routes
-	aiCmd.AddCommand(predictCmd)
+	aiCmd.AddCommand(aiPredictCmd)
 	aiCmd.AddCommand(optimiseCmd)
 	aiCmd.AddCommand(volumeCmd)
 	aiCmd.AddCommand(publishCmd)
 	aiCmd.AddCommand(fetchCmd)
-	aiCmd.AddCommand(listCmd)
+	aiCmd.AddCommand(aiListCmd)
 	aiCmd.AddCommand(buyCmd)
 	aiCmd.AddCommand(rentCmd)
 	aiCmd.AddCommand(releaseCmd)

--- a/synnergy-network/cmd/cli/authority_node.go
+++ b/synnergy-network/cmd/cli/authority_node.go
@@ -132,7 +132,7 @@ var authCmd = &cobra.Command{
 }
 
 // register -------------------------------------------------------------------
-var registerCmd = &cobra.Command{
+var authRegisterCmd = &cobra.Command{
 	Use:   "register <addr> <role>",
 	Short: "Submit a new authority‑node candidate for a role",
 	Args:  cobra.ExactArgs(2),
@@ -148,7 +148,7 @@ var registerCmd = &cobra.Command{
 }
 
 // vote -----------------------------------------------------------------------
-var voteCmd = &cobra.Command{
+var authVoteCmd = &cobra.Command{
 	Use:   "vote <voterAddr> <candidateAddr>",
 	Short: "Cast a vote for a candidate (deduped and role‑weighted)",
 	Args:  cobra.ExactArgs(2),
@@ -199,7 +199,7 @@ var isCmd = &cobra.Command{
 }
 
 // info -----------------------------------------------------------------------
-var infoCmd = &cobra.Command{
+var authInfoCmd = &cobra.Command{
 	Use:   "info <addr>",
 	Short: "Show details for an authority node",
 	Args:  cobra.ExactArgs(1),
@@ -217,7 +217,7 @@ var infoCmd = &cobra.Command{
 }
 
 // list -----------------------------------------------------------------------
-var listCmd = &cobra.Command{
+var authListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List authority nodes",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -234,7 +234,7 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
-	listCmd.Flags().Bool("active", false, "only show active nodes")
+	authListCmd.Flags().Bool("active", false, "only show active nodes")
 }
 
 // deregister -------------------------------------------------------------
@@ -258,12 +258,12 @@ var deregCmd = &cobra.Command{
 //---------------------------------------------------------------------
 
 func init() {
-	authCmd.AddCommand(registerCmd)
-	authCmd.AddCommand(voteCmd)
+	authCmd.AddCommand(authRegisterCmd)
+	authCmd.AddCommand(authVoteCmd)
 	authCmd.AddCommand(electorateCmd)
 	authCmd.AddCommand(isCmd)
-	authCmd.AddCommand(infoCmd)
-	authCmd.AddCommand(listCmd)
+	authCmd.AddCommand(authInfoCmd)
+	authCmd.AddCommand(authListCmd)
 	authCmd.AddCommand(deregCmd)
 }
 

--- a/synnergy-network/cmd/cli/charity_pool.go
+++ b/synnergy-network/cmd/cli/charity_pool.go
@@ -159,7 +159,7 @@ var charityCmd = &cobra.Command{
 }
 
 // register -------------------------------------------------------------------
-var registerCmd = &cobra.Command{
+var charityRegisterCmd = &cobra.Command{
 	Use:   "register <addr> <category> <name>",
 	Short: "Register a charity (must occur ≥30 days before cycle end)",
 	Args:  cobra.MinimumNArgs(3),
@@ -177,7 +177,7 @@ var registerCmd = &cobra.Command{
 }
 
 // vote -----------------------------------------------------------------------
-var voteCmd = &cobra.Command{
+var charityVoteCmd = &cobra.Command{
 	Use:   "vote <voterAddr> <charityAddr>",
 	Short: "Cast a vote (ID‑token holders only) during last 15d of cycle",
 	Args:  cobra.ExactArgs(2),
@@ -269,8 +269,8 @@ var winnersCmd = &cobra.Command{
 //---------------------------------------------------------------------
 
 func init() {
-	charityCmd.AddCommand(registerCmd)
-	charityCmd.AddCommand(voteCmd)
+	charityCmd.AddCommand(charityRegisterCmd)
+	charityCmd.AddCommand(charityVoteCmd)
 	charityCmd.AddCommand(tickCmd)
 	charityCmd.AddCommand(registrationCmd)
 	charityCmd.AddCommand(winnersCmd)

--- a/synnergy-network/cmd/cli/contracts.go
+++ b/synnergy-network/cmd/cli/contracts.go
@@ -285,8 +285,8 @@ var invokeCmd = &cobra.Command{
 	},
 }
 
-var listCmd = &cobra.Command{Use: "list", Short: "List deployed contracts", Args: cobra.NoArgs, RunE: handleList}
-var infoCmd = &cobra.Command{Use: "info <address>", Short: "Show ricardian manifest", Args: cobra.ExactArgs(1), RunE: handleInfo}
+var contractsListCmd = &cobra.Command{Use: "list", Short: "List deployed contracts", Args: cobra.NoArgs, RunE: handleList}
+var contractsInfoCmd = &cobra.Command{Use: "info <address>", Short: "Show ricardian manifest", Args: cobra.ExactArgs(1), RunE: handleInfo}
 
 func init() {
 	deployCmd.Flags().String("wasm", "", "compiled wasm path")
@@ -297,7 +297,7 @@ func init() {
 	invokeCmd.Flags().String("args", "", "hex‑encoded arg bytes")
 	invokeCmd.Flags().Uint64("gas", 200_000, "gas limit")
 
-	contractsCmd.AddCommand(compileCmd, deployCmd, invokeCmd, listCmd, infoCmd)
+	contractsCmd.AddCommand(compileCmd, deployCmd, invokeCmd, contractsListCmd, contractsInfoCmd)
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/synnergy-network/cmd/cli/cross_chain.go
+++ b/synnergy-network/cmd/cli/cross_chain.go
@@ -94,7 +94,7 @@ var xchainCmd = &cobra.Command{
 }
 
 // register -------------------------------------------------------------------
-var registerCmd = &cobra.Command{
+var xchainRegisterCmd = &cobra.Command{
 	Use:   "register <source_chain> <target_chain> <relayer_addr>",
 	Short: "Register a new bridge configuration (whitelisted relayers only)",
 	Args:  cobra.ExactArgs(3),
@@ -113,7 +113,7 @@ var registerCmd = &cobra.Command{
 }
 
 // list -----------------------------------------------------------------------
-var listCmd = &cobra.Command{
+var xchainListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all registered bridges",
 	Args:  cobra.NoArgs,
@@ -130,7 +130,7 @@ var listCmd = &cobra.Command{
 }
 
 // get ------------------------------------------------------------------------
-var getCmd = &cobra.Command{
+var xchainGetCmd = &cobra.Command{
 	Use:   "get <bridge_id>",
 	Short: "Retrieve a bridge configuration by ID",
 	Args:  cobra.ExactArgs(1),
@@ -186,9 +186,9 @@ var revokeCmd = &cobra.Command{
 //---------------------------------------------------------------------
 
 func init() {
-	xchainCmd.AddCommand(registerCmd)
-	xchainCmd.AddCommand(listCmd)
-	xchainCmd.AddCommand(getCmd)
+	xchainCmd.AddCommand(xchainRegisterCmd)
+	xchainCmd.AddCommand(xchainListCmd)
+	xchainCmd.AddCommand(xchainGetCmd)
 	xchainCmd.AddCommand(authorizeCmd)
 	xchainCmd.AddCommand(revokeCmd)
 }

--- a/synnergy-network/cmd/cli/governance.go
+++ b/synnergy-network/cmd/cli/governance.go
@@ -22,20 +22,20 @@
 package cli
 
 import (
-    "bufio"
-    "context"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "net"
-    "os"
-    "strings"
-    "time"
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
 
-    "github.com/spf13/cobra"
-    "github.com/spf13/viper"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
-    core "synnergy-network/core"
+	core "synnergy-network/core"
 )
 
 // -----------------------------------------------------------------------------
@@ -43,38 +43,38 @@ import (
 // -----------------------------------------------------------------------------
 
 type govClient struct {
-    conn net.Conn
-    rd   *bufio.Reader
+	conn net.Conn
+	rd   *bufio.Reader
 }
 
 func newGovClient(ctx context.Context) (*govClient, error) {
-    addr := viper.GetString("GOVERNANCE_API_ADDR")
-    if addr == "" {
-        addr = "127.0.0.1:7700"
-    }
-    d := net.Dialer{}
-    conn, err := d.DialContext(ctx, "tcp", addr)
-    if err != nil {
-        return nil, fmt.Errorf("cannot connect to governance daemon at %s: %w", addr, err)
-    }
-    return &govClient{conn: conn, rd: bufio.NewReader(conn)}, nil
+	addr := viper.GetString("GOVERNANCE_API_ADDR")
+	if addr == "" {
+		addr = "127.0.0.1:7700"
+	}
+	d := net.Dialer{}
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to governance daemon at %s: %w", addr, err)
+	}
+	return &govClient{conn: conn, rd: bufio.NewReader(conn)}, nil
 }
 
 func (c *govClient) Close() { _ = c.conn.Close() }
 
 func (c *govClient) writeJSON(v any) error {
-    b, err := json.Marshal(v)
-    if err != nil {
-        return err
-    }
-    b = append(b, '\n')
-    _, err = c.conn.Write(b)
-    return err
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	_, err = c.conn.Write(b)
+	return err
 }
 
 func (c *govClient) readJSON(v any) error {
-    dec := json.NewDecoder(c.rd)
-    return dec.Decode(v)
+	dec := json.NewDecoder(c.rd)
+	return dec.Decode(v)
 }
 
 // -----------------------------------------------------------------------------
@@ -82,94 +82,94 @@ func (c *govClient) readJSON(v any) error {
 // -----------------------------------------------------------------------------
 
 func submitProposal(ctx context.Context, changes map[string]string, desc string, deadline time.Duration) (string, error) {
-    cli, err := newGovClient(ctx)
-    if err != nil {
-        return "", err
-    }
-    defer cli.Close()
+	cli, err := newGovClient(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer cli.Close()
 
-    payload := map[string]any{
-        "action":      "propose",
-        "changes":     changes,
-        "description": desc,
-        "deadline":    int64(deadline.Seconds()), // secs from now
-    }
-    if err := cli.writeJSON(payload); err != nil {
-        return "", err
-    }
-    var resp struct {
-        ID    string `json:"id"`
-        Error string `json:"error,omitempty"`
-    }
-    if err := cli.readJSON(&resp); err != nil {
-        return "", err
-    }
-    if resp.Error != "" {
-        return "", errors.New(resp.Error)
-    }
-    return resp.ID, nil
+	payload := map[string]any{
+		"action":      "propose",
+		"changes":     changes,
+		"description": desc,
+		"deadline":    int64(deadline.Seconds()), // secs from now
+	}
+	if err := cli.writeJSON(payload); err != nil {
+		return "", err
+	}
+	var resp struct {
+		ID    string `json:"id"`
+		Error string `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return "", err
+	}
+	if resp.Error != "" {
+		return "", errors.New(resp.Error)
+	}
+	return resp.ID, nil
 }
 
 func castVote(ctx context.Context, id string, approve bool) error {
-    cli, err := newGovClient(ctx)
-    if err != nil {
-        return err
-    }
-    defer cli.Close()
-    return cli.writeJSON(map[string]any{"action": "vote", "id": id, "approve": approve})
+	cli, err := newGovClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	return cli.writeJSON(map[string]any{"action": "vote", "id": id, "approve": approve})
 }
 
 func executeProposal(ctx context.Context, id string) error {
-    cli, err := newGovClient(ctx)
-    if err != nil {
-        return err
-    }
-    defer cli.Close()
-    return cli.writeJSON(map[string]any{"action": "execute", "id": id})
+	cli, err := newGovClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer cli.Close()
+	return cli.writeJSON(map[string]any{"action": "execute", "id": id})
 }
 
 func listProposals(ctx context.Context) ([]core.GovProposal, error) {
-    cli, err := newGovClient(ctx)
-    if err != nil {
-        return nil, err
-    }
-    defer cli.Close()
-    if err := cli.writeJSON(map[string]any{"action": "list"}); err != nil {
-        return nil, err
-    }
-    var resp struct {
-        Proposals []core.GovProposal `json:"proposals"`
-        Error     string            `json:"error,omitempty"`
-    }
-    if err := cli.readJSON(&resp); err != nil {
-        return nil, err
-    }
-    if resp.Error != "" {
-        return nil, errors.New(resp.Error)
-    }
-    return resp.Proposals, nil
+	cli, err := newGovClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "list"}); err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Proposals []core.GovProposal `json:"proposals"`
+		Error     string             `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.Proposals, nil
 }
 
 func getProposal(ctx context.Context, id string) (*core.GovProposal, error) {
-    cli, err := newGovClient(ctx)
-    if err != nil {
-        return nil, err
-    }
-    defer cli.Close()
-    if err := cli.writeJSON(map[string]any{"action": "get", "id": id}); err != nil {
-        return nil, err
-    }
-    var resp struct {
-        Proposal core.GovProposal `json:"proposal"`
-        Error    string          `json:"error,omitempty"`
-    }
-    if err := cli.readJSON(&resp); err != nil {
-        return nil, err
-    }
-    if resp.Error != "" {
-        return nil, errors.New(resp.Error)
-    }
-    return &resp.Proposal, nil
+	cli, err := newGovClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.Close()
+	if err := cli.writeJSON(map[string]any{"action": "get", "id": id}); err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Proposal core.GovProposal `json:"proposal"`
+		Error    string           `json:"error,omitempty"`
+	}
+	if err := cli.readJSON(&resp); err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+	return &resp.Proposal, nil
 }
 
 // -----------------------------------------------------------------------------
@@ -177,127 +177,127 @@ func getProposal(ctx context.Context, id string) (*core.GovProposal, error) {
 // -----------------------------------------------------------------------------
 
 var govCmd = &cobra.Command{
-    Use:     "~gov",
-    Short:   "Network governance & DAO operations",
-    Aliases: []string{"gov", "governance"},
-    PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-        cobra.OnInitialize(initGovConfig)
-        return nil
-    },
+	Use:     "~gov",
+	Short:   "Network governance & DAO operations",
+	Aliases: []string{"gov", "governance"},
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		cobra.OnInitialize(initGovConfig)
+		return nil
+	},
 }
 
 // propose ---------------------------------------------------------------------
 var proposeCmd = &cobra.Command{
-    Use:   "propose",
-    Short: "Submit a new proposal",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        changesStr, _ := cmd.Flags().GetString("changes")
-        desc, _ := cmd.Flags().GetString("desc")
-        dlStr, _ := cmd.Flags().GetString("deadline")
+	Use:   "propose",
+	Short: "Submit a new proposal",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		changesStr, _ := cmd.Flags().GetString("changes")
+		desc, _ := cmd.Flags().GetString("desc")
+		dlStr, _ := cmd.Flags().GetString("deadline")
 
-        if changesStr == "" {
-            return errors.New("--changes required")
-        }
-        changes := map[string]string{}
-        for _, pair := range strings.Split(changesStr, ",") {
-            kv := strings.SplitN(pair, "=", 2)
-            if len(kv) != 2 {
-                return fmt.Errorf("invalid change pair %q", pair)
-            }
-            changes[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
-        }
+		if changesStr == "" {
+			return errors.New("--changes required")
+		}
+		changes := map[string]string{}
+		for _, pair := range strings.Split(changesStr, ",") {
+			kv := strings.SplitN(pair, "=", 2)
+			if len(kv) != 2 {
+				return fmt.Errorf("invalid change pair %q", pair)
+			}
+			changes[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+		}
 
-        deadline := 72 * time.Hour // default 3d
-        if dlStr != "" {
-            d, err := time.ParseDuration(dlStr)
-            if err != nil {
-                return fmt.Errorf("invalid --deadline: %w", err)
-            }
-            deadline = d
-        }
+		deadline := 72 * time.Hour // default 3d
+		if dlStr != "" {
+			d, err := time.ParseDuration(dlStr)
+			if err != nil {
+				return fmt.Errorf("invalid --deadline: %w", err)
+			}
+			deadline = d
+		}
 
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        id, err := submitProposal(ctx, changes, desc, deadline)
-        if err != nil {
-            return err
-        }
-        fmt.Printf("Proposal submitted: %s\n", id)
-        return nil
-    },
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		id, err := submitProposal(ctx, changes, desc, deadline)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Proposal submitted: %s\n", id)
+		return nil
+	},
 }
 
 // vote ------------------------------------------------------------------------
-var voteCmd = &cobra.Command{
-    Use:   "vote [proposal-id]",
-    Short: "Cast a vote on a proposal",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        approve, _ := cmd.Flags().GetBool("approve")
-        ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
-        defer cancel()
-        return castVote(ctx, args[0], approve)
-    },
+var govVoteCmd = &cobra.Command{
+	Use:   "vote [proposal-id]",
+	Short: "Cast a vote on a proposal",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		approve, _ := cmd.Flags().GetBool("approve")
+		ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
+		defer cancel()
+		return castVote(ctx, args[0], approve)
+	},
 }
 
 // execute ---------------------------------------------------------------------
 var execCmd = &cobra.Command{
-    Use:   "execute [proposal-id]",
-    Short: "Execute a proposal after the deadline",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        return executeProposal(ctx, args[0])
-    },
+	Use:   "execute [proposal-id]",
+	Short: "Execute a proposal after the deadline",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		return executeProposal(ctx, args[0])
+	},
 }
 
 // get -------------------------------------------------------------------------
-var getCmd = &cobra.Command{
-    Use:   "get [proposal-id]",
-    Short: "Show a single proposal",
-    Args:  cobra.ExactArgs(1),
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
-        defer cancel()
-        p, err := getProposal(ctx, args[0])
-        if err != nil {
-            return err
-        }
-        enc := json.NewEncoder(os.Stdout)
-        enc.SetIndent("", "  ")
-        return enc.Encode(p)
-    },
+var govGetCmd = &cobra.Command{
+	Use:   "get [proposal-id]",
+	Short: "Show a single proposal",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Second)
+		defer cancel()
+		p, err := getProposal(ctx, args[0])
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(p)
+	},
 }
 
 // list ------------------------------------------------------------------------
-var listCmd = &cobra.Command{
-    Use:   "list",
-    Short: "List all proposals",
-    RunE: func(cmd *cobra.Command, args []string) error {
-        ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
-        defer cancel()
-        props, err := listProposals(ctx)
-        if err != nil {
-            return err
-        }
-        switch viper.GetString("output.format") {
-        case "json":
-            enc := json.NewEncoder(os.Stdout)
-            enc.SetIndent("", "  ")
-            return enc.Encode(props)
-        default:
-            fmt.Printf("%-36s %-20s %-8s %-8s %-5s %s\n", "ID", "Created", "For", "Against", "Exec", "Description")
-            for _, p := range props {
-                execFlag := "no"
-                if p.Executed {
-                    execFlag = "yes"
-                }
-                fmt.Printf("%-36s %-20s %-8d %-8d %-5s %s\n", p.ID, p.Created.Format(time.RFC3339), p.VotesFor, p.VotesAgainst, execFlag, p.Description)
-            }
-            return nil
-        }
-    },
+var govListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all proposals",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
+		defer cancel()
+		props, err := listProposals(ctx)
+		if err != nil {
+			return err
+		}
+		switch viper.GetString("output.format") {
+		case "json":
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(props)
+		default:
+			fmt.Printf("%-36s %-20s %-8s %-8s %-5s %s\n", "ID", "Created", "For", "Against", "Exec", "Description")
+			for _, p := range props {
+				execFlag := "no"
+				if p.Executed {
+					execFlag = "yes"
+				}
+				fmt.Printf("%-36s %-20s %-8d %-8d %-5s %s\n", p.ID, p.Created.Format(time.RFC3339), p.VotesFor, p.VotesAgainst, execFlag, p.Description)
+			}
+			return nil
+		}
+	},
 }
 
 // -----------------------------------------------------------------------------
@@ -305,39 +305,39 @@ var listCmd = &cobra.Command{
 // -----------------------------------------------------------------------------
 
 func initGovConfig() {
-    viper.SetEnvPrefix("synnergy")
-    viper.AutomaticEnv()
+	viper.SetEnvPrefix("synnergy")
+	viper.AutomaticEnv()
 
-    cfg := viper.GetString("config")
-    if cfg != "" {
-        viper.SetConfigFile(cfg)
-    } else {
-        viper.SetConfigName("synnergy")
-        viper.AddConfigPath(".")
-        viper.AddConfigPath("$HOME/.config/synnergy")
-    }
-    _ = viper.ReadInConfig()
+	cfg := viper.GetString("config")
+	if cfg != "" {
+		viper.SetConfigFile(cfg)
+	} else {
+		viper.SetConfigName("synnergy")
+		viper.AddConfigPath(".")
+		viper.AddConfigPath("$HOME/.config/synnergy")
+	}
+	_ = viper.ReadInConfig()
 
-    viper.SetDefault("GOVERNANCE_API_ADDR", "127.0.0.1:7700")
-    viper.SetDefault("output.format", "table")
+	viper.SetDefault("GOVERNANCE_API_ADDR", "127.0.0.1:7700")
+	viper.SetDefault("output.format", "table")
 }
 
 func init() {
-    proposeCmd.Flags().String("changes", "", "comma‑separated key=value list of param changes")
-    proposeCmd.Flags().String("desc", "", "human‑readable description")
-    proposeCmd.Flags().String("deadline", "", "voting deadline as duration (e.g. 48h), default 72h")
+	proposeCmd.Flags().String("changes", "", "comma‑separated key=value list of param changes")
+	proposeCmd.Flags().String("desc", "", "human‑readable description")
+	proposeCmd.Flags().String("deadline", "", "voting deadline as duration (e.g. 48h), default 72h")
 
-    voteCmd.Flags().Bool("approve", true, "vote approve=true / deny=false")
+	govVoteCmd.Flags().Bool("approve", true, "vote approve=true / deny=false")
 
-    listCmd.Flags().StringP("format", "f", "table", "output format: table|json")
-    _ = viper.BindPFlag("output.format", listCmd.Flags().Lookup("format"))
+	govListCmd.Flags().StringP("format", "f", "table", "output format: table|json")
+	_ = viper.BindPFlag("output.format", govListCmd.Flags().Lookup("format"))
 
-    // Register sub‑commands
-    govCmd.AddCommand(proposeCmd)
-    govCmd.AddCommand(voteCmd)
-    govCmd.AddCommand(execCmd)
-    govCmd.AddCommand(getCmd)
-    govCmd.AddCommand(listCmd)
+	// Register sub‑commands
+	govCmd.AddCommand(proposeCmd)
+	govCmd.AddCommand(govVoteCmd)
+	govCmd.AddCommand(execCmd)
+	govCmd.AddCommand(govGetCmd)
+	govCmd.AddCommand(govListCmd)
 }
 
 // NewGovernanceCommand returns a consolidated Cobra command tree for the root

--- a/synnergy-network/cmd/cli/green_technology.go
+++ b/synnergy-network/cmd/cli/green_technology.go
@@ -305,7 +305,7 @@ var throttleCmd = &cobra.Command{
 }
 
 // list ------------------------------------------------------------------------
-var listCmd = &cobra.Command{
+var greenListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List certificates for all validators",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -358,8 +358,8 @@ func init() {
 
 	offsetCmd.Flags().String("kg", "", "offset amount in kg CO₂e")
 
-	listCmd.Flags().StringP("format", "f", "table", "output format: table|json")
-	_ = viper.BindPFlag("output.format", listCmd.Flags().Lookup("format"))
+	greenListCmd.Flags().StringP("format", "f", "table", "output format: table|json")
+	_ = viper.BindPFlag("output.format", greenListCmd.Flags().Lookup("format"))
 
 	// Register sub‑commands
 	greenCmd.AddCommand(usageCmd)
@@ -367,7 +367,7 @@ func init() {
 	greenCmd.AddCommand(certifyCmd)
 	greenCmd.AddCommand(certCmd)
 	greenCmd.AddCommand(throttleCmd)
-	greenCmd.AddCommand(listCmd)
+	greenCmd.AddCommand(greenListCmd)
 }
 
 // NewGreenCommand exposes the consolidated green‑tech command tree.

--- a/synnergy-network/cmd/cli/ledger.go
+++ b/synnergy-network/cmd/cli/ledger.go
@@ -318,7 +318,7 @@ var utxoCmd = &cobra.Command{
 }
 
 // pool ------------------------------------------------------------------------
-var poolCmd = &cobra.Command{
+var ledgerPoolCmd = &cobra.Command{
 	Use:   "pool",
 	Short: "List pending transactions in mem‑pool",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -414,9 +414,9 @@ func init() {
 	_ = viper.BindPFlag("output.format", blockCmd.Flags().Lookup("format"))
 
 	utxoCmd.Flags().Int("limit", 0, "max entries (0=all)")
-	poolCmd.Flags().Int("limit", 0, "max transactions (0=all)")
-	poolCmd.Flags().StringP("format", "f", "table", "output format: table|json")
-	_ = viper.BindPFlag("output.format", poolCmd.Flags().Lookup("format"))
+	ledgerPoolCmd.Flags().Int("limit", 0, "max transactions (0=all)")
+	ledgerPoolCmd.Flags().StringP("format", "f", "table", "output format: table|json")
+	_ = viper.BindPFlag("output.format", ledgerPoolCmd.Flags().Lookup("format"))
 
 	mintCmd.Flags().String("token", "", "token symbol or ID")
 	mintCmd.Flags().String("amount", "", "amount to mint")
@@ -429,7 +429,7 @@ func init() {
 	ledgerCmd.AddCommand(blockCmd)
 	ledgerCmd.AddCommand(balanceCmd)
 	ledgerCmd.AddCommand(utxoCmd)
-	ledgerCmd.AddCommand(poolCmd)
+	ledgerCmd.AddCommand(ledgerPoolCmd)
 	ledgerCmd.AddCommand(mintCmd)
 	ledgerCmd.AddCommand(transferCmd)
 }

--- a/synnergy-network/cmd/cli/replication.go
+++ b/synnergy-network/cmd/cli/replication.go
@@ -167,7 +167,7 @@ var repCmd = &cobra.Command{
 }
 
 // start -----------------------------------------------------------------------
-var startCmd = &cobra.Command{
+var repStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Launch replication goroutines (idempotent)",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -178,7 +178,7 @@ var startCmd = &cobra.Command{
 }
 
 // stop ------------------------------------------------------------------------
-var stopCmd = &cobra.Command{
+var repStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop replication goroutines gracefully",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -189,7 +189,7 @@ var stopCmd = &cobra.Command{
 }
 
 // status ----------------------------------------------------------------------
-var statusCmd = &cobra.Command{
+var repStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show replication subsystem status",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -279,13 +279,13 @@ func initReplConfig() {
 
 func init() {
 	// flag binding for status output format
-	statusCmd.Flags().StringP("format", "f", "table", "output format: table|json")
-	_ = viper.BindPFlag("output.format", statusCmd.Flags().Lookup("format"))
+	repStatusCmd.Flags().StringP("format", "f", "table", "output format: table|json")
+	_ = viper.BindPFlag("output.format", repStatusCmd.Flags().Lookup("format"))
 
 	// sub‑command registration
-	repCmd.AddCommand(startCmd)
-	repCmd.AddCommand(stopCmd)
-	repCmd.AddCommand(statusCmd)
+	repCmd.AddCommand(repStartCmd)
+	repCmd.AddCommand(repStopCmd)
+	repCmd.AddCommand(repStatusCmd)
 	repCmd.AddCommand(replicateCmd)
 	repCmd.AddCommand(requestCmd)
 	repCmd.AddCommand(syncCmd)

--- a/synnergy-network/cmd/cli/rollups.go
+++ b/synnergy-network/cmd/cli/rollups.go
@@ -157,7 +157,7 @@ func infoRPC(ctx context.Context, batchID uint64) (*core.BatchHeader, core.Batch
 	return &resp.Header, resp.State, nil
 }
 
-func listRPC(ctx context.Context, limit int) ([]struct {
+func rollupsListRPC(ctx context.Context, limit int) ([]struct {
 	Header core.BatchHeader `json:"header"`
 	State  core.BatchState  `json:"state"`
 }, error) {
@@ -222,7 +222,7 @@ var rollCmd = &cobra.Command{
 }
 
 // submit ----------------------------------------------------------------------
-var submitCmd = &cobra.Command{
+var rollupsSubmitCmd = &cobra.Command{
 	Use:   "submit",
 	Short: "Submit a new batch (reads tx hashes from flags or stdin)",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -279,7 +279,7 @@ func readHashes(r io.Reader) ([][]byte, error) {
 }
 
 // challenge -------------------------------------------------------------------
-var challengeCmd = &cobra.Command{
+var rollupsChallengeCmd = &cobra.Command{
 	Use:   "challenge [batchID] [txIdx] [proof‑hex…]",
 	Short: "Submit a fraud proof for a batch",
 	Args:  cobra.MinimumNArgs(3),
@@ -307,7 +307,7 @@ var challengeCmd = &cobra.Command{
 }
 
 // finalize --------------------------------------------------------------------
-var finalizeCmd = &cobra.Command{
+var rollupsFinalizeCmd = &cobra.Command{
 	Use:   "finalize [batchID]",
 	Short: "Finalize (or revert) a batch after challenge period",
 	Args:  cobra.ExactArgs(1),
@@ -323,7 +323,7 @@ var finalizeCmd = &cobra.Command{
 }
 
 // info ------------------------------------------------------------------------
-var infoCmd = &cobra.Command{
+var rollupsInfoCmd = &cobra.Command{
 	Use:   "info [batchID]",
 	Short: "Display batch header & state",
 	Args:  cobra.ExactArgs(1),
@@ -348,7 +348,7 @@ var infoCmd = &cobra.Command{
 }
 
 // list ------------------------------------------------------------------------
-var listCmd = &cobra.Command{
+var rollupsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List recent batches",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -356,7 +356,7 @@ var listCmd = &cobra.Command{
 		format := viper.GetString("output.format")
 		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
 		defer cancel()
-		list, err := listRPC(ctx, limit)
+		list, err := rollupsListRPC(ctx, limit)
 		if err != nil {
 			return err
 		}
@@ -421,20 +421,20 @@ func initRollConfig() {
 }
 
 func init() {
-	submitCmd.Flags().String("pre-root", "", "pre‑state root hex (optional)")
-	submitCmd.Flags().String("txs", "", "comma‑separated list of tx hashes (hex32); omit to read from stdin")
-	submitCmd.Flags().String("submitter", "", "submitter address hex")
+	rollupsSubmitCmd.Flags().String("pre-root", "", "pre‑state root hex (optional)")
+	rollupsSubmitCmd.Flags().String("txs", "", "comma‑separated list of tx hashes (hex32); omit to read from stdin")
+	rollupsSubmitCmd.Flags().String("submitter", "", "submitter address hex")
 
-	listCmd.Flags().Int("limit", 10, "max batches to list")
-	listCmd.Flags().StringP("format", "f", "table", "output format: table|json")
-	_ = viper.BindPFlag("output.format", listCmd.Flags().Lookup("format"))
+	rollupsListCmd.Flags().Int("limit", 10, "max batches to list")
+	rollupsListCmd.Flags().StringP("format", "f", "table", "output format: table|json")
+	_ = viper.BindPFlag("output.format", rollupsListCmd.Flags().Lookup("format"))
 
 	// Register sub‑commands
-	rollCmd.AddCommand(submitCmd)
-	rollCmd.AddCommand(challengeCmd)
-	rollCmd.AddCommand(finalizeCmd)
-	rollCmd.AddCommand(infoCmd)
-	rollCmd.AddCommand(listCmd)
+	rollCmd.AddCommand(rollupsSubmitCmd)
+	rollCmd.AddCommand(rollupsChallengeCmd)
+	rollCmd.AddCommand(rollupsFinalizeCmd)
+	rollCmd.AddCommand(rollupsInfoCmd)
+	rollCmd.AddCommand(rollupsListCmd)
 	rollCmd.AddCommand(txsCmd)
 }
 

--- a/synnergy-network/cmd/cli/security.go
+++ b/synnergy-network/cmd/cli/security.go
@@ -230,7 +230,7 @@ var secCmd = &cobra.Command{
 }
 
 // sign ------------------------------------------------------------------------
-var signCmd = &cobra.Command{
+var secSignCmd = &cobra.Command{
 	Use:   "sign",
 	Short: "Sign a message (hex) with a private key (hex)",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -258,7 +258,7 @@ var signCmd = &cobra.Command{
 }
 
 // verify ----------------------------------------------------------------------
-var verifyCmd = &cobra.Command{
+var secVerifyCmd = &cobra.Command{
 	Use:   "verify",
 	Short: "Verify signature",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -486,15 +486,15 @@ func initSecConfig() {
 
 func init() {
 	// sign flags
-	signCmd.Flags().String("algo", "", "algo: ed25519|bls")
-	signCmd.Flags().String("key", "", "private key hex / compressed")
-	signCmd.Flags().String("msg", "", "message hex")
+	secSignCmd.Flags().String("algo", "", "algo: ed25519|bls")
+	secSignCmd.Flags().String("key", "", "private key hex / compressed")
+	secSignCmd.Flags().String("msg", "", "message hex")
 
 	// verify flags
-	verifyCmd.Flags().String("algo", "", "algo: ed25519|bls")
-	verifyCmd.Flags().String("pub", "", "public key hex / compressed")
-	verifyCmd.Flags().String("msg", "", "message hex")
-	verifyCmd.Flags().String("sig", "", "signature hex")
+	secVerifyCmd.Flags().String("algo", "", "algo: ed25519|bls")
+	secVerifyCmd.Flags().String("pub", "", "public key hex / compressed")
+	secVerifyCmd.Flags().String("msg", "", "message hex")
+	secVerifyCmd.Flags().String("sig", "", "signature hex")
 
 	// encrypt / decrypt flags
 	encCmd.Flags().String("key", "", "32‑byte key hex")
@@ -516,8 +516,8 @@ func init() {
 	anomalyCmd.Flags().Float64("value", 0, "value to score")
 
 	// register sub‑commands
-	secCmd.AddCommand(signCmd)
-	secCmd.AddCommand(verifyCmd)
+	secCmd.AddCommand(secSignCmd)
+	secCmd.AddCommand(secVerifyCmd)
 	secCmd.AddCommand(aggregateCmd)
 	secCmd.AddCommand(encCmd)
 	secCmd.AddCommand(decCmd)

--- a/synnergy-network/cmd/cli/sharding.go
+++ b/synnergy-network/cmd/cli/sharding.go
@@ -274,7 +274,7 @@ var mapCmd = &cobra.Command{
 }
 
 // submit ----------------------------------------------------------------------
-var submitCmd = &cobra.Command{
+var shardSubmitCmd = &cobra.Command{
 	Use:   "submit [fromShard] [toShard] [txHash]",
 	Short: "Submit cross‑shard tx header (manual)",
 	Args:  cobra.ExactArgs(3),
@@ -390,7 +390,7 @@ func init() {
 
 	shardCmd.AddCommand(leaderCmd)
 	shardCmd.AddCommand(mapCmd)
-	shardCmd.AddCommand(submitCmd)
+	shardCmd.AddCommand(shardSubmitCmd)
 	shardCmd.AddCommand(pullCmd)
 	shardCmd.AddCommand(reshardCmd)
 	shardCmd.AddCommand(rebalanceCmd)

--- a/synnergy-network/cmd/cli/sidechain.go
+++ b/synnergy-network/cmd/cli/sidechain.go
@@ -171,7 +171,7 @@ func metaRPC(ctx context.Context, id uint32) (map[string]any, error) {
 	return resp.Meta, nil
 }
 
-func listRPC(ctx context.Context) ([]map[string]any, error) {
+func sidechainListRPC(ctx context.Context) ([]map[string]any, error) {
 	cli, err := newSCClient(ctx)
 	if err != nil {
 		return nil, err
@@ -208,7 +208,7 @@ var scCmd = &cobra.Command{
 }
 
 // register --------------------------------------------------------------------
-var registerCmd = &cobra.Command{
+var sideRegisterCmd = &cobra.Command{
 	Use:   "register",
 	Short: "Register new side‑chain (governance only)",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -362,13 +362,13 @@ var metaCmd = &cobra.Command{
 }
 
 // list ------------------------------------------------------------------------
-var listCmd = &cobra.Command{
+var sideListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all registered side‑chains",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Second)
 		defer cancel()
-		list, err := listRPC(ctx)
+		list, err := sidechainListRPC(ctx)
 		if err != nil {
 			return err
 		}
@@ -401,10 +401,10 @@ func initSCConfig() {
 
 func init() {
 	// register flags
-	registerCmd.Flags().Uint32("id", 0, "side‑chain ID")
-	registerCmd.Flags().String("name", "", "human name")
-	registerCmd.Flags().Uint("threshold", 67, "BLS threshold percent")
-	registerCmd.Flags().String("validators", "", "comma‑separated BLS pubkeys hex")
+	sideRegisterCmd.Flags().Uint32("id", 0, "side‑chain ID")
+	sideRegisterCmd.Flags().String("name", "", "human name")
+	sideRegisterCmd.Flags().Uint("threshold", 67, "BLS threshold percent")
+	sideRegisterCmd.Flags().String("validators", "", "comma‑separated BLS pubkeys hex")
 
 	headerCmd.Flags().String("file", "", "path to header JSON file")
 	headerCmd.Flags().Uint32("chain", 0, "chainID")
@@ -424,13 +424,13 @@ func init() {
 	getHeaderCmd.Flags().Uint64("height", 0, "header height")
 
 	// route wiring
-	scCmd.AddCommand(registerCmd)
+	scCmd.AddCommand(sideRegisterCmd)
 	scCmd.AddCommand(headerCmd)
 	scCmd.AddCommand(depositCmd)
 	scCmd.AddCommand(withdrawCmd)
 	scCmd.AddCommand(getHeaderCmd)
 	scCmd.AddCommand(metaCmd)
-	scCmd.AddCommand(listCmd)
+	scCmd.AddCommand(sideListCmd)
 }
 
 // NewSidechainCommand exposes the consolidated CLI route.

--- a/synnergy-network/cmd/cli/utility_functions.go
+++ b/synnergy-network/cmd/cli/utility_functions.go
@@ -10,23 +10,23 @@ package cli
 // ---------------------------------------------------------------------------
 
 import (
-    "bufio"
-    "crypto/sha256"
-    "encoding/hex"
-    "errors"
-    "fmt"
-    "io"
-    "log"
-    "os"
-    "strings"
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
 
-    "golang.org/x/crypto/blake2b"
-    "golang.org/x/crypto/ripemd160"
-    "golang.org/x/crypto/sha3"
+	"golang.org/x/crypto/blake2b"
+	"golang.org/x/crypto/ripemd160"
+	"golang.org/x/crypto/sha3"
 
-    "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 
-    "synnergy-network/core"
+	"synnergy-network/core"
 )
 
 // ---------------------------------------------------------------------------
@@ -34,44 +34,44 @@ import (
 // ---------------------------------------------------------------------------
 
 var utilCmd = &cobra.Command{
-    Use:   "util",
-    Short: "Utility helpers — hashing, conversions, inspection",
+	Use:   "util",
+	Short: "Utility helpers — hashing, conversions, inspection",
 }
 
 var hashCmd = &cobra.Command{
-    Use:   "hash",
-    Short: "Compute a cryptographic hash of the input data",
-    Run:   hashHandler,
+	Use:   "hash",
+	Short: "Compute a cryptographic hash of the input data",
+	Run:   hashHandler,
 }
 
 var shortHashCmd = &cobra.Command{
-    Use:   "short-hash",
-    Short: "Return first4..last4 shorthand of a 32‑byte hash",
-    Run:   shortHashHandler,
+	Use:   "short-hash",
+	Short: "Return first4..last4 shorthand of a 32‑byte hash",
+	Run:   shortHashHandler,
 }
 
 var bytes2AddrCmd = &cobra.Command{
-    Use:   "bytes2addr",
-    Short: "Convert big‑endian bytes (hex) to a 20‑byte address",
-    Run:   bytesToAddressHandler,
+	Use:   "bytes2addr",
+	Short: "Convert big‑endian bytes (hex) to a 20‑byte address",
+	Run:   bytesToAddressHandler,
 }
 
 func init() {
-    // hash flags
-    hashCmd.Flags().StringP("alg", "a", "sha256", "Hash algorithm: sha256 | keccak256 | ripemd160 | blake2b256")
-    hashCmd.Flags().StringP("data", "d", "", "Input data as string – if omitted, reads from STDIN")
-    hashCmd.Flags().StringP("file", "f", "", "Path to file to hash (overrides --data)")
+	// hash flags
+	hashCmd.Flags().StringP("alg", "a", "sha256", "Hash algorithm: sha256 | keccak256 | ripemd160 | blake2b256")
+	hashCmd.Flags().StringP("data", "d", "", "Input data as string – if omitted, reads from STDIN")
+	hashCmd.Flags().StringP("file", "f", "", "Path to file to hash (overrides --data)")
 
-    // short‑hash flags
-    shortHashCmd.Flags().StringP("hash", "s", "", "32‑byte hash hex string [required]")
+	// short‑hash flags
+	shortHashCmd.Flags().StringP("hash", "s", "", "32‑byte hash hex string [required]")
 
-    // bytes2addr flags
-    bytes2AddrCmd.Flags().StringP("bytes", "b", "", "Hex string representing big‑endian bytes [required]")
+	// bytes2addr flags
+	bytes2AddrCmd.Flags().StringP("bytes", "b", "", "Hex string representing big‑endian bytes [required]")
 
-    // Register sub‑commands
-    utilCmd.AddCommand(hashCmd)
-    utilCmd.AddCommand(shortHashCmd)
-    utilCmd.AddCommand(bytes2AddrCmd)
+	// Register sub‑commands
+	utilCmd.AddCommand(hashCmd)
+	utilCmd.AddCommand(shortHashCmd)
+	utilCmd.AddCommand(bytes2AddrCmd)
 }
 
 // ---------------------------------------------------------------------------
@@ -79,88 +79,88 @@ func init() {
 // ---------------------------------------------------------------------------
 
 func hashHandler(cmd *cobra.Command, args []string) {
-    alg, _ := cmd.Flags().GetString("alg")
-    dataStr, _ := cmd.Flags().GetString("data")
-    filePath, _ := cmd.Flags().GetString("file")
+	alg, _ := cmd.Flags().GetString("alg")
+	dataStr, _ := cmd.Flags().GetString("data")
+	filePath, _ := cmd.Flags().GetString("file")
 
-    var data []byte
-    var err error
+	var data []byte
+	var err error
 
-    switch {
-    case filePath != "":
-        data, err = os.ReadFile(filePath)
-        bail(err)
-    case dataStr != "":
-        data = []byte(dataStr)
-    default:
-        // read from STDIN
-        in, err := io.ReadAll(bufio.NewReader(os.Stdin))
-        bail(err)
-        data = in
-    }
+	switch {
+	case filePath != "":
+		data, err = os.ReadFile(filePath)
+		utilBail(err)
+	case dataStr != "":
+		data = []byte(dataStr)
+	default:
+		// read from STDIN
+		in, err := io.ReadAll(bufio.NewReader(os.Stdin))
+		utilBail(err)
+		data = in
+	}
 
-    var sum []byte
-    switch strings.ToLower(alg) {
-    case "sha256":
-        v := sha256.Sum256(data)
-        sum = v[:]
-    case "keccak256":
-        h := sha3.NewLegacyKeccak256()
-        h.Write(data)
-        sum = h.Sum(nil)
-    case "ripemd160":
-        h := ripemd160.New()
-        h.Write(data)
-        raw := h.Sum(nil)
-        // left‑pad to 32 bytes to align with EVM semantics
-        sum = make([]byte, 32)
-        copy(sum[32-len(raw):], raw)
-    case "blake2b256":
-        v := blake2b.Sum256(data)
-        sum = v[:]
-    default:
-        bail(fmt.Errorf("unsupported algorithm: %s", alg))
-    }
+	var sum []byte
+	switch strings.ToLower(alg) {
+	case "sha256":
+		v := sha256.Sum256(data)
+		sum = v[:]
+	case "keccak256":
+		h := sha3.NewLegacyKeccak256()
+		h.Write(data)
+		sum = h.Sum(nil)
+	case "ripemd160":
+		h := ripemd160.New()
+		h.Write(data)
+		raw := h.Sum(nil)
+		// left‑pad to 32 bytes to align with EVM semantics
+		sum = make([]byte, 32)
+		copy(sum[32-len(raw):], raw)
+	case "blake2b256":
+		v := blake2b.Sum256(data)
+		sum = v[:]
+	default:
+		utilBail(fmt.Errorf("unsupported algorithm: %s", alg))
+	}
 
-    fmt.Printf("%x\n", sum)
+	fmt.Printf("%x\n", sum)
 }
 
 func shortHashHandler(cmd *cobra.Command, args []string) {
-    hHex, _ := cmd.Flags().GetString("hash")
-    if hHex == "" {
-        _ = cmd.Usage()
-        bail(errors.New("--hash is required"))
-    }
-    bytes, err := hex.DecodeString(strings.TrimPrefix(hHex, "0x"))
-    bail(err)
-    if len(bytes) != 32 {
-        bail(fmt.Errorf("hash must be 32 bytes, got %d", len(bytes)))
-    }
-    var h core.Hash
-    copy(h[:], bytes)
-    fmt.Println(h.Short())
+	hHex, _ := cmd.Flags().GetString("hash")
+	if hHex == "" {
+		_ = cmd.Usage()
+		utilBail(errors.New("--hash is required"))
+	}
+	bytes, err := hex.DecodeString(strings.TrimPrefix(hHex, "0x"))
+	utilBail(err)
+	if len(bytes) != 32 {
+		utilBail(fmt.Errorf("hash must be 32 bytes, got %d", len(bytes)))
+	}
+	var h core.Hash
+	copy(h[:], bytes)
+	fmt.Println(h.Short())
 }
 
 func bytesToAddressHandler(cmd *cobra.Command, args []string) {
-    bHex, _ := cmd.Flags().GetString("bytes")
-    if bHex == "" {
-        _ = cmd.Usage()
-        bail(errors.New("--bytes is required"))
-    }
-    raw, err := hex.DecodeString(strings.TrimPrefix(bHex, "0x"))
-    bail(err)
-    addr := core.BytesToAddress(raw)
-    fmt.Printf("0x%x\n", addr[:])
+	bHex, _ := cmd.Flags().GetString("bytes")
+	if bHex == "" {
+		_ = cmd.Usage()
+		utilBail(errors.New("--bytes is required"))
+	}
+	raw, err := hex.DecodeString(strings.TrimPrefix(bHex, "0x"))
+	utilBail(err)
+	addr := core.BytesToAddress(raw)
+	fmt.Printf("0x%x\n", addr[:])
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-func bail(err error) {
-    if err != nil {
-        log.Fatalf("❌ %v", err)
-    }
+func utilBail(err error) {
+	if err != nil {
+		log.Fatalf("❌ %v", err)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/synnergy-network/cmd/cli/wallet.go
+++ b/synnergy-network/cmd/cli/wallet.go
@@ -24,27 +24,27 @@ package cli
 // ──────────────────────────────────────────────────────────────────────────────
 
 import (
-    "crypto/aes"
-    "crypto/cipher"
-    "crypto/rand"
-    "crypto/sha256"
-    "encoding/hex"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "io"
-    "io/ioutil"
-    "os"
-    "path/filepath"
-    "strings"
-    "sync"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 
-    "github.com/joho/godotenv"
-    "github.com/sirupsen/logrus"
-    "github.com/spf13/cobra"
-    "golang.org/x/crypto/pbkdf2"
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/pbkdf2"
 
-    "synnergy-network/core"
+	"synnergy-network/core"
 )
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -52,22 +52,27 @@ import (
 // ──────────────────────────────────────────────────────────────────────────────
 
 var (
-    logger = logrus.StandardLogger()
-    once   sync.Once
+	logger = logrus.StandardLogger()
+	once   sync.Once
 )
 
 func initWalletMiddleware(cmd *cobra.Command, _ []string) error {
-    var err error
-    once.Do(func() {
-        _ = godotenv.Load()
-        lvl := os.Getenv("LOG_LEVEL")
-        if lvl == "" { lvl = "info" }
-        l, e := logrus.ParseLevel(lvl)
-        if e != nil { err = e; return }
-        logger.SetLevel(l)
-        core.SetWalletLogger(logger)
-    })
-    return err
+	var err error
+	once.Do(func() {
+		_ = godotenv.Load()
+		lvl := os.Getenv("LOG_LEVEL")
+		if lvl == "" {
+			lvl = "info"
+		}
+		l, e := logrus.ParseLevel(lvl)
+		if e != nil {
+			err = e
+			return
+		}
+		logger.SetLevel(l)
+		core.SetWalletLogger(logger)
+	})
+	return err
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -75,142 +80,199 @@ func initWalletMiddleware(cmd *cobra.Command, _ []string) error {
 // ──────────────────────────────────────────────────────────────────────────────
 
 type keystore struct {
-    Seed   string `json:"seed"`
-    Salt   string `json:"salt"`
-    Nonce  string `json:"nonce"`
-    Cipher string `json:"cipher"`
+	Seed   string `json:"seed"`
+	Salt   string `json:"salt"`
+	Nonce  string `json:"nonce"`
+	Cipher string `json:"cipher"`
 }
 
 func deriveKey(password string, salt []byte) []byte {
-    return pbkdf2.Key([]byte(password), salt, 150_000, 32, sha256.New)
+	return pbkdf2.Key([]byte(password), salt, 150_000, 32, sha256.New)
 }
 
 func encryptSeed(seed []byte, password string) (*keystore, error) {
-    salt := make([]byte, 16); if _, err := rand.Read(salt); err != nil { return nil, err }
-    key := deriveKey(password, salt)
-    block, err := aes.NewCipher(key); if err != nil { return nil, err }
-    gcm, err := cipher.NewGCM(block); if err != nil { return nil, err }
-    nonce := make([]byte, gcm.NonceSize()); if _, err := rand.Read(nonce); err != nil { return nil, err }
-    cipherText := gcm.Seal(nil, nonce, seed, nil)
-    return &keystore{
-        Salt:   hex.EncodeToString(salt),
-        Nonce:  hex.EncodeToString(nonce),
-        Cipher: hex.EncodeToString(cipherText),
-    }, nil
+	salt := make([]byte, 16)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, err
+	}
+	key := deriveKey(password, salt)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	cipherText := gcm.Seal(nil, nonce, seed, nil)
+	return &keystore{
+		Salt:   hex.EncodeToString(salt),
+		Nonce:  hex.EncodeToString(nonce),
+		Cipher: hex.EncodeToString(cipherText),
+	}, nil
 }
 
 func decryptSeed(ks *keystore, password string) ([]byte, error) {
-    salt, _ := hex.DecodeString(ks.Salt)
-    nonce, _ := hex.DecodeString(ks.Nonce)
-    cipherText, _ := hex.DecodeString(ks.Cipher)
-    key := deriveKey(password, salt)
-    block, err := aes.NewCipher(key); if err != nil { return nil, err }
-    gcm, err := cipher.NewGCM(block); if err != nil { return nil, err }
-    return gcm.Open(nil, nonce, cipherText, nil)
+	salt, _ := hex.DecodeString(ks.Salt)
+	nonce, _ := hex.DecodeString(ks.Nonce)
+	cipherText, _ := hex.DecodeString(ks.Cipher)
+	key := deriveKey(password, salt)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return gcm.Open(nil, nonce, cipherText, nil)
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Controller logic
 // ──────────────────────────────────────────────────────────────────────────────
 
-type createFlags struct {
-    bits int
-    out  string
-    pwd  string
+type walletCreateFlags struct {
+	bits int
+	out  string
+	pwd  string
 }
 
 type importFlags struct {
-    mnemonic   string
-    passphrase string
-    pwd        string
-    out        string
+	mnemonic   string
+	passphrase string
+	pwd        string
+	out        string
 }
 
 type addrFlags struct {
-    wallet string
-    pwd    string
-    acct   uint32
-    idx    uint32
+	wallet string
+	pwd    string
+	acct   uint32
+	idx    uint32
 }
 
-type signFlags struct {
-    wallet   string
-    pwd      string
-    acct     uint32
-    idx      uint32
-    txIn     string
-    txOut    string
-    gasPrice uint64
+type walletSignFlags struct {
+	wallet   string
+	pwd      string
+	acct     uint32
+	idx      uint32
+	txIn     string
+	txOut    string
+	gasPrice uint64
 }
 
-func handleCreate(cmd *cobra.Command, _ []string) error {
-    cf := cmd.Context().Value("cflags").(createFlags)
-    w, mnemonic, err := core.NewRandomWallet(cf.bits)
-    if err != nil { return err }
+func walletHandleCreate(cmd *cobra.Command, _ []string) error {
+	cf := cmd.Context().Value("cflags").(walletCreateFlags)
+	w, mnemonic, err := core.NewRandomWallet(cf.bits)
+	if err != nil {
+		return err
+	}
 
-    ks, err := encryptSeed(w.Seed(), cf.pwd)
-    if err != nil { return err }
-    data, _ := json.MarshalIndent(ks, "", "  ")
+	ks, err := encryptSeed(w.Seed(), cf.pwd)
+	if err != nil {
+		return err
+	}
+	data, _ := json.MarshalIndent(ks, "", "  ")
 
-    if cf.out != "" {
-        if err := ioutil.WriteFile(cf.out, data, 0o600); err != nil { return err }
-        fmt.Fprintf(cmd.OutOrStdout(), "wallet saved to %s\n", cf.out)
-    } else {
-        cmd.OutOrStdout().Write(data)
-        fmt.Fprintln(cmd.OutOrStdout())
-    }
-    fmt.Fprintf(cmd.OutOrStdout(), "mnemonic (WRITE IT DOWN): %s\n", mnemonic)
-    return nil
+	if cf.out != "" {
+		if err := ioutil.WriteFile(cf.out, data, 0o600); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "wallet saved to %s\n", cf.out)
+	} else {
+		cmd.OutOrStdout().Write(data)
+		fmt.Fprintln(cmd.OutOrStdout())
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "mnemonic (WRITE IT DOWN): %s\n", mnemonic)
+	return nil
 }
 
 func handleImport(cmd *cobra.Command, _ []string) error {
-    f := cmd.Context().Value("iflags").(importFlags)
-    w, err := core.WalletFromMnemonic(f.mnemonic, f.passphrase)
-    if err != nil { return err }
-    ks, err := encryptSeed(w.Seed(), f.pwd)
-    if err != nil { return err }
-    data, _ := json.MarshalIndent(ks, "", "  ")
-    if f.out != "" {
-        if err := ioutil.WriteFile(f.out, data, 0o600); err != nil { return err }
-        fmt.Fprintf(cmd.OutOrStdout(), "wallet saved to %s\n", f.out)
-    } else {
-        cmd.OutOrStdout().Write(data)
-        fmt.Fprintln(cmd.OutOrStdout())
-    }
-    return nil
+	f := cmd.Context().Value("iflags").(importFlags)
+	w, err := core.WalletFromMnemonic(f.mnemonic, f.passphrase)
+	if err != nil {
+		return err
+	}
+	ks, err := encryptSeed(w.Seed(), f.pwd)
+	if err != nil {
+		return err
+	}
+	data, _ := json.MarshalIndent(ks, "", "  ")
+	if f.out != "" {
+		if err := ioutil.WriteFile(f.out, data, 0o600); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "wallet saved to %s\n", f.out)
+	} else {
+		cmd.OutOrStdout().Write(data)
+		fmt.Fprintln(cmd.OutOrStdout())
+	}
+	return nil
 }
 
 func loadWallet(path, pwd string) (*core.HDWallet, error) {
-    raw, err := ioutil.ReadFile(filepath.Clean(path)); if err != nil { return nil, err }
-    var ks keystore; if err := json.Unmarshal(raw, &ks); err != nil { return nil, err }
-    seed, err := decryptSeed(&ks, pwd); if err != nil { return nil, err }
-    return core.NewHDWalletFromSeed(seed, logger)
+	raw, err := ioutil.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	var ks keystore
+	if err := json.Unmarshal(raw, &ks); err != nil {
+		return nil, err
+	}
+	seed, err := decryptSeed(&ks, pwd)
+	if err != nil {
+		return nil, err
+	}
+	return core.NewHDWalletFromSeed(seed, logger)
 }
 
 func handleAddress(cmd *cobra.Command, _ []string) error {
-    af := cmd.Context().Value("aflags").(addrFlags)
-    w, err := loadWallet(af.wallet, af.pwd); if err != nil { return err }
-    addr, err := w.NewAddress(af.acct, af.idx); if err != nil { return err }
-    fmt.Fprintln(cmd.OutOrStdout(), addr.Hex())
-    return nil
+	af := cmd.Context().Value("aflags").(addrFlags)
+	w, err := loadWallet(af.wallet, af.pwd)
+	if err != nil {
+		return err
+	}
+	addr, err := w.NewAddress(af.acct, af.idx)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), addr.Hex())
+	return nil
 }
 
-func handleSign(cmd *cobra.Command, _ []string) error {
-    sf := cmd.Context().Value("sflags").(signFlags)
-    w, err := loadWallet(sf.wallet, sf.pwd); if err != nil { return err }
-    raw, err := ioutil.ReadFile(sf.txIn); if err != nil { return err }
-    var tx core.Transaction
-    if err := json.Unmarshal(raw, &tx); err != nil { return err }
-    if err := w.SignTx(&tx, sf.acct, sf.idx, sf.gasPrice); err != nil { return err }
-    out, _ := json.MarshalIndent(&tx, "", "  ")
-    if sf.txOut != "" {
-        if err := ioutil.WriteFile(sf.txOut, out, 0o600); err != nil { return err }
-        fmt.Fprintf(cmd.OutOrStdout(), "signed tx written to %s\n", sf.txOut)
-    } else {
-        cmd.OutOrStdout().Write(out)
-        fmt.Fprintln(cmd.OutOrStdout())
-    }
-    return nil
+func walletHandleSign(cmd *cobra.Command, _ []string) error {
+	sf := cmd.Context().Value("sflags").(walletSignFlags)
+	w, err := loadWallet(sf.wallet, sf.pwd)
+	if err != nil {
+		return err
+	}
+	raw, err := ioutil.ReadFile(sf.txIn)
+	if err != nil {
+		return err
+	}
+	var tx core.Transaction
+	if err := json.Unmarshal(raw, &tx); err != nil {
+		return err
+	}
+	if err := w.SignTx(&tx, sf.acct, sf.idx, sf.gasPrice); err != nil {
+		return err
+	}
+	out, _ := json.MarshalIndent(&tx, "", "  ")
+	if sf.txOut != "" {
+		if err := ioutil.WriteFile(sf.txOut, out, 0o600); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "signed tx written to %s\n", sf.txOut)
+	} else {
+		cmd.OutOrStdout().Write(out)
+		fmt.Fprintln(cmd.OutOrStdout())
+	}
+	return nil
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -218,115 +280,121 @@ func handleSign(cmd *cobra.Command, _ []string) error {
 // ──────────────────────────────────────────────────────────────────────────────
 
 var walletCmd = &cobra.Command{
-    Use:               "wallet",
-    Short:             "HD wallet management & tx signing",
-    PersistentPreRunE: initWalletMiddleware,
+	Use:               "wallet",
+	Short:             "HD wallet management & tx signing",
+	PersistentPreRunE: initWalletMiddleware,
 }
 
 var createCmd = &cobra.Command{
-    Use:  "create",
-    Args: cobra.NoArgs,
-    Short: "Generate a new wallet & mnemonic",
-    RunE:  handleCreate,
-    PreRunE: func(cmd *cobra.Command, args []string) error {
-        cf := createFlags{}
-        cf.bits, _ = cmd.Flags().GetInt("bits")
-        cf.out, _ = cmd.Flags().GetString("out")
-        cf.pwd, _ = cmd.Flags().GetString("password")
-        if cf.pwd == "" { return errors.New("--password required") }
-        ctx := context.WithValue(cmd.Context(), "cflags", cf)
-        cmd.SetContext(ctx)
-        return nil
-    },
+	Use:   "create",
+	Args:  cobra.NoArgs,
+	Short: "Generate a new wallet & mnemonic",
+	RunE:  walletHandleCreate,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		cf := walletCreateFlags{}
+		cf.bits, _ = cmd.Flags().GetInt("bits")
+		cf.out, _ = cmd.Flags().GetString("out")
+		cf.pwd, _ = cmd.Flags().GetString("password")
+		if cf.pwd == "" {
+			return errors.New("--password required")
+		}
+		ctx := context.WithValue(cmd.Context(), "cflags", cf)
+		cmd.SetContext(ctx)
+		return nil
+	},
 }
 
 var importCmd = &cobra.Command{
-    Use:   "import",
-    Short: "Import existing mnemonic",
-    Args:  cobra.NoArgs,
-    RunE:  handleImport,
-    PreRunE: func(cmd *cobra.Command, args []string) error {
-        inf := importFlags{}
-        inf.mnemonic, _ = cmd.Flags().GetString("mnemonic")
-        inf.passphrase, _ = cmd.Flags().GetString("passphrase")
-        inf.out, _ = cmd.Flags().GetString("out")
-        inf.pwd, _ = cmd.Flags().GetString("password")
-        if inf.mnemonic == "" || inf.pwd == "" { return errors.New("--mnemonic and --password required") }
-        ctx := context.WithValue(cmd.Context(), "iflags", inf)
-        cmd.SetContext(ctx)
-        return nil
-    },
+	Use:   "import",
+	Short: "Import existing mnemonic",
+	Args:  cobra.NoArgs,
+	RunE:  handleImport,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		inf := importFlags{}
+		inf.mnemonic, _ = cmd.Flags().GetString("mnemonic")
+		inf.passphrase, _ = cmd.Flags().GetString("passphrase")
+		inf.out, _ = cmd.Flags().GetString("out")
+		inf.pwd, _ = cmd.Flags().GetString("password")
+		if inf.mnemonic == "" || inf.pwd == "" {
+			return errors.New("--mnemonic and --password required")
+		}
+		ctx := context.WithValue(cmd.Context(), "iflags", inf)
+		cmd.SetContext(ctx)
+		return nil
+	},
 }
 
 var addressCmd = &cobra.Command{
-    Use:   "address",
-    Short: "Derive address",
-    Args:  cobra.NoArgs,
-    RunE:  handleAddress,
-    PreRunE: func(cmd *cobra.Command, args []string) error {
-        af := addrFlags{}
-        af.wallet, _ = cmd.Flags().GetString("wallet")
-        af.pwd, _ = cmd.Flags().GetString("password")
-        af.acct, _ = cmd.Flags().GetUint32("account")
-        af.idx, _ = cmd.Flags().GetUint32("index")
-        if af.wallet == "" || af.pwd == "" { return errors.New("--wallet and --password required") }
-        ctx := context.WithValue(cmd.Context(), "aflags", af)
-        cmd.SetContext(ctx)
-        return nil
-    },
+	Use:   "address",
+	Short: "Derive address",
+	Args:  cobra.NoArgs,
+	RunE:  handleAddress,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		af := addrFlags{}
+		af.wallet, _ = cmd.Flags().GetString("wallet")
+		af.pwd, _ = cmd.Flags().GetString("password")
+		af.acct, _ = cmd.Flags().GetUint32("account")
+		af.idx, _ = cmd.Flags().GetUint32("index")
+		if af.wallet == "" || af.pwd == "" {
+			return errors.New("--wallet and --password required")
+		}
+		ctx := context.WithValue(cmd.Context(), "aflags", af)
+		cmd.SetContext(ctx)
+		return nil
+	},
 }
 
 var signCmd = &cobra.Command{
-    Use:   "sign",
-    Short: "Sign a transaction JSON",
-    Args:  cobra.NoArgs,
-    RunE:  handleSign,
-    PreRunE: func(cmd *cobra.Command, args []string) error {
-        sf := signFlags{}
-        sf.wallet, _ = cmd.Flags().GetString("wallet")
-        sf.pwd, _ = cmd.Flags().GetString("password")
-        sf.acct, _ = cmd.Flags().GetUint32("account")
-        sf.idx, _ = cmd.Flags().GetUint32("index")
-        sf.txIn, _ = cmd.Flags().GetString("in")
-        sf.txOut, _ = cmd.Flags().GetString("out")
-        sf.gasPrice, _ = cmd.Flags().GetUint64("gas")
-        if sf.wallet == "" || sf.pwd == "" || sf.txIn == "" {
-            return errors.New("--wallet, --password, --in required")
-        }
-        ctx := context.WithValue(cmd.Context(), "sflags", sf)
-        cmd.SetContext(ctx)
-        return nil
-    },
+	Use:   "sign",
+	Short: "Sign a transaction JSON",
+	Args:  cobra.NoArgs,
+	RunE:  walletHandleSign,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		sf := walletSignFlags{}
+		sf.wallet, _ = cmd.Flags().GetString("wallet")
+		sf.pwd, _ = cmd.Flags().GetString("password")
+		sf.acct, _ = cmd.Flags().GetUint32("account")
+		sf.idx, _ = cmd.Flags().GetUint32("index")
+		sf.txIn, _ = cmd.Flags().GetString("in")
+		sf.txOut, _ = cmd.Flags().GetString("out")
+		sf.gasPrice, _ = cmd.Flags().GetUint64("gas")
+		if sf.wallet == "" || sf.pwd == "" || sf.txIn == "" {
+			return errors.New("--wallet, --password, --in required")
+		}
+		ctx := context.WithValue(cmd.Context(), "sflags", sf)
+		cmd.SetContext(ctx)
+		return nil
+	},
 }
 
 func init() {
-    // create flags
-    createCmd.Flags().Int("bits", 128, "entropy bits (128|256)")
-    createCmd.Flags().String("out", "", "output wallet file")
-    createCmd.Flags().String("password", "", "encryption password")
+	// create flags
+	createCmd.Flags().Int("bits", 128, "entropy bits (128|256)")
+	createCmd.Flags().String("out", "", "output wallet file")
+	createCmd.Flags().String("password", "", "encryption password")
 
-    // import flags
-    importCmd.Flags().String("mnemonic", "", "bip39 words")
-    importCmd.Flags().String("passphrase", "", "optional bip39 passphrase")
-    importCmd.Flags().String("password", "", "encryption password")
-    importCmd.Flags().String("out", "", "output wallet file")
+	// import flags
+	importCmd.Flags().String("mnemonic", "", "bip39 words")
+	importCmd.Flags().String("passphrase", "", "optional bip39 passphrase")
+	importCmd.Flags().String("password", "", "encryption password")
+	importCmd.Flags().String("out", "", "output wallet file")
 
-    // address flags
-    addressCmd.Flags().String("wallet", "", "wallet file")
-    addressCmd.Flags().String("password", "", "wallet password")
-    addressCmd.Flags().Uint32("account", 0, "account # (hardened)")
-    addressCmd.Flags().Uint32("index", 0, "index # (hardened)")
+	// address flags
+	addressCmd.Flags().String("wallet", "", "wallet file")
+	addressCmd.Flags().String("password", "", "wallet password")
+	addressCmd.Flags().Uint32("account", 0, "account # (hardened)")
+	addressCmd.Flags().Uint32("index", 0, "index # (hardened)")
 
-    // sign flags
-    signCmd.Flags().String("wallet", "", "wallet file")
-    signCmd.Flags().String("password", "", "wallet password")
-    signCmd.Flags().Uint32("account", 0, "account #")
-    signCmd.Flags().Uint32("index", 0, "index #")
-    signCmd.Flags().String("in", "", "unsigned tx JSON path")
-    signCmd.Flags().String("out", "", "output signed tx path (stdout if empty)")
-    signCmd.Flags().Uint64("gas", 0, "override gas price (wei)")
+	// sign flags
+	signCmd.Flags().String("wallet", "", "wallet file")
+	signCmd.Flags().String("password", "", "wallet password")
+	signCmd.Flags().Uint32("account", 0, "account #")
+	signCmd.Flags().Uint32("index", 0, "index #")
+	signCmd.Flags().String("in", "", "unsigned tx JSON path")
+	signCmd.Flags().String("out", "", "output signed tx path (stdout if empty)")
+	signCmd.Flags().Uint64("gas", 0, "override gas price (wei)")
 
-    walletCmd.AddCommand(createCmd, importCmd, addressCmd, signCmd)
+	walletCmd.AddCommand(createCmd, importCmd, addressCmd, signCmd)
 }
 
 // ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- rename CLI commands to avoid name collisions across files
- update helper functions and structs with unique names
- adjust references after renaming

## Testing
- `go vet ./cmd/cli` *(fails: initMiddleware redeclared, missing packages)*
- `go build ./cmd/cli` *(fails: missing txpool/security packages and unresolved core references)*

------
https://chatgpt.com/codex/tasks/task_e_688be9ffdb3883209791d1bf54df1c26