### PR TITLE
Add faucet module and CLI

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -74,6 +74,7 @@ all modules from the core library. Highlights include:
 - `storage` – interact with on‑chain storage providers
 - `tokens` – ERC‑20 style token commands
 - `transactions` – build and sign transactions
+- `faucet` – dispense test tokens or coins with rate limits
 - `utility_functions` – assorted helpers
 - `virtual_machine` – run the on‑chain VM service
 - `wallet` – mnemonic generation and signing

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -15,6 +15,7 @@ The Synnergy ecosystem brings together several services:
 - **DEX and AMM** – Native modules manage liquidity pools and cross-chain swaps.
 - **Governance** – Token holders can create proposals and vote on protocol upgrades.
 - **Developer Tooling** – CLI modules, RPC services, and SDKs make integration straightforward.
+- **Faucet Service** – Dispense test coins and tokens to developers with rate limits.
 All services are optional and run as independent modules that plug into the core.
 
 ## Synnergy Network Architecture

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -35,6 +35,7 @@ The following command groups expose the same functionality available in the core
 - **utility_functions** – Miscellaneous helpers shared by other command groups.
 - **virtual_machine** – Execute scripts in the built‑in VM for testing.
 - **wallet** – Generate mnemonics, derive addresses and sign transactions.
+- **faucet** – Dispense test funds with rate limiting.
 
 
 To use these groups, import the corresponding command constructor (e.g. `ledger.NewLedgerCommand()`) in your main program and attach it to the root `cobra.Command`.
@@ -388,3 +389,11 @@ needed in custom tooling.
 | `import` | Import an existing mnemonic. |
 | `address` | Derive an address from a wallet. |
 | `sign` | Sign a transaction JSON using the wallet. |
+
+### faucet
+
+| Sub-command | Description |
+|-------------|-------------|
+| `request <addr>` | Request faucet funds for an address. |
+| `balance` | Display remaining faucet balance. |
+| `config --amount <n> --cooldown <d>` | Update faucet parameters. |

--- a/synnergy-network/cmd/cli/faucet.go
+++ b/synnergy-network/cmd/cli/faucet.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+var (
+	faucet         *core.Faucet
+	faucetOnce     sync.Once
+	faucetAmt      uint64
+	faucetCooldown time.Duration
+	faucetToken    uint32
+)
+
+func faucetInit(cmd *cobra.Command, _ []string) error {
+	var err error
+	faucetOnce.Do(func() {
+		lg := logrus.StandardLogger()
+		led := core.CurrentLedger()
+		if led == nil {
+			err = fmt.Errorf("ledger not initialised")
+			return
+		}
+		faucet = core.NewFaucet(lg, led, core.TokenID(faucetToken), faucetAmt, faucetCooldown)
+	})
+	return err
+}
+
+var faucetCmd = &cobra.Command{
+	Use:               "faucet",
+	Short:             "Dispense test tokens or Synthron coins",
+	PersistentPreRunE: faucetInit,
+}
+
+var faucetRequestCmd = &cobra.Command{
+	Use:   "request <addr>",
+	Short: "Request funds",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := core.StringToAddress(args[0])
+		if err != nil {
+			return err
+		}
+		if err := faucet.Request(addr); err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "ok")
+		return nil
+	},
+}
+
+var faucetBalanceCmd = &cobra.Command{
+	Use:   "balance",
+	Short: "Show faucet balance",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		bal, err := faucet.Balance()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), bal)
+		return nil
+	},
+}
+
+var faucetConfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Update faucet parameters",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		amt, _ := cmd.Flags().GetUint64("amount")
+		cd, _ := cmd.Flags().GetDuration("cooldown")
+		faucet.SetAmount(amt)
+		faucet.SetCooldown(cd)
+		fmt.Fprintln(cmd.OutOrStdout(), "updated")
+		return nil
+	},
+}
+
+func init() {
+	faucetAmt = 1
+	faucetCooldown = time.Hour
+	faucetCmd.PersistentFlags().Uint64Var(&faucetAmt, "amount", faucetAmt, "amount per request")
+	faucetCmd.PersistentFlags().DurationVar(&faucetCooldown, "cooldown", faucetCooldown, "request cooldown")
+	faucetCmd.PersistentFlags().Uint32Var(&faucetToken, "token", 0, "token id (0 for SYNN)")
+
+	faucetConfigCmd.Flags().Uint64("amount", 0, "new amount")
+	faucetConfigCmd.Flags().Duration("cooldown", 0, "new cooldown")
+
+	faucetCmd.AddCommand(faucetRequestCmd, faucetBalanceCmd, faucetConfigCmd)
+}
+
+var FaucetCmd = faucetCmd

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -30,6 +30,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ChannelRoute,
 		StorageRoute,
 		UtilityRoute,
+		FaucetCmd,
 	)
 
 	// modules that expose constructors

--- a/synnergy-network/core/faucet.go
+++ b/synnergy-network/core/faucet.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// FaucetAccount is the default funding account used by the faucet.
+var FaucetAccount Address
+
+func init() {
+	var err error
+	FaucetAccount, err = StringToAddress("0x4661756365744163636f756e7400000000000000")
+	if err != nil {
+		panic("invalid FaucetAccount: " + err.Error())
+	}
+}
+
+// Faucet dispenses test tokens or coins with optional rate limiting.
+type Faucet struct {
+	logger   *logrus.Logger
+	ledger   *Ledger
+	token    TokenID       // 0 means Synthron coin
+	amount   uint64        // amount per request
+	cooldown time.Duration // minimum time between requests per address
+
+	mu   sync.Mutex
+	last map[Address]time.Time
+}
+
+// NewFaucet creates a new faucet bound to the given ledger. The faucet
+// dispenses `amount` of `token` every `cooldown` duration.
+func NewFaucet(lg *logrus.Logger, led *Ledger, token TokenID, amount uint64, cooldown time.Duration) *Faucet {
+	if lg == nil {
+		lg = logrus.StandardLogger()
+	}
+	return &Faucet{
+		logger:   lg,
+		ledger:   led,
+		token:    token,
+		amount:   amount,
+		cooldown: cooldown,
+		last:     make(map[Address]time.Time),
+	}
+}
+
+// Request sends faucet funds to the specified address if the cooldown
+// period has elapsed. It returns an error if the faucet balance is
+// insufficient or if rate limiting blocks the request.
+func (f *Faucet) Request(to Address) error {
+	if f == nil || f.ledger == nil {
+		return errors.New("faucet not initialised")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	now := time.Now().UTC()
+	if ts, ok := f.last[to]; ok {
+		if now.Sub(ts) < f.cooldown {
+			wait := f.cooldown - now.Sub(ts)
+			return fmt.Errorf("faucet: cooldown %s remaining", wait)
+		}
+	}
+
+	if f.token == 0 {
+		if err := f.ledger.Transfer(FaucetAccount, to, f.amount); err != nil {
+			return err
+		}
+	} else {
+		tok, ok := GetToken(f.token)
+		if !ok {
+			return fmt.Errorf("token %d not found", f.token)
+		}
+		if err := tok.Transfer(FaucetAccount, to, f.amount); err != nil {
+			return err
+		}
+	}
+
+	f.last[to] = now
+	f.logger.WithFields(logrus.Fields{"to": to.String(), "amount": f.amount}).Info("faucet dispense")
+	return nil
+}
+
+// Balance returns the current balance held by the faucet account.
+func (f *Faucet) Balance() (uint64, error) {
+	if f == nil || f.ledger == nil {
+		return 0, errors.New("faucet not initialised")
+	}
+	if f.token == 0 {
+		return f.ledger.BalanceOf(FaucetAccount), nil
+	}
+	tok, ok := GetToken(f.token)
+	if !ok {
+		return 0, fmt.Errorf("token %d not found", f.token)
+	}
+	return tok.BalanceOf(FaucetAccount), nil
+}
+
+// SetAmount updates the amount dispensed per request.
+func (f *Faucet) SetAmount(amt uint64) {
+	f.mu.Lock()
+	f.amount = amt
+	f.mu.Unlock()
+}
+
+// SetCooldown modifies the cooldown between requests.
+func (f *Faucet) SetCooldown(d time.Duration) {
+	f.mu.Lock()
+	f.cooldown = d
+	f.mu.Unlock()
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1183,6 +1183,15 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+
+	// ---------------------------------------------------------------------
+	// Faucet
+	// ---------------------------------------------------------------------
+	"NewFaucet":          5_000,
+	"Faucet_Request":     1_000,
+	"Faucet_Balance":     200,
+	"Faucet_SetAmount":   500,
+	"Faucet_SetCooldown": 500,
 }
 
 func init() {

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -96,21 +96,22 @@ func wrap(name string) OpcodeFunc {
 //
 // Category map:
 //
-//	0x01 AI                     0x0F Liquidity
-//	0x02 AMM                    0x10 Loanpool
-//	0x03 Authority              0x11 Network
-//	0x04 Charity                0x12 Replication
-//	0x05 Coin                   0x13 Rollups
-//	0x06 Compliance             0x14 Security
-//	0x07 Consensus              0x15 Sharding
-//	0x08 Contracts              0x16 Sidechains
-//	0x09 CrossChain             0x17 StateChannel
-//	0x0A Data                   0x18 Storage
-//	0x0B FaultTolerance         0x19 Tokens
-//	0x0C Governance             0x1A Transactions
-//	0x0D GreenTech              0x1B Utilities
-//	0x0E Ledger                 0x1C VirtualMachine
-//	                            0x1D Wallet
+//		0x01 AI                     0x0F Liquidity
+//		0x02 AMM                    0x10 Loanpool
+//		0x03 Authority              0x11 Network
+//		0x04 Charity                0x12 Replication
+//		0x05 Coin                   0x13 Rollups
+//		0x06 Compliance             0x14 Security
+//		0x07 Consensus              0x15 Sharding
+//		0x08 Contracts              0x16 Sidechains
+//		0x09 CrossChain             0x17 StateChannel
+//		0x0A Data                   0x18 Storage
+//		0x0B FaultTolerance         0x19 Tokens
+//		0x0C Governance             0x1A Transactions
+//		0x0D GreenTech              0x1B Utilities
+//		0x0E Ledger                 0x1C VirtualMachine
+//	                                 0x1D Wallet
+//	                                 0x1E Faucet
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,13 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// Faucet (0x1E)
+	{"NewFaucet", 0x1E0001},
+	{"Faucet_Request", 0x1E0002},
+	{"Faucet_Balance", 0x1E0003},
+	{"Faucet_SetAmount", 0x1E0004},
+	{"Faucet_SetCooldown", 0x1E0005},
 }
 
 // init wires the catalogue into the live dispatcher.


### PR DESCRIPTION
## Summary
- implement core faucet functionality with rate limiting
- price new faucet opcodes in `gas_table.go`
- register faucet opcodes in `opcode_dispatcher.go`
- wire faucet commands into CLI and route registration
- document faucet usage in README, CLI guide, and whitepaper

## Testing
- `go build ./core/...`
- `go build ./cmd/cli` *(fails: loanpool.go:36:30: cannot use logrus.StandardLogger() as *"log".Logger)*
- `go test ./core/...`


------
https://chatgpt.com/codex/tasks/task_e_688c228eb194832093caa800f4b4c150