### PR TITLE
Add user feedback system module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -77,6 +77,7 @@ all modules from the core library. Highlights include:
 - `utility_functions` – assorted helpers
 - `virtual_machine` – run the on‑chain VM service
 - `wallet` – mnemonic generation and signing
+- `feedback` – submit and query user feedback
 
 More details for each command can be found in `cmd/cli/cli_guide.md`.
 

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -15,6 +15,7 @@ The Synnergy ecosystem brings together several services:
 - **DEX and AMM** – Native modules manage liquidity pools and cross-chain swaps.
 - **Governance** – Token holders can create proposals and vote on protocol upgrades.
 - **Developer Tooling** – CLI modules, RPC services, and SDKs make integration straightforward.
+- **Feedback System** – Users can submit and browse feedback directly on chain, enabling transparent improvement cycles.
 All services are optional and run as independent modules that plug into the core.
 
 ## Synnergy Network Architecture
@@ -136,5 +137,5 @@ Assuming gradual adoption and comparable DeFi activity:
 These estimates rely on continued development, security audits, and ecosystem partnerships.
 
 ## Conclusion
-Synnergy Network aims to deliver a modular, enterprise-ready blockchain platform that blends advanced compliance, scalable architecture, and developer-friendly tools. The project is moving from early research into production and welcomes community feedback. For source code, development guides, and further documentation visit the repository.
+Synnergy Network aims to deliver a modular, enterprise-ready blockchain platform that blends advanced compliance, scalable architecture, and developer-friendly tools. The project is moving from early research into production and welcomes community feedback. A built-in on-chain feedback system allows suggestions to be recorded transparently. For source code, development guides, and further documentation visit the repository.
 

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -35,6 +35,7 @@ The following command groups expose the same functionality available in the core
 - **utility_functions** – Miscellaneous helpers shared by other command groups.
 - **virtual_machine** – Execute scripts in the built‑in VM for testing.
 - **wallet** – Generate mnemonics, derive addresses and sign transactions.
+- **feedback** – Submit and review on‑chain user feedback.
 
 
 To use these groups, import the corresponding command constructor (e.g. `ledger.NewLedgerCommand()`) in your main program and attach it to the root `cobra.Command`.

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -18,6 +18,7 @@ func RegisterRoutes(root *cobra.Command) {
 		VMCmd,
 		TransactionsCmd,
 		WalletCmd,
+		FeedbackCmd,
 		AICmd,
 		AMMCmd,
 		PoolsCmd,

--- a/synnergy-network/cmd/cli/user_feedback_system.go
+++ b/synnergy-network/cmd/cli/user_feedback_system.go
@@ -1,0 +1,130 @@
+package cli
+
+// cmd/cli/user_feedback_system.go - CLI for interacting with the on-chain
+// feedback engine. Commands are consolidated under "feedback" and operate
+// directly on the ledger using helper functions from the core package.
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/joho/godotenv"
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+var (
+	fbOnce   sync.Once
+	fbErr    error
+	fbEngine *core.FeedbackEngine
+)
+
+func fbInit(cmd *cobra.Command, _ []string) error {
+	fbOnce.Do(func() {
+		_ = godotenv.Load()
+		path := os.Getenv("LEDGER_PATH")
+		if path == "" {
+			fbErr = fmt.Errorf("LEDGER_PATH not set")
+			return
+		}
+		if err := core.InitLedger(path); err != nil {
+			fbErr = err
+			return
+		}
+		core.InitFeedback(core.CurrentLedger())
+		fbEngine = core.Feedback()
+	})
+	return fbErr
+}
+
+// submit ----------------------------------------------------------------------
+var fbSubmitCmd = &cobra.Command{
+	Use:   "submit",
+	Short: "Submit user feedback",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		userStr, _ := cmd.Flags().GetString("user")
+		rating, _ := cmd.Flags().GetUint8("rating")
+		msg, _ := cmd.Flags().GetString("message")
+		b, err := hex.DecodeString(userStr)
+		if err != nil || len(b) != 20 {
+			return fmt.Errorf("invalid user address")
+		}
+		var addr core.Address
+		copy(addr[:], b)
+		id, err := fbEngine.Submit(addr, rating, msg)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), id)
+		return nil
+	},
+	Args: cobra.NoArgs,
+}
+
+// get -------------------------------------------------------------------------
+var fbGetCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get feedback by id",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		e, err := fbEngine.Get(args[0])
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(e)
+	},
+}
+
+// list ------------------------------------------------------------------------
+var fbListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all feedback entries",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		list, err := fbEngine.List()
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(list)
+	},
+}
+
+// reward ----------------------------------------------------------------------
+var fbRewardCmd = &cobra.Command{
+	Use:   "reward <id> --amt=100",
+	Short: "Reward a feedback entry with SYNN",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		amt, _ := cmd.Flags().GetUint64("amt")
+		return fbEngine.Reward(args[0], amt)
+	},
+}
+
+// root ------------------------------------------------------------------------
+var FeedbackCmd = &cobra.Command{
+	Use:               "feedback",
+	Short:             "Interact with the feedback system",
+	PersistentPreRunE: fbInit,
+}
+
+func init() {
+	fbSubmitCmd.Flags().String("user", "", "user address")
+	fbSubmitCmd.Flags().Uint8("rating", 0, "rating 1-5")
+	fbSubmitCmd.Flags().String("message", "", "feedback message")
+	fbSubmitCmd.MarkFlagRequired("user")
+	fbSubmitCmd.MarkFlagRequired("rating")
+	fbSubmitCmd.MarkFlagRequired("message")
+
+	fbRewardCmd.Flags().Uint64("amt", 0, "amount of SYNN to mint")
+	fbRewardCmd.MarkFlagRequired("amt")
+
+	FeedbackCmd.AddCommand(fbSubmitCmd, fbGetCmd, fbListCmd, fbRewardCmd)
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1183,6 +1183,15 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+
+	// ---------------------------------------------------------------------
+	// Feedback System
+	// ---------------------------------------------------------------------
+	"InitFeedback":    8_000,
+	"Feedback_Submit": 2_000,
+	"Feedback_Get":    1_000,
+	"Feedback_List":   1_500,
+	"Feedback_Reward": 2_500,
 }
 
 func init() {

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -581,6 +581,13 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// Feedback (0x1E)
+	{"InitFeedback", 0x1E0001},
+	{"Feedback_Submit", 0x1E0002},
+	{"Feedback_Get", 0x1E0003},
+	{"Feedback_List", 0x1E0004},
+	{"Feedback_Reward", 0x1E0005},
 }
 
 // init wires the catalogue into the live dispatcher.

--- a/synnergy-network/core/user_feedback_system.go
+++ b/synnergy-network/core/user_feedback_system.go
@@ -1,0 +1,144 @@
+package core
+
+// user_feedback_system.go -- user feedback collection and reward engine
+// ----------------------------------------------------------------------
+// This module stores user feedback on-chain and exposes helper functions
+// for submitting entries, fetching them by ID and listing all stored
+// feedback. Entries are stored in the ledger state under the prefix
+// "feedback:". New submissions are broadcast on the network so that
+// replicators and indexers can react immediately.
+//
+// Rewarding positive contributions is optional; the FeedbackEngine can
+// mint SYNN coins directly using the ledger MintToken helper. Ratings are
+// 1–5 and callers are responsible for additional validation.
+// ----------------------------------------------------------------------
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+//---------------------------------------------------------------------
+// Data structures
+//---------------------------------------------------------------------
+
+// FeedbackEntry represents a single user submitted feedback record.
+type FeedbackEntry struct {
+	ID        string  `json:"id"`
+	User      Address `json:"user"`
+	Rating    uint8   `json:"rating"`
+	Message   string  `json:"message"`
+	Timestamp int64   `json:"ts"`
+}
+
+//---------------------------------------------------------------------
+// Engine singleton
+//---------------------------------------------------------------------
+
+var feedbackOnce sync.Once
+var feedbackEng *FeedbackEngine
+
+// FeedbackEngine stores feedback using the provided ledger backend.
+type FeedbackEngine struct {
+	led StateRW
+	mu  sync.Mutex
+}
+
+// InitFeedback sets up the global feedback engine with the given ledger.
+func InitFeedback(led StateRW) { feedbackOnce.Do(func() { feedbackEng = &FeedbackEngine{led: led} }) }
+
+// Feedback returns the initialised engine instance. It panics if InitFeedback
+// has not been called.
+func Feedback() *FeedbackEngine {
+	if feedbackEng == nil {
+		panic("feedback engine not initialised")
+	}
+	return feedbackEng
+}
+
+//---------------------------------------------------------------------
+// Core operations
+//---------------------------------------------------------------------
+
+// Submit records a new feedback entry from a user and broadcasts the event.
+// It returns the feedback ID which is a hex encoded SHA‑256 hash.
+func (f *FeedbackEngine) Submit(user Address, rating uint8, msg string) (string, error) {
+	if rating == 0 || rating > 5 {
+		return "", errors.New("rating must be between 1 and 5")
+	}
+	if len(msg) == 0 {
+		return "", errors.New("message required")
+	}
+	b := make([]byte, len(user)+8+len(msg))
+	copy(b, user[:])
+	binary.LittleEndian.PutUint64(b[len(user):], uint64(time.Now().UnixNano()))
+	copy(b[len(user)+8:], []byte(msg))
+	sum := sha256.Sum256(b)
+	id := hex.EncodeToString(sum[:])
+
+	entry := FeedbackEntry{ID: id, User: user, Rating: rating, Message: msg, Timestamp: time.Now().Unix()}
+	raw, _ := json.Marshal(entry)
+
+	key := append([]byte("feedback:"), sum[:]...)
+	if err := f.led.SetState(key, raw); err != nil {
+		return "", err
+	}
+	_ = Broadcast("feedback", raw)
+	return id, nil
+}
+
+// Get retrieves a single feedback entry by ID.
+func (f *FeedbackEngine) Get(id string) (FeedbackEntry, error) {
+	var out FeedbackEntry
+	b, err := hex.DecodeString(id)
+	if err != nil {
+		return out, fmt.Errorf("bad id: %w", err)
+	}
+	key := append([]byte("feedback:"), b...)
+	raw, err := f.led.GetState(key)
+	if err != nil {
+		return out, err
+	}
+	if len(raw) == 0 {
+		return out, errors.New("not found")
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// List returns all stored feedback entries.
+func (f *FeedbackEngine) List() ([]FeedbackEntry, error) {
+	it := f.led.PrefixIterator([]byte("feedback:"))
+	var out []FeedbackEntry
+	for it.Next() {
+		var e FeedbackEntry
+		if err := json.Unmarshal(it.Value(), &e); err == nil {
+			out = append(out, e)
+		}
+	}
+	return out, it.Error()
+}
+
+// Reward grants SYNN tokens to the user who submitted the given feedback ID.
+func (f *FeedbackEngine) Reward(id string, amt uint64) error {
+	if amt == 0 {
+		return errors.New("amount must be >0")
+	}
+	entry, err := f.Get(id)
+	if err != nil {
+		return err
+	}
+	return f.led.Mint(entry.User, amt)
+}
+
+//---------------------------------------------------------------------
+// END user_feedback_system.go
+//---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- implement `core/user_feedback_system.go` providing on-chain feedback storage
- wire feedback opcodes and gas costs
- create `cmd/cli/user_feedback_system.go` for CLI interaction
- register FeedbackCmd in the CLI index
- document the new feature in README, CLI guide and whitepaper

## Testing
- `go vet ./core/... ./cmd/cli` *(fails: loanpool.go etc.)*
- `go build ./core/...` *(passes)*
- `go build ./cmd/synnergy` *(fails: loanpool.go etc.)*
- `go test ./core/...`

------
https://chatgpt.com/codex/tasks/task_e_688c275171808320b4cc2f6c65a690f7