### PR TITLE
Add authority_apply module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -53,6 +53,7 @@ all modules from the core library. Highlights include:
 - `ai` – publish models and run inference jobs
 - `amm` – swap tokens and manage liquidity pools
 - `authority_node` – validator registration and voting
+- `authority_apply` – submit and approve authority node applications
 - `charity_pool` – query and disburse community funds
 - `coin` – mint and transfer the native SYNN coin
 - `compliance` – perform KYC/AML checks

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -47,6 +47,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `ai` – Publish machine learning models and run inference jobs.
 - `amm` – Swap tokens and manage liquidity pools.
 - `authority_node` – Register validators and manage the authority set.
+- `authority_apply` – Submit and vote on authority node applications.
 - `charity_pool` – Contribute to or distribute from community charity funds.
 - `coin` – Mint, transfer, and burn the base asset.
 - `compliance` – Perform KYC/AML verification and auditing.

--- a/synnergy-network/cmd/cli/authority_apply.go
+++ b/synnergy-network/cmd/cli/authority_apply.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+var applier *core.AuthorityApplier
+
+func ensureApplier(cmd *cobra.Command, _ []string) error {
+	if applier != nil {
+		return nil
+	}
+	led := core.CurrentLedger()
+	if led == nil {
+		return errors.New("ledger not initialised")
+	}
+	as := core.CurrentAuthoritySet()
+	if as == nil {
+		as = core.NewAuthoritySet(logrus.StandardLogger(), led)
+	}
+	applier = core.NewAuthorityApplier(logrus.StandardLogger(), led, as, nil)
+	return nil
+}
+
+// Controller thin wrapper
+
+type ApplyController struct{}
+
+func (c *ApplyController) Submit(addr core.Address, role core.AuthorityRole, desc string) (core.Hash, error) {
+	return applier.SubmitApplication(addr, role, desc)
+}
+func (c *ApplyController) Vote(voter core.Address, id core.Hash, approve bool) error {
+	return applier.VoteApplication(voter, id, approve)
+}
+func (c *ApplyController) Finalize(id core.Hash) error { return applier.FinalizeApplication(id) }
+func (c *ApplyController) Tick(ts time.Time)           { applier.Tick(ts) }
+func (c *ApplyController) Get(id core.Hash) (core.AuthApplication, bool, error) {
+	return applier.GetApplication(id)
+}
+func (c *ApplyController) List(st core.AuthAppStatus) ([]core.AuthApplication, error) {
+	return applier.ListApplications(st)
+}
+
+// helpers
+
+func parseRoleApply(s string) (core.AuthorityRole, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	switch s {
+	case "governmentnode", "government":
+		return core.GovernmentNode, nil
+	case "centralbanknode", "centralbank":
+		return core.CentralBankNode, nil
+	case "regulationnode", "regulation":
+		return core.RegulationNode, nil
+	case "standardauthoritynode", "standard", "standardauthority":
+		return core.StandardAuthorityNode, nil
+	case "militarynode", "military":
+		return core.MilitaryNode, nil
+	case "largecommercenode", "commerce", "largecommerce":
+		return core.LargeCommerceNode, nil
+	default:
+		return 0, fmt.Errorf("unknown role %q", s)
+	}
+}
+
+func hexToAddr(s string) (core.Address, error) {
+	var a core.Address
+	b, err := hex.DecodeString(strings.TrimPrefix(s, "0x"))
+	if err != nil || len(b) != len(a) {
+		return a, fmt.Errorf("invalid address")
+	}
+	copy(a[:], b)
+	return a, nil
+}
+
+// CLI commands
+
+var applyCmd = &cobra.Command{Use: "authority_apply", Short: "Authority application management", PersistentPreRunE: ensureApplier}
+
+var applySubmitCmd = &cobra.Command{
+	Use:  "submit <candidate> <role> <desc>",
+	Args: cobra.MinimumNArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &ApplyController{}
+		addr, err := hexToAddr(args[0])
+		if err != nil {
+			return err
+		}
+		role, err := parseRoleApply(args[1])
+		if err != nil {
+			return err
+		}
+		id, err := ctrl.Submit(addr, role, strings.Join(args[2:], " "))
+		if err != nil {
+			return err
+		}
+		fmt.Println("application", id.Hex())
+		return nil
+	},
+}
+
+var applyVoteCmd = &cobra.Command{
+	Use:  "vote <voter> <id> [--approve]",
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &ApplyController{}
+		voter, err := hexToAddr(args[0])
+		if err != nil {
+			return err
+		}
+		b, err := hex.DecodeString(args[1])
+		if err != nil {
+			return err
+		}
+		var h core.Hash
+		copy(h[:], b)
+		approve, _ := cmd.Flags().GetBool("approve")
+		return ctrl.Vote(voter, h, approve)
+	},
+}
+
+var applyFinalizeCmd = &cobra.Command{
+	Use:  "finalize <id>",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &ApplyController{}
+		b, err := hex.DecodeString(args[0])
+		if err != nil {
+			return err
+		}
+		var h core.Hash
+		copy(h[:], b)
+		return ctrl.Finalize(h)
+	},
+}
+
+var applyTickCmd = &cobra.Command{Use: "tick", Run: func(cmd *cobra.Command, args []string) {
+	ctrl := &ApplyController{}
+	ctrl.Tick(time.Now().UTC())
+}}
+
+var applyGetCmd = &cobra.Command{
+	Use:  "get <id>",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &ApplyController{}
+		b, err := hex.DecodeString(args[0])
+		if err != nil {
+			return err
+		}
+		var h core.Hash
+		copy(h[:], b)
+		app, ok, err := ctrl.Get(h)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errors.New("not found")
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(app)
+	},
+}
+
+var applyListCmd = &cobra.Command{Use: "list", RunE: func(cmd *cobra.Command, args []string) error {
+	ctrl := &ApplyController{}
+	apps, err := ctrl.List(0)
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(apps)
+}}
+
+func init() {
+	applyVoteCmd.Flags().Bool("approve", true, "approve application")
+	applyCmd.AddCommand(applySubmitCmd, applyVoteCmd, applyFinalizeCmd, applyTickCmd, applyGetCmd, applyListCmd)
+}
+
+var AuthorityApplyCmd = applyCmd

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -11,6 +11,7 @@ The following command groups expose the same functionality available in the core
 - **ai** – Tools for publishing ML models and running anomaly detection jobs via gRPC to the AI service. Useful for training pipelines and on‑chain inference.
 - **amm** – Swap tokens and manage liquidity pools. Includes helpers to quote routes and add/remove liquidity.
 - **authority_node** – Register new validators, vote on authority proposals and list the active electorate.
+- **authority_apply** – Submit and vote on authority node applications.
 - **charity_pool** – Query the community charity fund and trigger payouts for the current cycle.
 - **coin** – Mint the base coin, transfer balances and inspect supply metrics.
 - **compliance** – Run KYC/AML checks on addresses and export audit reports.
@@ -87,6 +88,17 @@ needed in custom tooling.
 | `info <addr>` | Display details for an authority node. |
 | `list` | List authority nodes. |
 | `deregister <addr>` | Remove an authority node and its votes. |
+
+### authority_apply
+
+| Sub-command | Description |
+|-------------|-------------|
+| `submit <candidate> <role> <desc>` | Submit an authority node application. |
+| `vote <voter> <id>` | Vote on an application. Use `--approve=false` to reject. |
+| `finalize <id>` | Finalize and register the node if the vote passed. |
+| `tick` | Check all pending applications for expiry. |
+| `get <id>` | Display an application by ID. |
+| `list` | List all applications. |
 
 ### charity_pool
 

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -22,6 +22,7 @@ func RegisterRoutes(root *cobra.Command) {
 		AMMCmd,
 		PoolsCmd,
 		AuthCmd,
+		AuthorityApplyCmd,
 		CharityCmd,
 		LoanCmd,
 		ComplianceCmd,

--- a/synnergy-network/core/authority_apply.go
+++ b/synnergy-network/core/authority_apply.go
@@ -1,0 +1,244 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"log"
+	"sync"
+	"time"
+)
+
+// AuthorityApplier manages proposals for new authority nodes.
+// Each application collects votes from a sampled electorate and
+// registers the candidate once approved.
+
+type AuthAppStatus uint8
+
+const (
+	AppPending AuthAppStatus = iota + 1
+	AppApproved
+	AppRejected
+	AppExpired
+)
+
+// AuthApplication is stored in the ledger under prefix "authapply:app:".
+// Votes are tracked separately to prevent double voting.
+
+type AuthApplication struct {
+	ID           Hash          `json:"id"`
+	Candidate    Address       `json:"candidate"`
+	Role         AuthorityRole `json:"role"`
+	Description  string        `json:"desc"`
+	Electorate   []Address     `json:"electorate"`
+	VotesFor     uint32        `json:"votes_for"`
+	VotesAgainst uint32        `json:"votes_against"`
+	Deadline     int64         `json:"deadline_unix"`
+	Status       AuthAppStatus `json:"status"`
+	ExecutedAt   int64         `json:"executed_unix,omitempty"`
+}
+
+func (a *AuthApplication) Marshal() []byte { b, _ := json.Marshal(a); return b }
+
+// AuthVoteRule defines quorum and majority thresholds per role.
+type AuthVoteRule struct {
+	Quorum   int `yaml:"quorum"`
+	Majority int `yaml:"majority"` // percentage
+}
+
+// AuthorityApplierConfig controls electorate size and voting rules.
+type AuthorityApplierConfig struct {
+	ElectorateSize int                            `yaml:"electorate_size"`
+	VotePeriod     time.Duration                  `yaml:"vote_period"`
+	Rules          map[AuthorityRole]AuthVoteRule `yaml:"rules"`
+}
+
+// AuthorityApplier coordinates authority node applications.
+type AuthorityApplier struct {
+	mu     sync.Mutex
+	logger *log.Logger
+	ledger StateRW
+	auth   *AuthoritySet
+	cfg    AuthorityApplierConfig
+	nextID uint64
+}
+
+func NewAuthorityApplier(lg *log.Logger, led StateRW, auth *AuthoritySet, cfg *AuthorityApplierConfig) *AuthorityApplier {
+	ap := &AuthorityApplier{logger: lg, ledger: led, auth: auth}
+	if cfg != nil {
+		ap.cfg = *cfg
+	} else {
+		ap.cfg.ElectorateSize = 5
+		ap.cfg.VotePeriod = 72 * time.Hour
+		ap.cfg.Rules = make(map[AuthorityRole]AuthVoteRule)
+	}
+	if ap.cfg.Rules == nil {
+		ap.cfg.Rules = make(map[AuthorityRole]AuthVoteRule)
+	}
+	return ap
+}
+
+// SubmitApplication registers a new authority application.
+func (ap *AuthorityApplier) SubmitApplication(candidate Address, role AuthorityRole, desc string) (Hash, error) {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+
+	if ap.auth.IsAuthority(candidate) {
+		return Hash{}, errors.New("candidate already active")
+	}
+	elect, err := ap.auth.RandomElectorate(ap.cfg.ElectorateSize)
+	if err != nil {
+		return Hash{}, err
+	}
+	ap.nextID++
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, ap.nextID)
+	h := sha256.Sum256(append(candidate.Bytes(), buf...))
+	var id Hash
+	copy(id[:], h[:])
+
+	app := &AuthApplication{
+		ID:          id,
+		Candidate:   candidate,
+		Role:        role,
+		Description: desc,
+		Electorate:  elect,
+		Deadline:    time.Now().Add(ap.cfg.VotePeriod).Unix(),
+		Status:      AppPending,
+	}
+	ap.ledger.SetState(appKey(id), app.Marshal())
+	ap.logger.Printf("authority application %s submitted", id.Hex())
+	return id, nil
+}
+
+// VoteApplication casts a vote from an authority node in the electorate.
+func (ap *AuthorityApplier) VoteApplication(voter Address, id Hash, approve bool) error {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+
+	raw, err := ap.ledger.GetState(appKey(id))
+	if err != nil || len(raw) == 0 {
+		return errors.New("application not found")
+	}
+	var app AuthApplication
+	if err := json.Unmarshal(raw, &app); err != nil {
+		return err
+	}
+	if app.Status != AppPending {
+		return errors.New("application not pending")
+	}
+	if !containsAddr(app.Electorate, voter) {
+		return errors.New("voter not in electorate")
+	}
+	if ok, _ := ap.ledger.HasState(appVoteKey(id, voter)); ok {
+		return errors.New("duplicate vote")
+	}
+	ap.ledger.SetState(appVoteKey(id, voter), []byte{0x01})
+	if approve {
+		app.VotesFor++
+	} else {
+		app.VotesAgainst++
+	}
+	ap.ledger.SetState(appKey(id), app.Marshal())
+	return nil
+}
+
+// FinalizeApplication evaluates a finished vote and registers the authority if approved.
+func (ap *AuthorityApplier) FinalizeApplication(id Hash) error {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+
+	raw, err := ap.ledger.GetState(appKey(id))
+	if err != nil || len(raw) == 0 {
+		return errors.New("application not found")
+	}
+	var app AuthApplication
+	if err := json.Unmarshal(raw, &app); err != nil {
+		return err
+	}
+	if app.Status != AppPending {
+		return errors.New("already finalised")
+	}
+	if time.Now().Unix() < app.Deadline {
+		return errors.New("voting period not ended")
+	}
+	rule := ap.cfg.Rules[app.Role]
+	if rule.Quorum == 0 {
+		rule.Quorum = len(app.Electorate)
+		rule.Majority = 51
+	}
+	total := int(app.VotesFor + app.VotesAgainst)
+	if total >= rule.Quorum && int(app.VotesFor)*100/total >= rule.Majority {
+		if err := ap.auth.RegisterCandidate(app.Candidate, app.Role); err != nil {
+			return err
+		}
+		app.Status = AppApproved
+		app.ExecutedAt = time.Now().Unix()
+		ap.logger.Printf("authority application %s approved", id.Hex())
+	} else {
+		app.Status = AppRejected
+		ap.logger.Printf("authority application %s rejected", id.Hex())
+	}
+	ap.ledger.SetState(appKey(id), app.Marshal())
+	return nil
+}
+
+// Tick finalises expired applications.
+func (ap *AuthorityApplier) Tick(now time.Time) {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	iter := ap.ledger.PrefixIterator([]byte("authapply:app:"))
+	for iter.Next() {
+		var app AuthApplication
+		_ = json.Unmarshal(iter.Value(), &app)
+		if app.Status != AppPending {
+			continue
+		}
+		if now.Unix() >= app.Deadline {
+			id := app.ID
+			_ = ap.FinalizeApplication(id)
+		}
+	}
+}
+
+// GetApplication returns a stored application.
+func (ap *AuthorityApplier) GetApplication(id Hash) (AuthApplication, bool, error) {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	var app AuthApplication
+	raw, err := ap.ledger.GetState(appKey(id))
+	if err != nil {
+		return app, false, err
+	}
+	if len(raw) == 0 {
+		return app, false, nil
+	}
+	if err := json.Unmarshal(raw, &app); err != nil {
+		return app, false, err
+	}
+	return app, true, nil
+}
+
+// ListApplications returns applications filtered by status (0 for all).
+func (ap *AuthorityApplier) ListApplications(status AuthAppStatus) ([]AuthApplication, error) {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	iter := ap.ledger.PrefixIterator([]byte("authapply:app:"))
+	var out []AuthApplication
+	for iter.Next() {
+		var app AuthApplication
+		if err := json.Unmarshal(iter.Value(), &app); err != nil {
+			return nil, err
+		}
+		if status == 0 || app.Status == status {
+			out = append(out, app)
+		}
+	}
+	return out, nil
+}
+
+func appKey(id Hash) []byte { return append([]byte("authapply:app:"), id[:]...) }
+func appVoteKey(id Hash, voter Address) []byte {
+	return append(append([]byte("authapply:vote:"), id[:]...), voter.Bytes()...)
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -75,6 +75,12 @@ var gasTable map[Opcode]uint64
    GetAuthority:        1_000,
    ListAuthorities:     2_000,
    DeregisterAuthority: 6_000,
+   NewAuthorityApplier: 20_000,
+   SubmitApplication:   4_000,
+   VoteApplication:     3_000,
+   FinalizeApplication: 5_000,
+   GetApplication:      1_000,
+   ListApplications:    2_000,
 
    // ----------------------------------------------------------------------
    // Charity Pool
@@ -651,6 +657,12 @@ var gasNames = map[string]uint64{
 	"GetAuthority":        1_000,
 	"ListAuthorities":     2_000,
 	"DeregisterAuthority": 6_000,
+	"NewAuthorityApplier": 20_000,
+	"SubmitApplication":   4_000,
+	"VoteApplication":     3_000,
+	"FinalizeApplication": 5_000,
+	"GetApplication":      1_000,
+	"ListApplications":    2_000,
 
 	// ----------------------------------------------------------------------
 	// Charity Pool

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -136,6 +136,12 @@ var catalogue = []struct {
 	{"GetAuthority", 0x030006},
 	{"ListAuthorities", 0x030007},
 	{"DeregisterAuthority", 0x030008},
+	{"NewAuthorityApplier", 0x030009},
+	{"SubmitApplication", 0x03000A},
+	{"VoteApplication", 0x03000B},
+	{"FinalizeApplication", 0x03000C},
+	{"GetApplication", 0x03000D},
+	{"ListApplications", 0x03000E},
 
 	// Charity (0x04)
 	{"NewCharityPool", 0x040001},


### PR DESCRIPTION
## Summary
- add authority_apply module with voting logic
- integrate opcodes and gas costs
- expose new CLI commands and register in index
- document authority_apply in README, CLI guide and whitepaper

## Testing
- `go vet ./cmd/... ./core/...`
- `go build ./cmd/...` *(fails: ledger does not implement StateRW)*
- `go build ./core/...`
- `go test ./core/... ./cmd/cli/...` *(fails: ledger does not implement StateRW)*

------
https://chatgpt.com/codex/tasks/task_e_688c24a72a70832091f3b4a373e2bb58