### PR TITLE
Add AI inference module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -51,6 +51,7 @@ Each file in `cmd/cli` registers its own group of commands with the root
 all modules from the core library. Highlights include:
 
 - `ai` – publish models and run inference jobs
+- `ai_infer` – advanced inference and transaction analysis
 - `amm` – swap tokens and manage liquidity pools
 - `authority_node` – validator registration and voting
 - `charity_pool` – query and disburse community funds

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -45,6 +45,7 @@ The supply inflates annually by 2% to maintain incentives and fund new initiativ
 ## Full CLI Guide and Index
 Synnergy comes with a powerful CLI built using the Cobra framework. Commands are grouped into modules mirroring the codebase. Below is a concise index; see `cmd/cli/cli_guide.md` for the detailed usage of each command group:
 - `ai` – Publish machine learning models and run inference jobs.
+- `ai_infer` – Advanced inference and batch analysis utilities.
 - `amm` – Swap tokens and manage liquidity pools.
 - `authority_node` – Register validators and manage the authority set.
 - `charity_pool` – Contribute to or distribute from community charity funds.

--- a/synnergy-network/cmd/cli/ai_inference.go
+++ b/synnergy-network/cmd/cli/ai_inference.go
@@ -1,0 +1,90 @@
+package cli
+
+// AI inference and analysis CLI module providing access to advanced
+// features of the core AI engine. The commands allow running inference
+// jobs against published models and analysing batches of transactions
+// for anomaly scores.
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/spf13/cobra"
+	core "synnergy-network/core"
+)
+
+type AIInferenceController struct{}
+
+func (c *AIInferenceController) InferModel(hashHex, path string) (*core.InferenceResult, error) {
+	hRaw, err := hex.DecodeString(strings.TrimPrefix(hashHex, "0x"))
+	if err != nil || len(hRaw) != 32 {
+		return nil, fmt.Errorf("invalid model hash")
+	}
+	var h [32]byte
+	copy(h[:], hRaw)
+	input, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read input: %w", err)
+	}
+	return core.AI().InferModel(h, input)
+}
+
+func (c *AIInferenceController) Analyse(path string) (map[core.Hash]float32, error) {
+	raw, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+	var txs []*core.Transaction
+	if err := json.Unmarshal(raw, &txs); err != nil {
+		return nil, fmt.Errorf("decode txs: %w", err)
+	}
+	return core.AI().AnalyseTransactions(txs)
+}
+
+var aiInferenceCmd = &cobra.Command{
+	Use:               "ai_infer",
+	Short:             "AI inference and analysis utilities",
+	PersistentPreRunE: ensureAIInitialised,
+}
+
+var inferCmd = &cobra.Command{
+	Use:   "run <model-hash> <input-file>",
+	Short: "Run inference against a model",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &AIInferenceController{}
+		res, err := ctrl.InferModel(args[0], args[1])
+		if err != nil {
+			return err
+		}
+		out, _ := json.MarshalIndent(res, "", "  ")
+		fmt.Println(string(out))
+		return nil
+	},
+}
+
+var analyseCmd = &cobra.Command{
+	Use:   "analyse <txs.json>",
+	Short: "Analyse transactions for fraud risk",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &AIInferenceController{}
+		res, err := ctrl.Analyse(args[0])
+		if err != nil {
+			return err
+		}
+		out, _ := json.MarshalIndent(res, "", "  ")
+		fmt.Println(string(out))
+		return nil
+	},
+}
+
+func init() {
+	aiInferenceCmd.AddCommand(inferCmd)
+	aiInferenceCmd.AddCommand(analyseCmd)
+}
+
+var AIInferenceCmd = aiInferenceCmd

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -9,6 +9,7 @@ Most commands require environment variables or a configuration file to be presen
 The following command groups expose the same functionality available in the core modules. Each can be mounted on a root [`cobra.Command`](https://github.com/spf13/cobra).
 
 - **ai** – Tools for publishing ML models and running anomaly detection jobs via gRPC to the AI service. Useful for training pipelines and on‑chain inference.
+- **ai_infer** – Advanced inference and batch analysis utilities.
 - **amm** – Swap tokens and manage liquidity pools. Includes helpers to quote routes and add/remove liquidity.
 - **authority_node** – Register new validators, vote on authority proposals and list the active electorate.
 - **charity_pool** – Query the community charity fund and trigger payouts for the current cycle.
@@ -64,6 +65,13 @@ needed in custom tooling.
 | `buy <listing-id> <buyer-addr>` | Buy a listed model with escrow. |
 | `rent <listing-id> <renter-addr> <hours>` | Rent a model for a period of time. |
 | `release <escrow-id>` | Release funds from escrow to the seller. |
+
+### ai_infer
+
+| Sub-command | Description |
+|-------------|-------------|
+| `ai_infer run <model-hash> <input-file>` | Execute model inference on input data. |
+| `ai_infer analyse <txs.json>` | Analyse a batch of transactions for fraud risk. |
 
 ### amm
 

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -19,6 +19,7 @@ func RegisterRoutes(root *cobra.Command) {
 		TransactionsCmd,
 		WalletCmd,
 		AICmd,
+		AIInferenceCmd,
 		AMMCmd,
 		PoolsCmd,
 		AuthCmd,

--- a/synnergy-network/core/ai.go
+++ b/synnergy-network/core/ai.go
@@ -31,6 +31,8 @@ type AIStubClient interface {
 	Anomaly(ctx context.Context, req *TFRequest) (*TFResponse, error)
 	FeeOpt(ctx context.Context, req *TFRequest) (*TFResponse, error)
 	Volume(ctx context.Context, req *TFRequest) (*TFResponse, error)
+	Inference(ctx context.Context, req *TFRequest) (*TFResponse, error)
+	Analyse(ctx context.Context, req *TFRequest) (*TFResponse, error)
 }
 
 //---------------------------------------------------------------------

--- a/synnergy-network/core/ai_inference_analysis.go
+++ b/synnergy-network/core/ai_inference_analysis.go
@@ -1,0 +1,65 @@
+package core
+
+// ai_inference_analysis.go - advanced AI inference and transaction analysis
+// Provides generic inference execution against registered models and batch
+// analysis helpers for transactions. This extends ai.go with additional
+// functionality used by consensus and the VM.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// InferenceResult stores the output of a model inference run along with
+// the score returned by the AI service.
+type InferenceResult struct {
+	Model     [32]byte `json:"model"`
+	Output    []byte   `json:"output"`
+	Score     float32  `json:"score"`
+	Timestamp int64    `json:"time"`
+}
+
+// InferModel runs the input through the referenced model and records the result
+// on the ledger. The model must have been published previously.
+func (ai *AIEngine) InferModel(hash [32]byte, input []byte) (*InferenceResult, error) {
+	if ai == nil {
+		return nil, errors.New("AI engine not initialised")
+	}
+	if _, ok := ai.modelMeta(hash); !ok {
+		return nil, fmt.Errorf("model %x not found", hash)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	resp, err := ai.client.Inference(ctx, &TFRequest{Payload: input})
+	if err != nil {
+		return nil, err
+	}
+	res := &InferenceResult{Model: hash, Output: resp.Result, Score: resp.Score, Timestamp: time.Now().Unix()}
+	key := append([]byte("ai:inference:"), hash[:]...)
+	ai.led.SetState(key, mustJSON(res))
+	return res, nil
+}
+
+// AnalyseTransactions runs anomaly detection over a batch of transactions and
+// returns a map of tx hash to risk score. It is used by the consensus engine
+// and compliance layer to pre-filter blocks.
+func (ai *AIEngine) AnalyseTransactions(txs []*Transaction) (map[Hash]float32, error) {
+	if ai == nil {
+		return nil, errors.New("AI engine not initialised")
+	}
+	out := make(map[Hash]float32)
+	for _, tx := range txs {
+		if tx == nil {
+			continue
+		}
+		tx.HashTx()
+		score, err := ai.PredictAnomaly(tx)
+		if err != nil {
+			return out, err
+		}
+		out[tx.Hash] = score
+	}
+	return out, nil
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -52,6 +52,8 @@ var gasTable map[Opcode]uint64
    RentModel:      20_000,
    ReleaseEscrow:  12_000,
    PredictVolume:  15_000,
+   InferModel:     30_000,
+   AnalyseTransactions: 35_000,
 
    // ----------------------------------------------------------------------
    // Automated-Market-Maker
@@ -616,18 +618,20 @@ var gasNames = map[string]uint64{
 	// ----------------------------------------------------------------------
 	// AI
 	// ----------------------------------------------------------------------
-	"InitAI":         50_000,
-	"AI":             40_000,
-	"PredictAnomaly": 35_000,
-	"OptimizeFees":   25_000,
-	"PublishModel":   45_000,
-	"FetchModel":     15_000,
-	"ListModel":      8_000,
-	"ValidateKYC":    1_000,
-	"BuyModel":       30_000,
-	"RentModel":      20_000,
-	"ReleaseEscrow":  12_000,
-	"PredictVolume":  15_000,
+	"InitAI":              50_000,
+	"AI":                  40_000,
+	"PredictAnomaly":      35_000,
+	"OptimizeFees":        25_000,
+	"PublishModel":        45_000,
+	"FetchModel":          15_000,
+	"ListModel":           8_000,
+	"ValidateKYC":         1_000,
+	"BuyModel":            30_000,
+	"RentModel":           20_000,
+	"ReleaseEscrow":       12_000,
+	"PredictVolume":       15_000,
+	"InferModel":          30_000,
+	"AnalyseTransactions": 35_000,
 
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker

--- a/synnergy-network/core/helpers.go
+++ b/synnergy-network/core/helpers.go
@@ -49,6 +49,12 @@ func (tfStubClient) FeeOpt(_ context.Context, _ *TFRequest) (*TFResponse, error)
 func (tfStubClient) Volume(_ context.Context, _ *TFRequest) (*TFResponse, error) {
 	return &TFResponse{}, nil
 }
+func (tfStubClient) Inference(_ context.Context, _ *TFRequest) (*TFResponse, error) {
+	return &TFResponse{}, nil
+}
+func (tfStubClient) Analyse(_ context.Context, _ *TFRequest) (*TFResponse, error) {
+	return &TFResponse{}, nil
+}
 
 // ------------------------------------------------------------------
 // Simple flat gas calculator used by CLI stubs

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -117,7 +117,9 @@ var catalogue = []struct {
 	name string
 	op   Opcode
 }{
-	// AI (0x01) – pending implementation
+	// AI (0x01)
+	{"InferModel", 0x010001},
+	{"AnalyseTransactions", 0x010002},
 
 	// AMM (0x02)
 	{"SwapExactIn", 0x020001},


### PR DESCRIPTION
## Summary
- add core AI inference & analysis functions
- expose new gRPC methods in AIStubClient and stub client
- price new opcodes in gas table and register them
- create CLI commands for AI inference and analysis
- document new `ai_infer` command group

## Testing
- `go vet ./core...`
- `go build ./core/...`
- `go test ./core`
- `go build ./cmd/cli/...` *(fails: various compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c269c32248320988217b8b3d35b13