### PR TITLE
Add dynamic gas calculator

### DIFF
--- a/synnergy-network/cmd/cli/transactions.go
+++ b/synnergy-network/cmd/cli/transactions.go
@@ -136,8 +136,8 @@ func initTxMiddleware(cmd *cobra.Command, _ []string) error {
 		// 6. Authority (for tx reversal checks)
 		authSvc := core.NewAuthoritySet(txLogger, txLedger)
 
-		// 7. Gas calculator – placeholder flat gas until economics stabilises
-		gasCalc := core.NewFlatGasCalculator(10) // 10 wei per gas unit
+		// 7. Gas calculator – dynamic gas based on opcode costs
+		gasCalc := core.NewDynamicGasCalculator()
 
 		// 8. TxPool
 		txPoolSvc = core.NewTxPool(nil, txLedger, authSvc, gasCalc, p2pSvc, 0)

--- a/synnergy-network/core/helpers.go
+++ b/synnergy-network/core/helpers.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"sync"
 )
 
@@ -60,3 +61,43 @@ func NewFlatGasCalculator(p uint64) *FlatGasCalculator { return &FlatGasCalculat
 
 func (f *FlatGasCalculator) Estimate(_ []byte) (uint64, error)     { return 0, nil }
 func (f *FlatGasCalculator) Calculate(_ string, amt uint64) uint64 { return f.Price * amt }
+
+// ------------------------------------------------------------------
+// DynamicGasCalculator parses bytecode and sums real gas costs
+// ------------------------------------------------------------------
+
+// DynamicGasCalculator implements GasCalculator using the opcode gas table. It
+// estimates gas consumption by decoding 3-byte opcodes from a payload. Each
+// opcode's base cost is retrieved via GasCost. If an unknown opcode is
+// encountered the default gas cost is applied and an error is returned.
+type DynamicGasCalculator struct{}
+
+func NewDynamicGasCalculator() *DynamicGasCalculator { return &DynamicGasCalculator{} }
+
+// Estimate walks the payload, treating it as a sequence of 3-byte opcodes. The
+// total gas cost is the sum of GasCost for each opcode. An error is returned if
+// the payload length is not a multiple of three or if an opcode fails to
+// decode.
+func (d *DynamicGasCalculator) Estimate(payload []byte) (uint64, error) {
+	if len(payload)%3 != 0 {
+		return 0, fmt.Errorf("invalid payload length %d", len(payload))
+	}
+	var total uint64
+	for i := 0; i < len(payload); i += 3 {
+		op, err := ParseOpcode(payload[i : i+3])
+		if err != nil {
+			return 0, err
+		}
+		total += GasCost(op)
+	}
+	return total, nil
+}
+
+// Calculate returns the gas for running the named opcode `amt` times. Unknown
+// names fall back to DefaultGasCost.
+func (d *DynamicGasCalculator) Calculate(name string, amt uint64) uint64 {
+	if op, ok := nameToOp[name]; ok {
+		return GasCost(op) * amt
+	}
+	return DefaultGasCost * amt
+}


### PR DESCRIPTION
## Summary
- implement `DynamicGasCalculator` that sums opcode costs
- switch transactions CLI to use the new calculator

## Testing
- `go vet ./core`
- `go build ./core`
- `go test ./core`
- `go vet ./core ./cmd/cli/...` *(fails: cannot use logrus.StandardLogger)*
- `go build ./cmd/cli` *(fails: loanpool.go etc.)*
- `go test ./tests` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c22d258888320916dab85dd389cc3