### PR TITLE
Add Docker support and entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.21 AS builder
+WORKDIR /src
+COPY . .
+RUN cd synnergy-network && go mod download && GOFLAGS="-trimpath" go build -o synnergy ./cmd/synnergy
+
+FROM debian:bullseye-slim
+WORKDIR /app
+COPY --from=builder /src/synnergy-network ./synnergy-network
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh synnergy-network/synnergy
+WORKDIR /app
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd synnergy-network
+
+./synnergy network start &
+NET_PID=$!
+
+./synnergy consensus start &
+CONS_PID=$!
+
+./synnergy replication start &
+REPL_PID=$!
+
+./synnergy vm start &
+VM_PID=$!
+
+echo "Synnergy network running. Press Ctrl+C to stop."
+trap 'kill $NET_PID $CONS_PID $REPL_PID $VM_PID' INT TERM
+wait $NET_PID $CONS_PID $REPL_PID $VM_PID

--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -112,6 +112,19 @@ Additional helper scripts live under `cmd/scripts`.  Running
 `start_synnergy_network.sh` will build the CLI, launch networking, consensus and
 other daemons, then run a demo security command.
 
+
+## Docker
+
+A `Dockerfile` at the repository root allows running Synnergy without a local Go installation.
+Build the image and start a node with:
+
+```bash
+docker build -t synnergy ..
+docker run --rm -it synnergy
+```
+
+The container launches networking, consensus, replication and VM services automatically.
+
 ## Testing
 
 Unit tests are located in the `tests` directory. Run them using:


### PR DESCRIPTION
## Summary
- add Dockerfile for building synnergy
- provide docker-entrypoint.sh to launch services
- document Docker usage in README

## Testing
- `go vet ./cmd/...` *(fails: various undefined references)*

------
https://chatgpt.com/codex/tasks/task_e_688c126da8388320af5e37b844bc7c64