### PR TITLE
Add resource management module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -60,6 +60,7 @@ all modules from the core library. Highlights include:
 - `contracts` – deploy and invoke smart contracts
 - `cross_chain` – configure asset bridges
 - `data` – inspect and manage raw data storage
+- `resource` – manage stored data and VM gas allocations
 - `fault_tolerance` – simulate faults and backups
 - `governance` – DAO style governance commands
 - `green_technology` – sustainability features

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -11,6 +11,7 @@ The Synnergy ecosystem brings together several services:
 - **Core Ledger and Consensus** – The canonical ledger stores blocks and coordinates the validator set.
 - **Virtual Machine** – A modular VM executes smart contracts compiled to WASM or EVM-compatible bytecode.
 - **Data Layer** – Integrated IPFS-style storage allows assets and off-chain data to be referenced on-chain.
+- **Data & Resource Management** – Tracks stored blobs and dynamically allocates gas limits.
 - **AI Compliance** – A built-in AI service scans transactions for fraud patterns, KYC signals, and anomalies.
 - **DEX and AMM** – Native modules manage liquidity pools and cross-chain swaps.
 - **Governance** – Token holders can create proposals and vote on protocol upgrades.

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -18,6 +18,7 @@ The following command groups expose the same functionality available in the core
 - **contracts** – Deploy, upgrade and invoke smart contracts stored on chain.
 - **cross_chain** – Bridge assets to or from other chains using lock and release commands.
 - **data** – Inspect raw key/value pairs in the underlying data store for debugging.
+- **resource** – Manage stored data and VM gas allocations.
 - **fault_tolerance** – Inject faults, simulate network partitions and test recovery procedures.
 - **governance** – Create proposals, cast votes and check DAO parameters.
 - **green_technology** – View energy metrics and toggle any experimental sustainability features.
@@ -176,6 +177,14 @@ needed in custom tooling.
 | `oracle push <oracleID> <value>` | Push a value to an oracle feed. |
 | `oracle query <oracleID>` | Query the latest oracle value. |
 | `oracle list` | List registered oracles. |
+
+### resource
+
+| Sub-command | Description |
+|-------------|-------------|
+| `store <owner> <key> <file> <gas>` | Store data and set a gas limit. |
+| `load <owner> <key> [out|-]` | Load data for a key. |
+| `delete <owner> <key>` | Remove stored data and reset the limit. |
 
 ### fault_tolerance
 

--- a/synnergy-network/cmd/cli/data_resource_management.go
+++ b/synnergy-network/cmd/cli/data_resource_management.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/spf13/cobra"
+	core "synnergy-network/core"
+)
+
+// DataResourceController exposes high level helpers.
+type DataResourceController struct {
+	mgr *core.DataResourceManager
+}
+
+func newDRController() *DataResourceController {
+	return &DataResourceController{mgr: core.NewDataResourceManager()}
+}
+
+func drmParseAddr(a string) (core.Address, error) {
+	b, err := hex.DecodeString(strings.TrimPrefix(a, "0x"))
+	if err != nil || len(b) != 20 {
+		return core.Address{}, fmt.Errorf("invalid address")
+	}
+	var out core.Address
+	copy(out[:], b)
+	return out, nil
+}
+
+func (c *DataResourceController) store(owner, key, file string, gas uint64) error {
+	addr, err := drmParseAddr(owner)
+	if err != nil {
+		return err
+	}
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	return c.mgr.Store(addr, key, data, gas)
+}
+
+func (c *DataResourceController) load(owner, key, out string) error {
+	addr, err := drmParseAddr(owner)
+	if err != nil {
+		return err
+	}
+	data, _, err := c.mgr.Load(addr, key)
+	if err != nil {
+		return err
+	}
+	if out == "-" {
+		fmt.Printf("%s", string(data))
+		return nil
+	}
+	return ioutil.WriteFile(out, data, 0o644)
+}
+
+func (c *DataResourceController) del(owner, key string) error {
+	addr, err := drmParseAddr(owner)
+	if err != nil {
+		return err
+	}
+	return c.mgr.Delete(addr, key)
+}
+
+var resourceCmd = &cobra.Command{
+	Use:   "resource",
+	Short: "Data and resource management utilities",
+}
+
+var resStoreCmd = &cobra.Command{
+	Use:   "store <owner> <key> <file> <gas>",
+	Short: "Store data and set gas limit",
+	Args:  cobra.ExactArgs(4),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		gas, err := parseUint(args[3])
+		if err != nil {
+			return err
+		}
+		return newDRController().store(args[0], args[1], args[2], gas)
+	},
+}
+
+var resLoadCmd = &cobra.Command{
+	Use:   "load <owner> <key> [out|-]",
+	Short: "Load data for an owner/key",
+	Args:  cobra.RangeArgs(2, 3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := "-"
+		if len(args) == 3 {
+			out = args[2]
+		}
+		return newDRController().load(args[0], args[1], out)
+	},
+}
+
+var resDelCmd = &cobra.Command{
+	Use:   "delete <owner> <key>",
+	Short: "Delete stored data",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return newDRController().del(args[0], args[1])
+	},
+}
+
+func init() {
+	resourceCmd.AddCommand(resStoreCmd, resLoadCmd, resDelCmd)
+}
+
+// ResourceCmd is exported for registration in the root CLI.
+var ResourceCmd = resourceCmd
+
+func parseUint(s string) (uint64, error) {
+	var v uint64
+	_, err := fmt.Sscan(s, &v)
+	return v, err
+}

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -27,6 +27,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ComplianceCmd,
 		CrossChainCmd,
 		DataCmd,
+		ResourceCmd,
 		ChannelRoute,
 		StorageRoute,
 		UtilityRoute,

--- a/synnergy-network/core/data_resource_management.go
+++ b/synnergy-network/core/data_resource_management.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// DataResourceManager combines simple data storage helpers with
+// dynamic resource allocation. Stored blobs are accounted for in the
+// ledger and a ResourceAllocator tracks the gas limit for each owner.
+// Data is persisted using the global KV store.
+
+type DataResourceManager struct {
+	alloc *ResourceAllocator
+	mu    sync.Mutex
+}
+
+// NewDataResourceManager returns a ready-to-use manager instance.
+func NewDataResourceManager() *DataResourceManager {
+	return &DataResourceManager{alloc: NewResourceAllocator()}
+}
+
+func (m *DataResourceManager) key(owner Address, k string) []byte {
+	return []byte(fmt.Sprintf("drm:%x:%s", owner[:], k))
+}
+
+// Store writes data under the given key and adjusts the gas limit for the owner.
+// Storage rent is charged via the ledger and an event is broadcast for
+// consensus replication.
+func (m *DataResourceManager) Store(owner Address, key string, data []byte, gas uint64) error {
+	if len(key) == 0 {
+		return fmt.Errorf("empty key")
+	}
+	store := CurrentStore()
+	led := CurrentLedger()
+	if store == nil || led == nil {
+		return fmt.Errorf("store or ledger not initialised")
+	}
+	if err := store.Set(m.key(owner, key), data); err != nil {
+		return err
+	}
+	if err := led.ChargeStorageRent(owner, int64(len(data))); err != nil {
+		return err
+	}
+	m.alloc.Adjust(owner, gas)
+	payload, _ := json.Marshal(struct {
+		Owner Address `json:"owner"`
+		Key   string  `json:"key"`
+		Gas   uint64  `json:"gas"`
+	}{owner, key, gas})
+	_ = Broadcast("drm:store", payload)
+	return nil
+}
+
+// Load retrieves the stored data and current gas limit for the owner.
+func (m *DataResourceManager) Load(owner Address, key string) ([]byte, uint64, error) {
+	store := CurrentStore()
+	if store == nil {
+		return nil, 0, fmt.Errorf("store not initialised")
+	}
+	b, err := store.Get(m.key(owner, key))
+	if err != nil {
+		return nil, 0, err
+	}
+	limit := m.alloc.limits[owner]
+	return b, limit, nil
+}
+
+// Delete removes stored data and resets the gas limit to zero.
+func (m *DataResourceManager) Delete(owner Address, key string) error {
+	store := CurrentStore()
+	if store == nil {
+		return fmt.Errorf("store not initialised")
+	}
+	if err := store.Delete(m.key(owner, key)); err != nil {
+		return err
+	}
+	m.alloc.Adjust(owner, 0)
+	payload, _ := json.Marshal(struct {
+		Owner Address `json:"owner"`
+		Key   string  `json:"key"`
+	}{owner, key})
+	_ = Broadcast("drm:delete", payload)
+	return nil
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -726,17 +726,20 @@ var gasNames = map[string]uint64{
 	// ----------------------------------------------------------------------
 	// Data / Oracle / IPFS Integration
 	// ----------------------------------------------------------------------
-	"RegisterNode":   10_000,
-	"UploadAsset":    30_000,
-	"Pin":            5_000, // shared with Storage
-	"Retrieve":       4_000, // shared with Storage
-	"RetrieveAsset":  4_000,
-	"RegisterOracle": 10_000,
-	"PushFeed":       3_000,
-	"QueryOracle":    3_000,
-	"ListCDNNodes":   3_000,
-	"ListOracles":    3_000,
-	"PushFeedSigned": 4_000,
+	"RegisterNode":      10_000,
+	"UploadAsset":       30_000,
+	"Pin":               5_000, // shared with Storage
+	"Retrieve":          4_000, // shared with Storage
+	"RetrieveAsset":     4_000,
+	"RegisterOracle":    10_000,
+	"PushFeed":          3_000,
+	"QueryOracle":       3_000,
+	"ListCDNNodes":      3_000,
+	"ListOracles":       3_000,
+	"PushFeedSigned":    4_000,
+	"StoreManagedData":  8_000,
+	"LoadManagedData":   3_000,
+	"DeleteManagedData": 2_000,
 
 	// ----------------------------------------------------------------------
 	// Fault-Tolerance / Health-Checker

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -210,6 +210,9 @@ var catalogue = []struct {
 	{"ListCDNNodes", 0x0A0009},
 	{"ListOracles", 0x0A000A},
 	{"PushFeedSigned", 0x0A000B},
+	{"StoreManagedData", 0x0A000C},
+	{"LoadManagedData", 0x0A000D},
+	{"DeleteManagedData", 0x0A000E},
 
 	// Fault-Tolerance (0x0B)
 	{"NewHealthChecker", 0x0B0001},


### PR DESCRIPTION
## Summary
- introduce `DataResourceManager` in core for storing data with gas limits
- expose `resource` CLI commands for managing stored data
- wire new opcodes and gas costs
- register resource CLI group
- update documentation for new module

## Testing
- `go vet ./core/...`
- `go build ./core/...`
- `go test ./core/...`
- `go mod tidy`

------
https://chatgpt.com/codex/tasks/task_e_688c261f4e6c8320adff9ccdaf88b98b