### PR TITLE
Add Explorer GUI and backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,8 @@ contains a basic HTML page, a JavaScript stub and a README to bootstrap
 interfaces such as the wallet, explorer and various marketplaces. These
 projects are designed for web hosting and will evolve alongside the core
 modules.
+- Explorer GUI implemented with backend server `cmd/explorer` and sample
+  smart contract `explorer_utils.sol`.
 
 These upgrades will require corresponding tests and documentation.  Contributors are encouraged to propose additional improvements as they work through the stages.
 

--- a/synnergy-network/.env
+++ b/synnergy-network/.env
@@ -99,3 +99,7 @@ KEYSTORE_PATH=./keystore
 # Security
 # ---------------------------------------------------------------------------
 JWT_SECRET=supersecret
+
+# Explorer server
+EXPLORER_BIND=:8081
+

--- a/synnergy-network/GUI/explorer/app.js
+++ b/synnergy-network/GUI/explorer/app.js
@@ -1,3 +1,12 @@
-// Placeholder for network explorer functionality
-// Calls ledger and transaction smart contract endpoints
-console.log('Network Explorer loaded');
+async function loadBlocks() {
+    const res = await fetch('/api/blocks');
+    const blocks = await res.json();
+    const tbody = document.querySelector('#blocks-table tbody');
+    tbody.innerHTML = '';
+    blocks.slice().reverse().forEach(b => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${b.height}</td><td>${b.hash}</td><td>${b.txs}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+window.onload = loadBlocks;

--- a/synnergy-network/GUI/explorer/assets/logo.svg
+++ b/synnergy-network/GUI/explorer/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#4e5d94"/>
+  <text x="50" y="58" font-size="40" text-anchor="middle" fill="white">S</text>
+</svg>

--- a/synnergy-network/GUI/explorer/index.html
+++ b/synnergy-network/GUI/explorer/index.html
@@ -3,12 +3,26 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Network Explorer</title>
+    <title>Synnergy Explorer</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="styles.css" rel="stylesheet">
 </head>
-<body class="container py-4">
-    <h1 class="display-4">Synnergy Network Explorer</h1>
-    <!-- Explorer interface -->
-    <script src="app.js"></script>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#"><img src="assets/logo.svg" alt="Logo">Explorer</a>
+    </div>
+</nav>
+<div class="container">
+    <h1 class="mt-4">Latest Blocks</h1>
+    <table class="table" id="blocks-table">
+        <thead>
+            <tr><th>Height</th><th>Hash</th><th>Txs</th></tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+<script src="app.js"></script>
 </body>
 </html>

--- a/synnergy-network/GUI/explorer/styles.css
+++ b/synnergy-network/GUI/explorer/styles.css
@@ -1,0 +1,7 @@
+body {
+    padding-top: 60px;
+}
+.navbar-brand img {
+    height: 30px;
+    margin-right: 8px;
+}

--- a/synnergy-network/cmd/config/explorer.yaml
+++ b/synnergy-network/cmd/config/explorer.yaml
@@ -1,0 +1,2 @@
+explorer:
+  listen: ":8081"

--- a/synnergy-network/cmd/explorer/main.go
+++ b/synnergy-network/cmd/explorer/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+
+	"github.com/joho/godotenv"
+	"github.com/spf13/viper"
+
+	core "synnergy-network/core"
+)
+
+func main() {
+	// Load environment variables from project .env if present
+	_ = godotenv.Load(".env")
+	_ = godotenv.Load("../.env")
+	_ = godotenv.Load("synnergy-network/.env")
+
+	viper.AutomaticEnv()
+
+	ledgerPath := viper.GetString("LEDGER_PATH")
+	if ledgerPath == "" {
+		ledgerPath = "./ledger.db"
+	}
+	if err := core.InitLedger(ledgerPath); err != nil {
+		log.Fatalf("ledger init: %v", err)
+	}
+
+	addr := viper.GetString("EXPLORER_BIND")
+	if addr == "" {
+		addr = ":8081"
+	}
+
+	srv := NewServer(addr)
+	log.Printf("Explorer listening on %s", addr)
+	if err := srv.Start(); err != nil {
+		log.Fatalf("server: %v", err)
+	}
+}

--- a/synnergy-network/cmd/explorer/middleware.go
+++ b/synnergy-network/cmd/explorer/middleware.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s", r.Method, r.URL.Path)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/synnergy-network/cmd/explorer/server.go
+++ b/synnergy-network/cmd/explorer/server.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+
+	core "synnergy-network/core"
+)
+
+// Server exposes ledger data over a small HTTP API.
+type Server struct {
+	router     *mux.Router
+	httpServer *http.Server
+}
+
+// NewServer constructs the router and HTTP server.
+func NewServer(addr string) *Server {
+	s := &Server{router: mux.NewRouter()}
+	s.routes()
+	s.httpServer = &http.Server{Addr: addr, Handler: s.router}
+	return s
+}
+
+func (s *Server) Start() error { return s.httpServer.ListenAndServe() }
+
+func (s *Server) routes() {
+	s.router.Use(loggingMiddleware)
+	s.router.HandleFunc("/api/blocks", s.handleBlocks).Methods("GET")
+	s.router.HandleFunc("/api/blocks/{height:[0-9]+}", s.handleBlock).Methods("GET")
+	s.router.HandleFunc("/api/tx/{id}", s.handleTx).Methods("GET")
+	// serve static GUI
+	s.router.PathPrefix("/").Handler(http.FileServer(http.Dir("GUI/explorer")))
+}
+
+func (s *Server) handleBlocks(w http.ResponseWriter, r *http.Request) {
+	led := core.CurrentLedger()
+	if led == nil {
+		http.Error(w, "ledger not initialised", http.StatusInternalServerError)
+		return
+	}
+	blocks := led.Blocks
+	n := len(blocks)
+	start := n - 10
+	if start < 0 {
+		start = 0
+	}
+	out := make([]map[string]interface{}, 0, n-start)
+	for i := start; i < n; i++ {
+		blk := blocks[i]
+		out = append(out, map[string]interface{}{
+			"height": blk.Header.Height,
+			"hash":   blk.Hash().Hex(),
+			"txs":    len(blk.Transactions),
+		})
+	}
+	writeJSON(w, out)
+}
+
+func (s *Server) handleBlock(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	h, _ := strconv.ParseUint(vars["height"], 10, 64)
+	led := core.CurrentLedger()
+	blk, err := led.GetBlock(h)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	writeJSON(w, blk)
+}
+
+func (s *Server) handleTx(w http.ResponseWriter, r *http.Request) {
+	idHex := mux.Vars(r)["id"]
+	id, err := hex.DecodeString(idHex)
+	if err != nil {
+		http.Error(w, "bad tx id", http.StatusBadRequest)
+		return
+	}
+	led := core.CurrentLedger()
+	for _, blk := range led.Blocks {
+		for _, tx := range blk.Transactions {
+			if string(tx.ID()[:]) == string(id) {
+				writeJSON(w, tx)
+				return
+			}
+		}
+	}
+	http.Error(w, "tx not found", http.StatusNotFound)
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	_ = enc.Encode(v)
+}

--- a/synnergy-network/cmd/smart_contracts/explorer_utils.sol
+++ b/synnergy-network/cmd/smart_contracts/explorer_utils.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title ExplorerUtils demonstrates reading ledger data via Synnergy opcodes
+///        defined in core/opcode_dispatcher.go.
+contract ExplorerUtils {
+    // Opcode constants from opcode_dispatcher.go
+    bytes3 private constant LAST_HEIGHT = hex"0E0016"; // LastBlockHeight
+    bytes3 private constant GET_BLOCK   = hex"0E000D"; // GetBlock
+
+    /// @notice Return the current block height recorded by the ledger
+    function lastBlockHeight() public returns (uint64 height) {
+        assembly {
+            let success := call(gas(), 0, LAST_HEIGHT, 0, 0, 0, 32)
+            if iszero(success) { revert(0, 0) }
+            height := mload(0)
+        }
+    }
+
+    /// @notice Query a block hash by height
+    function blockHash(uint64 h) public returns (bytes32 hash) {
+        assembly {
+            mstore(0x0, h)
+            let success := call(gas(), 0, GET_BLOCK, 0x0, 0x20, 0x0, 0x20)
+            if iszero(success) { revert(0, 0) }
+            hash := mload(0x0)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement Explorer GUI with Bootstrap and dynamic block table
- add backend service to serve ledger data via HTTP
- expose logging middleware and config
- include smart contract `ExplorerUtils` demonstrating opcode usage
- document new explorer progress in AGENTS

## Testing
- `go mod tidy`
- `go build ./cmd/explorer` *(failed: interrupted after compile stall)*

------
https://chatgpt.com/codex/tasks/task_e_688c194c13248320bec09a9d2b81307f