### PR TITLE
Add utility scripts and update script guide

### DIFF
--- a/synnergy-network/cmd/scripts/authority_apply.sh
+++ b/synnergy-network/cmd/scripts/authority_apply.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ADDR=${1:?"address"}
+ROLE=${2:-"validator"}
+./synnergy auth register "$ADDR" "$ROLE"

--- a/synnergy-network/cmd/scripts/dao_vote.sh
+++ b/synnergy-network/cmd/scripts/dao_vote.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ID=${1:?"proposal"}
+APPROVE=${2:-true}
+./synnergy ~gov vote "$ID" --approve="$APPROVE"

--- a/synnergy-network/cmd/scripts/faucet_fund.sh
+++ b/synnergy-network/cmd/scripts/faucet_fund.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ADDR=${1:?"address"}
+HOST=${FAUCET_HOST:-"http://localhost:8080"}
+curl -s -X POST -H "Content-Type: application/json" -d "{\"address\":\"$ADDR\"}" "$HOST/fund"

--- a/synnergy-network/cmd/scripts/loanpool_apply.sh
+++ b/synnergy-network/cmd/scripts/loanpool_apply.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CREATOR=${1:?"creator"}
+RECIPIENT=${2:?"recipient"}
+TYPE=${3:-0}
+AMOUNT=${4:-100}
+DESC=${5:-"loan"}
+./synnergy loanpool submit "$CREATOR" "$RECIPIENT" "$TYPE" "$AMOUNT" "$DESC"

--- a/synnergy-network/cmd/scripts/marketplace_list.sh
+++ b/synnergy-network/cmd/scripts/marketplace_list.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PRICE=${1:?"price"}
+CID=${2:?"cid"}
+./synnergy ai list "$PRICE" "$CID"

--- a/synnergy-network/cmd/scripts/script_guide.md
+++ b/synnergy-network/cmd/scripts/script_guide.md
@@ -1,6 +1,6 @@
 # Synnergy Script Guide
 
-This guide documents the utility scripts located in `cmd/scripts`. Each script wraps common `synnergy` CLI commands to showcase typical workflows and to help automate repetitive tasks during development. A working Go toolchain and the compiled `synnergy` binary are required.
+This guide documents the utility scripts located in `cmd/scripts`. Each script wraps common `synnergy` CLI commands to showcase typical workflows and to help automate repetitive tasks during development. The collection now includes helpers for the faucet service, DAO voting, marketplace listings and storage deals. A working Go toolchain and the compiled `synnergy` binary are required.
 
 ## Prerequisites
 
@@ -167,6 +167,48 @@ Pin a file in the storage subsystem.
 
 ```bash
 ./storage_pin.sh <file>
+```
+
+### faucet_fund.sh
+Request coins from the local faucet service.
+
+```bash
+./faucet_fund.sh <address>
+```
+
+### dao_vote.sh
+Cast a vote on a governance proposal.
+
+```bash
+./dao_vote.sh <proposal-id> [approve]
+```
+
+### marketplace_list.sh
+Create an AI marketplace listing for a model.
+
+```bash
+./marketplace_list.sh <price> <cid>
+```
+
+### storage_marketplace_pin.sh
+Pin data and publish a storage listing.
+
+```bash
+./storage_marketplace_pin.sh <file> [provider] [price] [capacity]
+```
+
+### loanpool_apply.sh
+Submit a loan proposal transaction.
+
+```bash
+./loanpool_apply.sh <creator> <recipient> [type] [amount] [desc]
+```
+
+### authority_apply.sh
+Register an authority-node candidate.
+
+```bash
+./authority_apply.sh <address> [role]
 ```
 
 These scripts are intentionally minimal to keep the focus on demonstrating CLI usage. Feel free to modify them or combine commands to suit your workflow.

--- a/synnergy-network/cmd/scripts/storage_marketplace_pin.sh
+++ b/synnergy-network/cmd/scripts/storage_marketplace_pin.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+FILE=${1:?"file"}
+PROVIDER=${2:-"0000000000000000000000000000000000000000"}
+PRICE=${3:-1}
+CAPACITY=${4:-1}
+./synnergy storage pin --file "$FILE" --payer "$PROVIDER"
+./synnergy storage listing:create --provider "$PROVIDER" --price "$PRICE" --capacity "$CAPACITY"


### PR DESCRIPTION
## Summary
- add `faucet_fund.sh`, `dao_vote.sh`, `marketplace_list.sh`
- add `storage_marketplace_pin.sh`, `loanpool_apply.sh`, `authority_apply.sh`
- document new scripts in `script_guide.md`

## Testing
- `go vet ./...` *(fails: various undefined errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c22f90a5c83209db14c41be5fb92b