### PR TITLE
Add marketplace module and CLI

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -72,6 +72,7 @@ all modules from the core library. Highlights include:
 - `sidechain` – launch and interact with sidechains
 - `state_channel` – open and settle payment channels
 - `storage` – interact with on‑chain storage providers
+- `marketplace` – buy and sell items using escrow
 - `tokens` – ERC‑20 style token commands
 - `transactions` – build and sign transactions
 - `utility_functions` – assorted helpers

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -68,6 +68,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `sidechain` – Launch or interact with auxiliary chains.
 - `state_channel` – Open and settle payment channels.
 - `storage` – Manage off-chain storage deals.
+- `marketplace` – General on-chain marketplace for digital goods.
 - `tokens` – Issue and manage token contracts.
 - `transactions` – Build and broadcast transactions manually.
 - `utility_functions` – Miscellaneous support utilities.

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -341,6 +341,19 @@ needed in custom tooling.
 | `deal:get` | Get details for a storage deal. |
 | `deal:list` | List storage deals. |
 
+### marketplace
+
+| Sub-command | Description |
+|-------------|-------------|
+| `listing:create <price> <metaJSON>` | Create a marketplace listing. |
+| `listing:get <id>` | Fetch a listing by ID. |
+| `listing:list` | List marketplace listings. |
+| `buy <id> <buyer>` | Purchase a listing via escrow. |
+| `cancel <id>` | Cancel an unsold listing. |
+| `release <escrow>` | Release escrow funds to seller. |
+| `deal:get <id>` | Retrieve deal details. |
+| `deal:list` | List marketplace deals. |
+
 ### tokens
 
 | Sub-command | Description |

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -29,6 +29,7 @@ func RegisterRoutes(root *cobra.Command) {
 		DataCmd,
 		ChannelRoute,
 		StorageRoute,
+		MarketplaceCmd,
 		UtilityRoute,
 	)
 

--- a/synnergy-network/cmd/cli/marketplace.go
+++ b/synnergy-network/cmd/cli/marketplace.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"synnergy-network/core"
+)
+
+func mpParseAddr(hexStr string) (core.Address, error) {
+	var a core.Address
+	b, err := hex.DecodeString(strings.TrimPrefix(hexStr, "0x"))
+	if err != nil || len(b) != len(a) {
+		return a, fmt.Errorf("invalid address")
+	}
+	copy(a[:], b)
+	return a, nil
+}
+
+var marketCmd = &cobra.Command{
+	Use:   "marketplace",
+	Short: "General marketplace operations",
+}
+
+var mpListCreateCmd = &cobra.Command{
+	Use:   "listing:create [price] [metadata-json]",
+	Short: "Create a marketplace listing",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		price, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil || price == 0 {
+			return fmt.Errorf("invalid price")
+		}
+		var meta map[string]string
+		if err := json.Unmarshal([]byte(args[1]), &meta); err != nil {
+			return fmt.Errorf("invalid meta JSON: %w", err)
+		}
+		listing := &core.MarketListing{Seller: core.ModuleAddress("cli"), Price: price, Meta: meta}
+		if err := core.CreateMarketListing(listing); err != nil {
+			return err
+		}
+		out, _ := json.MarshalIndent(listing, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	},
+}
+
+var mpListGetCmd = &cobra.Command{
+	Use:   "listing:get [id]",
+	Short: "Get a marketplace listing",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		l, err := core.GetMarketListing(args[0])
+		if err != nil {
+			return err
+		}
+		out, _ := json.MarshalIndent(l, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	},
+}
+
+var mpListCmd = &cobra.Command{
+	Use:   "listing:list",
+	Short: "List marketplace listings",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		lst, err := core.ListMarketListings(nil)
+		if err != nil {
+			return err
+		}
+		out, _ := json.MarshalIndent(lst, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	},
+}
+
+var mpBuyCmd = &cobra.Command{
+	Use:   "buy [listing-id] [buyer]",
+	Short: "Purchase a listing",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := mpParseAddr(args[1])
+		if err != nil {
+			return err
+		}
+		deal, err := core.PurchaseItem(&core.Context{}, args[0], addr)
+		if err != nil {
+			return err
+		}
+		out, _ := json.MarshalIndent(deal, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	},
+}
+
+var mpCancelCmd = &cobra.Command{
+	Use:   "cancel [listing-id]",
+	Short: "Cancel an open listing",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return core.CancelListing(args[0])
+	},
+}
+
+var mpReleaseCmd = &cobra.Command{
+	Use:   "release [escrow-id]",
+	Short: "Release escrow funds",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return core.ReleaseFunds(&core.Context{}, args[0])
+	},
+}
+
+var mpDealGetCmd = &cobra.Command{
+	Use:   "deal:get [id]",
+	Short: "Get deal details",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		d, err := core.GetMarketDeal(args[0])
+		if err != nil {
+			return err
+		}
+		out, _ := json.MarshalIndent(d, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	},
+}
+
+var mpDealListCmd = &cobra.Command{
+	Use:   "deal:list",
+	Short: "List marketplace deals",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ds, err := core.ListMarketDeals(nil)
+		if err != nil {
+			return err
+		}
+		out, _ := json.MarshalIndent(ds, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	},
+}
+
+func init() {
+	marketCmd.AddCommand(mpListCreateCmd)
+	marketCmd.AddCommand(mpListGetCmd)
+	marketCmd.AddCommand(mpListCmd)
+	marketCmd.AddCommand(mpBuyCmd)
+	marketCmd.AddCommand(mpCancelCmd)
+	marketCmd.AddCommand(mpReleaseCmd)
+	marketCmd.AddCommand(mpDealGetCmd)
+	marketCmd.AddCommand(mpDealListCmd)
+}
+
+// MarketplaceCmd is the exported command group.
+var MarketplaceCmd = marketCmd

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -368,6 +368,15 @@ var gasTable map[Opcode]uint64
    ListListings:  1_000,
    GetDeal:       1_000,
    ListDeals:     1_000,
+        // General Marketplace
+        CreateMarketListing:  8_000,
+        PurchaseItem:        6_000,
+        CancelListing:       3_000,
+        ReleaseFunds:        2_000,
+        GetMarketListing:    1_000,
+        ListMarketListings:  1_000,
+        GetMarketDeal:       1_000,
+        ListMarketDeals:     1_000,
    // Pin & Retrieve already priced
 
    // ----------------------------------------------------------------------
@@ -944,6 +953,15 @@ var gasNames = map[string]uint64{
 	"ListListings":  1_000,
 	"GetDeal":       1_000,
 	"ListDeals":     1_000,
+	// General Marketplace
+	"CreateMarketListing": 8_000,
+	"PurchaseItem":        6_000,
+	"CancelListing":       3_000,
+	"ReleaseFunds":        2_000,
+	"GetMarketListing":    1_000,
+	"ListMarketListings":  1_000,
+	"GetMarketDeal":       1_000,
+	"ListMarketDeals":     1_000,
 	// Pin & Retrieve already priced
 
 	// ----------------------------------------------------------------------

--- a/synnergy-network/core/marketplace.go
+++ b/synnergy-network/core/marketplace.go
@@ -1,0 +1,240 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// MarketListing represents a generic item listed for sale on chain.
+type MarketListing struct {
+	ID        string            `json:"id"`
+	Seller    Address           `json:"seller"`
+	Price     uint64            `json:"price"`
+	Meta      map[string]string `json:"meta,omitempty"`
+	CreatedAt time.Time         `json:"created_at"`
+	Sold      bool              `json:"sold"`
+	Buyer     Address           `json:"buyer"`
+}
+
+// MarketDeal tracks a purchase backed by escrow.
+type MarketDeal struct {
+	ID        string     `json:"id"`
+	ListingID string     `json:"listing_id"`
+	Buyer     Address    `json:"buyer"`
+	EscrowID  string     `json:"escrow_id"`
+	CreatedAt time.Time  `json:"created_at"`
+	Closed    bool       `json:"closed"`
+	ClosedAt  *time.Time `json:"closed_at,omitempty"`
+}
+
+func saveMarketListing(l *MarketListing) error {
+	key := fmt.Sprintf("market:list:%s", l.ID)
+	raw, err := json.Marshal(l)
+	if err != nil {
+		return err
+	}
+	return CurrentStore().Set([]byte(key), raw)
+}
+
+// CreateMarketListing registers a new listing for sale.
+func CreateMarketListing(l *MarketListing) error {
+	if l == nil {
+		return fmt.Errorf("nil listing")
+	}
+	if l.Price == 0 {
+		return fmt.Errorf("price must be positive")
+	}
+	if l.ID == "" {
+		l.ID = uuid.New().String()
+	}
+	l.CreatedAt = time.Now().UTC()
+	return saveMarketListing(l)
+}
+
+// GetMarketListing retrieves a listing by ID.
+func GetMarketListing(id string) (*MarketListing, error) {
+	key := fmt.Sprintf("market:list:%s", id)
+	raw, err := CurrentStore().Get([]byte(key))
+	if err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return nil, fmt.Errorf("listing not found")
+	}
+	var l MarketListing
+	if err := json.Unmarshal(raw, &l); err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
+// ListMarketListings returns all listings or those by a specific seller.
+func ListMarketListings(seller *Address) ([]MarketListing, error) {
+	it := CurrentStore().Iterator([]byte("market:list:"), nil)
+	defer it.Close()
+	var out []MarketListing
+	for it.Next() {
+		var l MarketListing
+		if err := json.Unmarshal(it.Value(), &l); err != nil {
+			continue
+		}
+		if seller != nil && l.Seller != *seller {
+			continue
+		}
+		out = append(out, l)
+	}
+	return out, it.Error()
+}
+
+// CancelListing removes a listing that has not yet been sold.
+func CancelListing(id string) error {
+	l, err := GetMarketListing(id)
+	if err != nil {
+		return err
+	}
+	if l.Sold {
+		return fmt.Errorf("cannot cancel sold listing")
+	}
+	key := fmt.Sprintf("market:list:%s", id)
+	return CurrentStore().Delete([]byte(key))
+}
+
+// PurchaseItem buys a listing and creates an escrow-backed deal.
+func PurchaseItem(ctx *Context, listingID string, buyer Address) (*MarketDeal, error) {
+	logger := zap.L().Sugar()
+
+	l, err := GetMarketListing(listingID)
+	if err != nil {
+		return nil, err
+	}
+	if l.Sold {
+		return nil, fmt.Errorf("listing already sold")
+	}
+
+	escrowAcc := ModuleAddress("marketplace")
+	if err := Transfer(ctx, AssetRef{Kind: AssetCoin}, buyer, escrowAcc, l.Price); err != nil {
+		return nil, err
+	}
+
+	esc := &Escrow{
+		ID:     uuid.New().String(),
+		Buyer:  buyer,
+		Seller: l.Seller,
+		Amount: l.Price,
+		State:  "funded",
+	}
+	escKey := fmt.Sprintf("market:escrow:%s", esc.ID)
+	escRaw, _ := json.Marshal(esc)
+	if err := CurrentStore().Set([]byte(escKey), escRaw); err != nil {
+		return nil, err
+	}
+
+	l.Sold = true
+	l.Buyer = buyer
+	if err := saveMarketListing(l); err != nil {
+		return nil, err
+	}
+
+	deal := &MarketDeal{
+		ID:        uuid.New().String(),
+		ListingID: l.ID,
+		Buyer:     buyer,
+		EscrowID:  esc.ID,
+		CreatedAt: time.Now().UTC(),
+	}
+	dealKey := fmt.Sprintf("market:deal:%s", deal.ID)
+	dealRaw, _ := json.Marshal(deal)
+	if err := CurrentStore().Set([]byte(dealKey), dealRaw); err != nil {
+		return nil, err
+	}
+
+	logger.Infow("marketplace deal opened", "deal", deal.ID)
+	return deal, nil
+}
+
+// ReleaseFunds releases an escrow to the seller and marks the deal closed.
+func ReleaseFunds(ctx *Context, escrowID string) error {
+	key := fmt.Sprintf("market:escrow:%s", escrowID)
+	raw, err := CurrentStore().Get([]byte(key))
+	if err != nil || raw == nil {
+		return fmt.Errorf("escrow not found")
+	}
+	var esc Escrow
+	if err := json.Unmarshal(raw, &esc); err != nil {
+		return err
+	}
+	if esc.State != "funded" {
+		return fmt.Errorf("escrow in invalid state")
+	}
+
+	escrowAcc := ModuleAddress("marketplace")
+	if err := Transfer(ctx, AssetRef{Kind: AssetCoin}, escrowAcc, esc.Seller, esc.Amount); err != nil {
+		return err
+	}
+
+	esc.State = "released"
+	upd, _ := json.Marshal(&esc)
+	if err := CurrentStore().Set([]byte(key), upd); err != nil {
+		return err
+	}
+
+	it := CurrentStore().Iterator([]byte("market:deal:"), nil)
+	defer it.Close()
+	for it.Next() {
+		var d MarketDeal
+		if err := json.Unmarshal(it.Value(), &d); err != nil {
+			continue
+		}
+		if d.EscrowID == escrowID && !d.Closed {
+			d.Closed = true
+			now := time.Now().UTC()
+			d.ClosedAt = &now
+			buf, _ := json.Marshal(&d)
+			_ = CurrentStore().Set(it.Key(), buf)
+			break
+		}
+	}
+
+	return nil
+}
+
+// GetMarketDeal retrieves a deal by ID.
+func GetMarketDeal(id string) (*MarketDeal, error) {
+	key := fmt.Sprintf("market:deal:%s", id)
+	raw, err := CurrentStore().Get([]byte(key))
+	if err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return nil, fmt.Errorf("deal not found")
+	}
+	var d MarketDeal
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+// ListMarketDeals lists deals optionally filtered by buyer.
+func ListMarketDeals(buyer *Address) ([]MarketDeal, error) {
+	it := CurrentStore().Iterator([]byte("market:deal:"), nil)
+	defer it.Close()
+	var out []MarketDeal
+	for it.Next() {
+		var d MarketDeal
+		if err := json.Unmarshal(it.Value(), &d); err != nil {
+			continue
+		}
+		if buyer != nil && d.Buyer != *buyer {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out, it.Error()
+}
+
+// END marketplace.go

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -96,21 +96,22 @@ func wrap(name string) OpcodeFunc {
 //
 // Category map:
 //
-//	0x01 AI                     0x0F Liquidity
-//	0x02 AMM                    0x10 Loanpool
-//	0x03 Authority              0x11 Network
-//	0x04 Charity                0x12 Replication
-//	0x05 Coin                   0x13 Rollups
-//	0x06 Compliance             0x14 Security
-//	0x07 Consensus              0x15 Sharding
-//	0x08 Contracts              0x16 Sidechains
-//	0x09 CrossChain             0x17 StateChannel
-//	0x0A Data                   0x18 Storage
-//	0x0B FaultTolerance         0x19 Tokens
-//	0x0C Governance             0x1A Transactions
-//	0x0D GreenTech              0x1B Utilities
-//	0x0E Ledger                 0x1C VirtualMachine
-//	                            0x1D Wallet
+//		0x01 AI                     0x0F Liquidity
+//		0x02 AMM                    0x10 Loanpool
+//		0x03 Authority              0x11 Network
+//		0x04 Charity                0x12 Replication
+//		0x05 Coin                   0x13 Rollups
+//		0x06 Compliance             0x14 Security
+//		0x07 Consensus              0x15 Sharding
+//		0x08 Contracts              0x16 Sidechains
+//		0x09 CrossChain             0x17 StateChannel
+//		0x0A Data                   0x18 Storage
+//		0x0B FaultTolerance         0x19 Tokens
+//		0x0C Governance             0x1A Transactions
+//		0x0D GreenTech              0x1B Utilities
+//		0x0E Ledger                 0x1C VirtualMachine
+//		                            0x1D Wallet
+//	                                 0x1E Marketplace
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,16 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// Marketplace (0x1E)
+	{"CreateMarketListing", 0x1E0001},
+	{"PurchaseItem", 0x1E0002},
+	{"CancelListing", 0x1E0003},
+	{"ReleaseFunds", 0x1E0004},
+	{"GetMarketListing", 0x1E0005},
+	{"ListMarketListings", 0x1E0006},
+	{"GetMarketDeal", 0x1E0007},
+	{"ListMarketDeals", 0x1E0008},
 }
 
 // init wires the catalogue into the live dispatcher.


### PR DESCRIPTION
## Summary
- implement marketplace operations in core
- register marketplace opcodes and gas prices
- add CLI commands for marketplace management
- wire marketplace into CLI route registration
- document marketplace command group in README, CLI guide, and whitepaper

## Testing
- `go vet ./core/... ./cmd/cli/marketplace.go`
- `go build ./core/...`
- `go build ./cmd/cli/marketplace.go`
- `go test ./core/...`


------
https://chatgpt.com/codex/tasks/task_e_688c2384c9bc8320bf69b69342dd2899