### PR TITLE
Add escrow management module and CLI

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -72,6 +72,7 @@ all modules from the core library. Highlights include:
 - `sidechain` – launch and interact with sidechains
 - `state_channel` – open and settle payment channels
 - `storage` – interact with on‑chain storage providers
+- `escrow` – manage multi-party escrow accounts
 - `tokens` – ERC‑20 style token commands
 - `transactions` – build and sign transactions
 - `utility_functions` – assorted helpers

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -68,6 +68,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `sidechain` – Launch or interact with auxiliary chains.
 - `state_channel` – Open and settle payment channels.
 - `storage` – Manage off-chain storage deals.
+- `escrow` – Multi-party escrow management.
 - `tokens` – Issue and manage token contracts.
 - `transactions` – Build and broadcast transactions manually.
 - `utility_functions` – Miscellaneous support utilities.

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -341,6 +341,17 @@ needed in custom tooling.
 | `deal:get` | Get details for a storage deal. |
 | `deal:list` | List storage deals. |
 
+### escrow
+
+| Sub-command | Description |
+|-------------|-------------|
+| `create` | Create a new multi-party escrow |
+| `deposit` | Deposit additional funds |
+| `release` | Release funds to participants |
+| `cancel` | Cancel an escrow and refund |
+| `info` | Show escrow details |
+| `list` | List all escrows |
+
 ### tokens
 
 | Sub-command | Description |

--- a/synnergy-network/cmd/cli/escrow.go
+++ b/synnergy-network/cmd/cli/escrow.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+// helper to parse address from hex
+func escParseAddr(hexStr string) (core.Address, error) {
+	return core.ParseAddress(hexStr)
+}
+
+// ---------------------------- Controllers ----------------------------
+
+type EscrowController struct{}
+
+func (EscrowController) Create(parties []core.EscrowParty) (*core.EscrowContract, error) {
+	return core.Escrow_Create(&core.Context{}, parties)
+}
+
+func (EscrowController) Deposit(id string, amt uint64) error {
+	return core.Escrow_Deposit(&core.Context{}, id, amt)
+}
+
+func (EscrowController) Release(id string) error                     { return core.Escrow_Release(&core.Context{}, id) }
+func (EscrowController) Cancel(id string) error                      { return core.Escrow_Cancel(&core.Context{}, id) }
+func (EscrowController) Get(id string) (*core.EscrowContract, error) { return core.Escrow_Get(id) }
+func (EscrowController) List() ([]core.EscrowContract, error)        { return core.Escrow_List() }
+
+// ------------------------------ CLI ---------------------------------
+
+var escrowCmd = &cobra.Command{
+	Use:   "escrow",
+	Short: "Manage multi-party escrows",
+}
+
+var escrowCreateCmd = &cobra.Command{
+	Use:   "create <amount> <addr1> [addrN...]",
+	Short: "Create a new escrow splitting amount equally",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		total, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid amount: %w", err)
+		}
+		n := len(args) - 1
+		share := total / uint64(n)
+		parties := make([]core.EscrowParty, n)
+		for i, hexAddr := range args[1:] {
+			addr, err := escParseAddr(hexAddr)
+			if err != nil {
+				return err
+			}
+			parties[i] = core.EscrowParty{Address: addr, Amount: share}
+		}
+		esc, err := EscrowController{}.Create(parties)
+		if err != nil {
+			return err
+		}
+		out, _ := json.MarshalIndent(esc, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	},
+}
+
+var escrowDepositCmd = &cobra.Command{
+	Use:   "deposit <escrow-id> <amount>",
+	Short: "Deposit additional funds to an escrow",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		amt, err := strconv.ParseUint(args[1], 10, 64)
+		if err != nil {
+			return err
+		}
+		return EscrowController{}.Deposit(args[0], amt)
+	},
+}
+
+var escrowReleaseCmd = &cobra.Command{
+	Use:   "release <escrow-id>",
+	Short: "Release funds to escrow parties",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return EscrowController{}.Release(args[0])
+	},
+}
+
+var escrowCancelCmd = &cobra.Command{
+	Use:   "cancel <escrow-id>",
+	Short: "Cancel an escrow and refund creator",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return EscrowController{}.Cancel(args[0])
+	},
+}
+
+var escrowInfoCmd = &cobra.Command{
+	Use:   "info <escrow-id>",
+	Short: "Show escrow details",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		esc, err := EscrowController{}.Get(args[0])
+		if err != nil {
+			return err
+		}
+		out, _ := json.MarshalIndent(esc, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	},
+}
+
+var escrowListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all escrows",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		escs, err := EscrowController{}.List()
+		if err != nil {
+			return err
+		}
+		out, _ := json.MarshalIndent(escs, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(out))
+		return nil
+	},
+}
+
+func init() {
+	escrowCmd.AddCommand(escrowCreateCmd)
+	escrowCmd.AddCommand(escrowDepositCmd)
+	escrowCmd.AddCommand(escrowReleaseCmd)
+	escrowCmd.AddCommand(escrowCancelCmd)
+	escrowCmd.AddCommand(escrowInfoCmd)
+	escrowCmd.AddCommand(escrowListCmd)
+}
+
+// EscrowRoute is exported for registration in the main CLI.
+var EscrowRoute = escrowCmd

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -29,6 +29,7 @@ func RegisterRoutes(root *cobra.Command) {
 		DataCmd,
 		ChannelRoute,
 		StorageRoute,
+		EscrowRoute,
 		UtilityRoute,
 	)
 

--- a/synnergy-network/core/escrow.go
+++ b/synnergy-network/core/escrow.go
@@ -1,0 +1,183 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EscrowParty defines a recipient and amount in an escrow agreement.
+type EscrowParty struct {
+	Address Address `json:"address"`
+	Amount  uint64  `json:"amount"`
+	Paid    bool    `json:"paid"`
+}
+
+// Escrow represents a multi-party escrow contract managed by the core.
+type EscrowContract struct {
+	ID        string        `json:"id"`
+	Creator   Address       `json:"creator"`
+	Parties   []EscrowParty `json:"parties"`
+	Balance   uint64        `json:"balance"`
+	Released  bool          `json:"released"`
+	CreatedAt time.Time     `json:"created_at"`
+}
+
+var escrowMu sync.Mutex
+
+// Escrow storage key helper.
+func escrowKey(id string) []byte {
+	return []byte(fmt.Sprintf("escrow:%s", id))
+}
+
+// Escrow_Create initialises a new escrow and transfers the total amount from
+// the caller to the escrow module account.
+func Escrow_Create(ctx *Context, parties []EscrowParty) (*EscrowContract, error) {
+	if len(parties) == 0 {
+		return nil, fmt.Errorf("no parties supplied")
+	}
+
+	var total uint64
+	for _, p := range parties {
+		if p.Amount == 0 {
+			return nil, fmt.Errorf("party amount must be >0")
+		}
+		total += p.Amount
+	}
+
+	esc := &EscrowContract{
+		ID:        uuid.New().String(),
+		Creator:   ctx.Caller,
+		Parties:   parties,
+		Balance:   total,
+		Released:  false,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	escrowAccount := ModuleAddress("escrow")
+	if err := Transfer(ctx, AssetRef{Kind: AssetCoin}, ctx.Caller, escrowAccount, total); err != nil {
+		return nil, err
+	}
+
+	data, _ := json.Marshal(esc)
+	if err := CurrentStore().Set(escrowKey(esc.ID), data); err != nil {
+		return nil, err
+	}
+	return esc, nil
+}
+
+// Escrow_Deposit adds additional funds to an existing escrow from the caller.
+func Escrow_Deposit(ctx *Context, id string, amount uint64) error {
+	if amount == 0 {
+		return fmt.Errorf("amount must be >0")
+	}
+	escrowMu.Lock()
+	defer escrowMu.Unlock()
+
+	raw, err := CurrentStore().Get(escrowKey(id))
+	if err != nil || raw == nil {
+		return fmt.Errorf("escrow not found")
+	}
+	var esc EscrowContract
+	if err := json.Unmarshal(raw, &esc); err != nil {
+		return err
+	}
+	if esc.Released {
+		return fmt.Errorf("escrow already released")
+	}
+	escrowAccount := ModuleAddress("escrow")
+	if err := Transfer(ctx, AssetRef{Kind: AssetCoin}, ctx.Caller, escrowAccount, amount); err != nil {
+		return err
+	}
+	esc.Balance += amount
+	data, _ := json.Marshal(&esc)
+	return CurrentStore().Set(escrowKey(id), data)
+}
+
+// Escrow_Release transfers escrow funds to all parties according to their
+// allocations. Funds are sent from the escrow module account.
+func Escrow_Release(ctx *Context, id string) error {
+	escrowMu.Lock()
+	defer escrowMu.Unlock()
+
+	raw, err := CurrentStore().Get(escrowKey(id))
+	if err != nil || raw == nil {
+		return fmt.Errorf("escrow not found")
+	}
+	var esc EscrowContract
+	if err := json.Unmarshal(raw, &esc); err != nil {
+		return err
+	}
+	if esc.Released {
+		return fmt.Errorf("already released")
+	}
+
+	escrowAccount := ModuleAddress("escrow")
+	for i, p := range esc.Parties {
+		if p.Paid {
+			continue
+		}
+		if err := Transfer(ctx, AssetRef{Kind: AssetCoin}, escrowAccount, p.Address, p.Amount); err != nil {
+			return err
+		}
+		esc.Parties[i].Paid = true
+	}
+	esc.Released = true
+	data, _ := json.Marshal(&esc)
+	return CurrentStore().Set(escrowKey(id), data)
+}
+
+// Escrow_Cancel refunds the remaining balance back to the creator if the escrow
+// has not been released yet.
+func Escrow_Cancel(ctx *Context, id string) error {
+	escrowMu.Lock()
+	defer escrowMu.Unlock()
+
+	raw, err := CurrentStore().Get(escrowKey(id))
+	if err != nil || raw == nil {
+		return fmt.Errorf("escrow not found")
+	}
+	var esc EscrowContract
+	if err := json.Unmarshal(raw, &esc); err != nil {
+		return err
+	}
+	if esc.Released {
+		return fmt.Errorf("cannot cancel released escrow")
+	}
+
+	escrowAccount := ModuleAddress("escrow")
+	if err := Transfer(ctx, AssetRef{Kind: AssetCoin}, escrowAccount, esc.Creator, esc.Balance); err != nil {
+		return err
+	}
+	return CurrentStore().Delete(escrowKey(id))
+}
+
+// Escrow_Get returns details for an escrow by ID.
+func Escrow_Get(id string) (*EscrowContract, error) {
+	raw, err := CurrentStore().Get(escrowKey(id))
+	if err != nil || raw == nil {
+		return nil, fmt.Errorf("escrow not found")
+	}
+	var esc EscrowContract
+	if err := json.Unmarshal(raw, &esc); err != nil {
+		return nil, err
+	}
+	return &esc, nil
+}
+
+// Escrow_List lists all escrows currently stored.
+func Escrow_List() ([]EscrowContract, error) {
+	it := CurrentStore().Iterator([]byte("escrow:"), nil)
+	defer it.Close()
+	var out []EscrowContract
+	for it.Next() {
+		var e EscrowContract
+		if err := json.Unmarshal(it.Value(), &e); err == nil {
+			out = append(out, e)
+		}
+	}
+	return out, it.Error()
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1183,6 +1183,16 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+
+	// ------------------------------------------------------------------
+	// Escrow Management
+	// ------------------------------------------------------------------
+	"Escrow_Create":  8_000,
+	"Escrow_Deposit": 4_000,
+	"Escrow_Release": 12_000,
+	"Escrow_Cancel":  6_000,
+	"Escrow_Get":     1_000,
+	"Escrow_List":    2_000,
 }
 
 func init() {

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -96,21 +96,22 @@ func wrap(name string) OpcodeFunc {
 //
 // Category map:
 //
-//	0x01 AI                     0x0F Liquidity
-//	0x02 AMM                    0x10 Loanpool
-//	0x03 Authority              0x11 Network
-//	0x04 Charity                0x12 Replication
-//	0x05 Coin                   0x13 Rollups
-//	0x06 Compliance             0x14 Security
-//	0x07 Consensus              0x15 Sharding
-//	0x08 Contracts              0x16 Sidechains
-//	0x09 CrossChain             0x17 StateChannel
-//	0x0A Data                   0x18 Storage
-//	0x0B FaultTolerance         0x19 Tokens
-//	0x0C Governance             0x1A Transactions
-//	0x0D GreenTech              0x1B Utilities
-//	0x0E Ledger                 0x1C VirtualMachine
-//	                            0x1D Wallet
+//		0x01 AI                     0x0F Liquidity
+//		0x02 AMM                    0x10 Loanpool
+//		0x03 Authority              0x11 Network
+//		0x04 Charity                0x12 Replication
+//		0x05 Coin                   0x13 Rollups
+//		0x06 Compliance             0x14 Security
+//		0x07 Consensus              0x15 Sharding
+//		0x08 Contracts              0x16 Sidechains
+//		0x09 CrossChain             0x17 StateChannel
+//		0x0A Data                   0x18 Storage
+//		0x0B FaultTolerance         0x19 Tokens
+//		0x0C Governance             0x1A Transactions
+//		0x0D GreenTech              0x1B Utilities
+//		0x0E Ledger                 0x1C VirtualMachine
+//		                            0x1D Wallet
+//	                                 0x1E Escrow
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,14 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// Escrow (0x1E)
+	{"Escrow_Create", 0x1E0001},
+	{"Escrow_Deposit", 0x1E0002},
+	{"Escrow_Release", 0x1E0003},
+	{"Escrow_Cancel", 0x1E0004},
+	{"Escrow_Get", 0x1E0005},
+	{"Escrow_List", 0x1E0006},
 }
 
 // init wires the catalogue into the live dispatcher.


### PR DESCRIPTION
## Summary
- implement new `EscrowContract` type and escrow management functions
- price escrow operations in `gas_table.go`
- register escrow opcodes in the dispatcher
- provide CLI command group for escrow
- wire escrow command group in CLI index
- document escrow functionality in README, CLI guide and whitepaper

## Testing
- `go vet ./core`
- `go build ./core`
- `go test ./core/...`
- `go vet ./core ./cmd/cli` *(fails: cannot use logrus.StandardLogger in other packages)*
- `go build ./cmd/cli` *(fails: existing compile errors in other packages)*

------
https://chatgpt.com/codex/tasks/task_e_688c23aea64c8320a6731839dd325925