### PR TITLE
Add DAO module with CLI integration

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -62,6 +62,7 @@ all modules from the core library. Highlights include:
 - `data` – inspect and manage raw data storage
 - `fault_tolerance` – simulate faults and backups
 - `governance` – DAO style governance commands
+- `dao` – create and manage DAOs
 - `green_technology` – sustainability features
 - `ledger` – low level ledger inspection
 - `network` – libp2p networking helpers

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -32,6 +32,7 @@ The native asset powering the network is `SYNTHRON` (ticker: THRON). It has thre
 - **Payment and Transaction Fees** – Every on-chain action consumes gas priced in THRON.
 - **Staking** – Validators must lock tokens to participate in consensus and receive block rewards.
 - **Governance** – Token holders vote on protocol parameters, feature releases, and treasury expenditures.
+- **DAO Module** – Users can create independent DAOs and manage membership directly on-chain.
 
 ### Token Distribution
 Initial supply is minted at genesis with a gradual release schedule:
@@ -56,6 +57,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `data` – Low-level debugging of key/value storage and oracles.
 - `fault_tolerance` – Simulate network failures and snapshot recovery.
 - `governance` – Create proposals and cast votes.
+- `dao` – Create DAOs and manage their members.
 - `green_technology` – Manage energy tracking and carbon offsets.
 - `ledger` – Inspect blocks, accounts, and token metrics.
 - `liquidity_pools` – Create pools and provide liquidity.

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -20,6 +20,7 @@ The following command groups expose the same functionality available in the core
 - **data** – Inspect raw key/value pairs in the underlying data store for debugging.
 - **fault_tolerance** – Inject faults, simulate network partitions and test recovery procedures.
 - **governance** – Create proposals, cast votes and check DAO parameters.
+- **dao** – Manage DAO creation and membership.
 - **green_technology** – View energy metrics and toggle any experimental sustainability features.
 - **ledger** – Inspect blocks, query balances and perform administrative token operations via the ledger daemon.
 - **network** – Manage peer connections and print networking statistics.
@@ -199,6 +200,16 @@ needed in custom tooling.
 | `execute <proposal-id>` | Execute a proposal after the deadline. |
 | `get <proposal-id>` | Display a single proposal. |
 | `list` | List all proposals. |
+
+### dao
+
+| Sub-command | Description |
+|-------------|-------------|
+| `create <name> <creator>` | Create a new DAO. |
+| `join <dao-id> <addr>` | Join an existing DAO. |
+| `leave <dao-id> <addr>` | Leave a DAO. |
+| `info <dao-id>` | Display DAO information. |
+| `list` | List all DAOs. |
 
 ### green_technology
 

--- a/synnergy-network/cmd/cli/dao.go
+++ b/synnergy-network/cmd/cli/dao.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+// helper to decode hex address
+func daoParseAddr(h string) (core.Address, error) {
+	var a core.Address
+	b, err := hex.DecodeString(strings.TrimPrefix(h, "0x"))
+	if err != nil || len(b) != len(a) {
+		return a, fmt.Errorf("invalid address")
+	}
+	copy(a[:], b)
+	return a, nil
+}
+
+var daoCmd = &cobra.Command{
+	Use:   "dao",
+	Short: "Manage DAOs on the network",
+}
+
+var daoCreateCmd = &cobra.Command{
+	Use:   "create <name> <creator>",
+	Short: "Create a new DAO",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		creator, err := daoParseAddr(args[1])
+		if err != nil {
+			return err
+		}
+		d, err := core.CreateDAO(name, creator)
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(d)
+	},
+}
+
+var daoJoinCmd = &cobra.Command{
+	Use:   "join <dao-id> <addr>",
+	Short: "Join an existing DAO",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := daoParseAddr(args[1])
+		if err != nil {
+			return err
+		}
+		return core.JoinDAO(args[0], addr)
+	},
+}
+
+var daoLeaveCmd = &cobra.Command{
+	Use:   "leave <dao-id> <addr>",
+	Short: "Leave a DAO",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := daoParseAddr(args[1])
+		if err != nil {
+			return err
+		}
+		return core.LeaveDAO(args[0], addr)
+	},
+}
+
+var daoInfoCmd = &cobra.Command{
+	Use:   "info <dao-id>",
+	Short: "Show DAO details",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		d, err := core.DAOInfo(args[0])
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(d)
+	},
+}
+
+var daoListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all DAOs",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ds, err := core.ListDAOs()
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(ds)
+	},
+}
+
+func init() {
+	daoCmd.AddCommand(daoCreateCmd, daoJoinCmd, daoLeaveCmd, daoInfoCmd, daoListCmd)
+}
+
+// Exported for index.go
+var DAOCmd = daoCmd

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -23,6 +23,7 @@ func RegisterRoutes(root *cobra.Command) {
 		PoolsCmd,
 		AuthCmd,
 		CharityCmd,
+		DAOCmd,
 		LoanCmd,
 		ComplianceCmd,
 		CrossChainCmd,

--- a/synnergy-network/core/dao.go
+++ b/synnergy-network/core/dao.go
@@ -1,0 +1,147 @@
+package core
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DAO represents a decentralised autonomous organisation managed on chain.
+type DAO struct {
+	ID      string          `json:"id"`
+	Name    string          `json:"name"`
+	Creator Address         `json:"creator"`
+	Members map[string]bool `json:"members"`
+	Created time.Time       `json:"created"`
+}
+
+var (
+	// ErrDAOExists is returned when attempting to create a DAO with an existing ID.
+	ErrDAOExists = errors.New("dao already exists")
+	// ErrDAONotFound indicates the requested DAO is missing from the store.
+	ErrDAONotFound = errors.New("dao not found")
+	// ErrMemberExists is returned when a member already belongs to the DAO.
+	ErrMemberExists = errors.New("member already added")
+	// ErrMemberMissing is returned when a member is not part of the DAO.
+	ErrMemberMissing = errors.New("member not part of dao")
+)
+
+// CreateDAO initialises a new DAO with the given name and creator.
+func CreateDAO(name string, creator Address) (*DAO, error) {
+	if name == "" {
+		return nil, errors.New("name required")
+	}
+	id := uuid.New().String()
+	key := fmt.Sprintf("dao:meta:%s", id)
+	raw, err := CurrentStore().Get([]byte(key))
+	if err != nil {
+		return nil, err
+	}
+	if raw != nil {
+		return nil, ErrDAOExists
+	}
+	d := &DAO{
+		ID:      id,
+		Name:    name,
+		Creator: creator,
+		Members: map[string]bool{hex.EncodeToString(creator[:]): true},
+		Created: time.Now().UTC(),
+	}
+	data, _ := json.Marshal(d)
+	if err := CurrentStore().Set([]byte(key), data); err != nil {
+		return nil, err
+	}
+	Broadcast("dao:new", data)
+	return d, nil
+}
+
+// JoinDAO registers a new member with an existing DAO.
+func JoinDAO(id string, member Address) error {
+	key := fmt.Sprintf("dao:meta:%s", id)
+	raw, err := CurrentStore().Get([]byte(key))
+	if err != nil {
+		return err
+	}
+	if raw == nil {
+		return ErrDAONotFound
+	}
+	var d DAO
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return err
+	}
+	m := hex.EncodeToString(member[:])
+	if d.Members[m] {
+		return ErrMemberExists
+	}
+	d.Members[m] = true
+	updated, _ := json.Marshal(&d)
+	if err := CurrentStore().Set([]byte(key), updated); err != nil {
+		return err
+	}
+	Broadcast("dao:join", updated)
+	return nil
+}
+
+// LeaveDAO removes a member from the DAO.
+func LeaveDAO(id string, member Address) error {
+	key := fmt.Sprintf("dao:meta:%s", id)
+	raw, err := CurrentStore().Get([]byte(key))
+	if err != nil {
+		return err
+	}
+	if raw == nil {
+		return ErrDAONotFound
+	}
+	var d DAO
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return err
+	}
+	m := hex.EncodeToString(member[:])
+	if !d.Members[m] {
+		return ErrMemberMissing
+	}
+	delete(d.Members, m)
+	updated, _ := json.Marshal(&d)
+	if err := CurrentStore().Set([]byte(key), updated); err != nil {
+		return err
+	}
+	Broadcast("dao:leave", updated)
+	return nil
+}
+
+// DAOInfo returns metadata for the DAO with the given ID.
+func DAOInfo(id string) (*DAO, error) {
+	key := fmt.Sprintf("dao:meta:%s", id)
+	raw, err := CurrentStore().Get([]byte(key))
+	if err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return nil, ErrDAONotFound
+	}
+	var d DAO
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+// ListDAOs returns all DAOs stored on chain.
+func ListDAOs() ([]DAO, error) {
+	it := CurrentStore().Iterator([]byte("dao:meta:"), nil)
+	var out []DAO
+	for it.Next() {
+		var d DAO
+		if err := json.Unmarshal(it.Value(), &d); err == nil {
+			out = append(out, d)
+		}
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	return out, it.Close()
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -769,6 +769,11 @@ var gasNames = map[string]uint64{
 	"ExecuteProposal": 15_000,
 	"GetProposal":     1_000,
 	"ListProposals":   2_000,
+	"CreateDAO":       10_000,
+	"JoinDAO":         3_000,
+	"LeaveDAO":        2_000,
+	"DAOInfo":         1_000,
+	"ListDAOs":        2_000,
 
 	// ----------------------------------------------------------------------
 	// Green Technology

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -238,6 +238,11 @@ var catalogue = []struct {
 	{"ExecuteProposal", 0x0C0008},
 	{"GetProposal", 0x0C0009},
 	{"ListProposals", 0x0C000A},
+	{"CreateDAO", 0x0C000B},
+	{"JoinDAO", 0x0C000C},
+	{"LeaveDAO", 0x0C000D},
+	{"DAOInfo", 0x0C000E},
+	{"ListDAOs", 0x0C000F},
 
 	// GreenTech (0x0D)
 	{"InitGreenTech", 0x0D0001},

--- a/synnergy-network/tests/dao_test.go
+++ b/synnergy-network/tests/dao_test.go
@@ -1,0 +1,38 @@
+package core_test
+
+import (
+	"fmt"
+	core "synnergy-network/core"
+	"testing"
+)
+
+func TestDAOLifecycle(t *testing.T) {
+	core.SetStore(core.NewInMemoryStore())
+	creator := core.Address{1}
+	dao, err := core.CreateDAO("TestDAO", creator)
+	if err != nil {
+		t.Fatalf("create err %v", err)
+	}
+
+	member := core.Address{2}
+	if err := core.JoinDAO(dao.ID, member); err != nil {
+		t.Fatalf("join err %v", err)
+	}
+
+	info, err := core.DAOInfo(dao.ID)
+	if err != nil {
+		t.Fatalf("info err %v", err)
+	}
+	key := fmt.Sprintf("%x", member[:])
+	if !info.Members[key] {
+		t.Fatalf("member not recorded")
+	}
+
+	if err := core.LeaveDAO(dao.ID, member); err != nil {
+		t.Fatalf("leave err %v", err)
+	}
+	list, err := core.ListDAOs()
+	if err != nil || len(list) == 0 {
+		t.Fatalf("list err %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `core/dao.go` providing DAO creation and membership management
- register new DAO opcodes and gas costs
- expose new `dao` commands in the CLI and index
- document DAO usage in README, cli_guide and whitepaper
- add basic DAO lifecycle test

## Testing
- `go vet ./core/...` passed
- `go vet ./cmd/cli` failed: `loanpool.go:36:30: cannot use logrus.StandardLogger()`
- `go build ./core/...` succeeded
- `go build ./cmd/cli` failed with multiple errors
- `go test ./core/... ./tests/...` failed to build existing tests

------
https://chatgpt.com/codex/tasks/task_e_688c23567594832094cbad702eeba9af