### PR TITLE
Add basic DEX screener server and UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,8 @@ modules.
 
 These upgrades will require corresponding tests and documentation.  Contributors are encouraged to propose additional improvements as they work through the stages.
 
+- Added `cmd/dexserver` and expanded `GUI/dex-screener` with Tailwind interface and pool API integration.
+
 ---
 
 This playbook should be kept up to date as the project evolves.  Check off files as they are completed and add new tasks or modules to the roadmap so that future developers have a clear picture of the current status.

--- a/synnergy-network/.env
+++ b/synnergy-network/.env
@@ -99,3 +99,6 @@ KEYSTORE_PATH=./keystore
 # Security
 # ---------------------------------------------------------------------------
 JWT_SECRET=supersecret
+
+# DEX Screener
+DEX_API_ADDR=127.0.0.1:8081

--- a/synnergy-network/GUI/dex-screener/README.md
+++ b/synnergy-network/GUI/dex-screener/README.md
@@ -1,3 +1,6 @@
 # DEX Screener GUI
 
 Shows token charts and provides liquidity pool creation without trading features.
+It relies on `cmd/dexserver` which exposes liquidity pool data from the
+Synnergy node via `/api/pools`. The JavaScript frontend fetches this endpoint and
+renders a simple table of pools using Tailwind CSS.

--- a/synnergy-network/GUI/dex-screener/app.js
+++ b/synnergy-network/GUI/dex-screener/app.js
@@ -1,3 +1,7 @@
-// DEX Screener GUI
-// Displays charts and allows creation of liquidity pools via amm.go
-console.log('DEX Screener loaded');
+import { renderPools } from './components/poolTable.js';
+
+function init() {
+    renderPools();
+}
+
+window.onload = init;

--- a/synnergy-network/GUI/dex-screener/assets/README.md
+++ b/synnergy-network/GUI/dex-screener/assets/README.md
@@ -1,0 +1,1 @@
+Placeholder for icons

--- a/synnergy-network/GUI/dex-screener/components/poolTable.js
+++ b/synnergy-network/GUI/dex-screener/components/poolTable.js
@@ -1,0 +1,17 @@
+export async function renderPools() {
+    const res = await fetch('/api/pools');
+    const pools = await res.json();
+    const tbody = document.getElementById('pools');
+    tbody.innerHTML = '';
+    for (const p of pools) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${p.id}</td>
+            <td>${p.token_a}/${p.token_b}</td>
+            <td>${p.res_a}</td>
+            <td>${p.res_b}</td>
+            <td>${p.fee_bps}</td>
+        `;
+        tbody.appendChild(tr);
+    }
+}

--- a/synnergy-network/GUI/dex-screener/index.html
+++ b/synnergy-network/GUI/dex-screener/index.html
@@ -5,10 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DEX Screener</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="styles/main.css">
 </head>
 <body class="p-4">
-    <h1 class="text-2xl font-bold">DEX Screener</h1>
-    <!-- Charts and liquidity pool creation -->
-    <script src="app.js"></script>
+    <h1 class="text-2xl font-bold mb-4">DEX Screener</h1>
+    <table id="pool-table" class="min-w-full text-left">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Pair</th>
+                <th>Reserve A</th>
+                <th>Reserve B</th>
+                <th>Fee (bps)</th>
+            </tr>
+        </thead>
+        <tbody id="pools"></tbody>
+    </table>
+    <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/synnergy-network/GUI/dex-screener/styles/main.css
+++ b/synnergy-network/GUI/dex-screener/styles/main.css
@@ -1,0 +1,8 @@
+body {
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+#pool-table th, #pool-table td {
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid #e2e8f0;
+}

--- a/synnergy-network/cmd/dexserver/README.md
+++ b/synnergy-network/cmd/dexserver/README.md
@@ -1,0 +1,5 @@
+# dexserver
+
+A small HTTP service exposing AMM liquidity pool data for the DEX Screener GUI.
+It loads the node configuration, initialises the ledger and AMM modules and
+serves `/api/pools` which returns a JSON list of all liquidity pools.

--- a/synnergy-network/cmd/dexserver/main.go
+++ b/synnergy-network/cmd/dexserver/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+
+	config "synnergy-network/cmd/config"
+	core "synnergy-network/core"
+)
+
+// poolView is a public representation of a liquidity pool.
+type poolView struct {
+	ID      core.PoolID  `json:"id"`
+	TokenA  core.TokenID `json:"token_a"`
+	TokenB  core.TokenID `json:"token_b"`
+	ResA    uint64       `json:"res_a"`
+	ResB    uint64       `json:"res_b"`
+	TotalLP uint64       `json:"total_lp"`
+	FeeBps  uint16       `json:"fee_bps"`
+}
+
+func poolsHandler(w http.ResponseWriter, _ *http.Request) {
+	pools := core.Manager().Snapshot()
+	out := make([]poolView, 0, len(pools))
+	for _, p := range pools {
+		pv := poolView{
+			ID:      p.ID,
+			TokenA:  p.TokenA,
+			TokenB:  p.TokenB,
+			ResA:    p.ResA,
+			ResB:    p.ResB,
+			FeeBps:  p.FeeBps,
+			TotalLP: p.TotalLP,
+		}
+		out = append(out, pv)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+func main() {
+	config.LoadConfig(os.Getenv("SYNN_ENV"))
+	if err := core.InitLedger(os.Getenv("LEDGER_PATH")); err != nil {
+		log.Fatalf("ledger init: %v", err)
+	}
+	logger := log.New()
+	core.InitAMM(logger, nil)
+
+	addr := os.Getenv("DEX_API_ADDR")
+	if addr == "" {
+		addr = "127.0.0.1:8081"
+	}
+	http.HandleFunc("/api/pools", poolsHandler)
+	logger.Printf("dexserver listening on %s", addr)
+	logger.Fatal(http.ListenAndServe(addr, nil))
+}

--- a/synnergy-network/cmd/smart_contracts/dex_pool_reader.sol
+++ b/synnergy-network/cmd/smart_contracts/dex_pool_reader.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title DexPoolReader retrieves all AMM pools using custom opcodes
+/// @notice Utilises opcode 0x0F0008 (Liquidity_Pools) from opcode_dispatcher.go
+contract DexPoolReader {
+    function pools() external returns (bytes memory data) {
+        bytes4 opcode = 0x0F0008;
+        assembly {
+            let success := call(gas(), 0, opcode, 0, 0, 0, 0)
+            if iszero(success) { revert(0, 0) }
+            let size := returndatasize()
+            data := mload(0x40)
+            mstore(data, size)
+            let ptr := add(data, 0x20)
+            returndatacopy(ptr, 0, size)
+            mstore(0x40, add(ptr, size))
+        }
+    }
+}

--- a/synnergy-network/core/liquidity_views.go
+++ b/synnergy-network/core/liquidity_views.go
@@ -1,0 +1,34 @@
+package core
+
+// PoolView exposes read-only information about a liquidity pool.
+type PoolView struct {
+	ID      PoolID
+	TokenA  TokenID
+	TokenB  TokenID
+	ResA    uint64
+	ResB    uint64
+	TotalLP uint64
+	FeeBps  uint16
+}
+
+// Snapshot returns a slice of PoolView describing all pools managed by the AMM.
+func (a *AMM) Snapshot() []PoolView {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	out := make([]PoolView, 0, len(a.pools))
+	for _, p := range a.pools {
+		p.mu.RLock()
+		pv := PoolView{
+			ID:      p.ID,
+			TokenA:  p.tokenA,
+			TokenB:  p.tokenB,
+			ResA:    p.resA,
+			ResB:    p.resB,
+			TotalLP: p.totalLP,
+			FeeBps:  p.feeBps,
+		}
+		p.mu.RUnlock()
+		out = append(out, pv)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- create `dexserver` HTTP service for exposing liquidity pools
- expose pool snapshots via new `PoolView` in core
- build a simple Tailwind-based DEX screener GUI that consumes the API
- include Solidity contract `DexPoolReader` showing opcode usage
- document progress in `AGENTS.md`

## Testing
- `go vet ./cmd/dexserver/... ./core/...`
- `go build ./cmd/dexserver`


------
https://chatgpt.com/codex/tasks/task_e_688c193bbaa083208c028c5174205170