### PR TITLE
Add polls management module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -62,6 +62,7 @@ all modules from the core library. Highlights include:
 - `data` – inspect and manage raw data storage
 - `fault_tolerance` – simulate faults and backups
 - `governance` – DAO style governance commands
+- `polls_management` – create and vote on community polls
 - `green_technology` – sustainability features
 - `ledger` – low level ledger inspection
 - `network` – libp2p networking helpers

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -14,6 +14,7 @@ The Synnergy ecosystem brings together several services:
 - **AI Compliance** – A built-in AI service scans transactions for fraud patterns, KYC signals, and anomalies.
 - **DEX and AMM** – Native modules manage liquidity pools and cross-chain swaps.
 - **Governance** – Token holders can create proposals and vote on protocol upgrades.
+- **Polls** – Lightweight polls let the community signal preferences off-chain.
 - **Developer Tooling** – CLI modules, RPC services, and SDKs make integration straightforward.
 All services are optional and run as independent modules that plug into the core.
 
@@ -56,6 +57,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `data` – Low-level debugging of key/value storage and oracles.
 - `fault_tolerance` – Simulate network failures and snapshot recovery.
 - `governance` – Create proposals and cast votes.
+- `polls_management` – Lightweight polls for community feedback.
 - `green_technology` – Manage energy tracking and carbon offsets.
 - `ledger` – Inspect blocks, accounts, and token metrics.
 - `liquidity_pools` – Create pools and provide liquidity.
@@ -95,6 +97,7 @@ All high-level functions in the protocol are mapped to unique 24-bit opcodes of 
 0x0D  GreenTech              0x1B  Utilities
 0x0E  Ledger                 0x1C  VirtualMachine
                                  0x1D  Wallet
+                                 0x1E  Polls
 ```
 The complete list of opcodes along with their handlers can be inspected in `core/opcode_dispatcher.go`. Tools like `synnergy opcodes` dump the catalogue in `<FunctionName>=<Hex>` format to aid audits.
 

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -20,6 +20,7 @@ The following command groups expose the same functionality available in the core
 - **data** – Inspect raw key/value pairs in the underlying data store for debugging.
 - **fault_tolerance** – Inject faults, simulate network partitions and test recovery procedures.
 - **governance** – Create proposals, cast votes and check DAO parameters.
+- **polls_management** – Create and vote on community polls.
 - **green_technology** – View energy metrics and toggle any experimental sustainability features.
 - **ledger** – Inspect blocks, query balances and perform administrative token operations via the ledger daemon.
 - **network** – Manage peer connections and print networking statistics.
@@ -199,6 +200,16 @@ needed in custom tooling.
 | `execute <proposal-id>` | Execute a proposal after the deadline. |
 | `get <proposal-id>` | Display a single proposal. |
 | `list` | List all proposals. |
+
+### polls_management
+
+| Sub-command | Description |
+|-------------|-------------|
+| `create` | Create a new poll. |
+| `vote <id>` | Cast a vote on a poll. |
+| `close <id>` | Close a poll immediately. |
+| `get <id>` | Display a poll. |
+| `list` | List existing polls. |
 
 ### green_technology
 

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -21,6 +21,7 @@ func RegisterRoutes(root *cobra.Command) {
 		AICmd,
 		AMMCmd,
 		PoolsCmd,
+		PollsCmd,
 		AuthCmd,
 		CharityCmd,
 		LoanCmd,

--- a/synnergy-network/cmd/cli/polls_management.go
+++ b/synnergy-network/cmd/cli/polls_management.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+// PollController wraps core poll management functions for the CLI.
+type PollController struct{}
+
+func (PollController) Create(question string, opts []string, creator string, dur time.Duration) (core.Poll, error) {
+	addr, err := core.ParseAddress(creator)
+	if err != nil {
+		return core.Poll{}, err
+	}
+	return core.CreatePoll(question, opts, addr, dur)
+}
+
+func (PollController) Vote(id, voter string, option int) error {
+	addr, err := core.ParseAddress(voter)
+	if err != nil {
+		return err
+	}
+	return core.VotePoll(id, addr, option)
+}
+
+func (PollController) Close(id string) error            { return core.ClosePoll(id) }
+func (PollController) Get(id string) (core.Poll, error) { return core.GetPoll(id) }
+func (PollController) List() ([]core.Poll, error)       { return core.ListPolls() }
+
+// ----------------------------------------------------------------------
+// CLI commands
+// ----------------------------------------------------------------------
+
+var pollsCmd = &cobra.Command{Use: "polls", Short: "Manage on-chain polls"}
+
+var pollsCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new poll",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		q, _ := cmd.Flags().GetString("question")
+		optStr, _ := cmd.Flags().GetStringSlice("option")
+		creator, _ := cmd.Flags().GetString("creator")
+		durStr, _ := cmd.Flags().GetString("duration")
+		if q == "" || len(optStr) < 2 {
+			return fmt.Errorf("question and at least two --option required")
+		}
+		d, err := time.ParseDuration(durStr)
+		if durStr == "" || err != nil {
+			d = 72 * time.Hour
+		}
+		ctrl := PollController{}
+		p, err := ctrl.Create(q, optStr, creator, d)
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(p)
+	},
+}
+
+var pollsVoteCmd = &cobra.Command{
+	Use:   "vote <id>",
+	Short: "Vote on a poll",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		voter, _ := cmd.Flags().GetString("voter")
+		opt, _ := cmd.Flags().GetInt("option")
+		ctrl := PollController{}
+		return ctrl.Vote(args[0], voter, opt)
+	},
+}
+
+var pollsCloseCmd = &cobra.Command{Use: "close <id>", Short: "Close a poll", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+	ctrl := PollController{}
+	return ctrl.Close(args[0])
+}}
+
+var pollsGetCmd = &cobra.Command{Use: "get <id>", Short: "Show a poll", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+	ctrl := PollController{}
+	p, err := ctrl.Get(args[0])
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(p)
+}}
+
+var pollsListCmd = &cobra.Command{Use: "list", Short: "List polls", RunE: func(cmd *cobra.Command, args []string) error {
+	ctrl := PollController{}
+	polls, err := ctrl.List()
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(polls)
+}}
+
+func init() {
+	pollsCreateCmd.Flags().String("question", "", "poll question")
+	pollsCreateCmd.Flags().StringSlice("option", nil, "poll option (repeat)")
+	pollsCreateCmd.Flags().String("creator", "", "creator address")
+	pollsCreateCmd.Flags().String("duration", "72h", "voting duration")
+	pollsCreateCmd.MarkFlagRequired("question")
+	pollsCreateCmd.MarkFlagRequired("option")
+	pollsCreateCmd.MarkFlagRequired("creator")
+
+	pollsVoteCmd.Flags().String("voter", "", "voter address")
+	pollsVoteCmd.Flags().Int("option", 0, "option index")
+	pollsVoteCmd.MarkFlagRequired("voter")
+	pollsVoteCmd.MarkFlagRequired("option")
+
+	pollsCmd.AddCommand(pollsCreateCmd, pollsVoteCmd, pollsCloseCmd, pollsGetCmd, pollsListCmd)
+}
+
+var PollsCmd = pollsCmd
+
+func RegisterPolls(root *cobra.Command) { root.AddCommand(PollsCmd) }

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1183,6 +1183,15 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+
+	// ----------------------------------------------------------------------
+	// Polls Management
+	// ----------------------------------------------------------------------
+	"CreatePoll": 8_000,
+	"VotePoll":   3_000,
+	"ClosePoll":  2_000,
+	"GetPoll":    500,
+	"ListPolls":  1_000,
 }
 
 func init() {

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -581,6 +581,13 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// Polls Management (0x1E)
+	{"CreatePoll", 0x1E0001},
+	{"VotePoll", 0x1E0002},
+	{"ClosePoll", 0x1E0003},
+	{"GetPoll", 0x1E0004},
+	{"ListPolls", 0x1E0005},
 }
 
 // init wires the catalogue into the live dispatcher.

--- a/synnergy-network/core/polls_management.go
+++ b/synnergy-network/core/polls_management.go
@@ -1,0 +1,144 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Poll represents a simple community poll stored in the global KV store.
+type Poll struct {
+	ID       string          `json:"id"`
+	Question string          `json:"question"`
+	Options  []string        `json:"options"`
+	Counts   []uint64        `json:"counts"`
+	Voters   map[string]bool `json:"voters"`
+	Creator  Address         `json:"creator"`
+	Deadline time.Time       `json:"deadline"`
+	Closed   bool            `json:"closed"`
+}
+
+const pollPrefix = "poll:" // key prefix in the KV store
+
+// CreatePoll registers a new poll. Duration defines how long voting is open.
+func CreatePoll(question string, options []string, creator Address, duration time.Duration) (Poll, error) {
+	if question == "" || len(options) < 2 {
+		return Poll{}, fmt.Errorf("invalid poll parameters")
+	}
+	if CurrentStore() == nil {
+		return Poll{}, fmt.Errorf("kv store not initialised")
+	}
+
+	p := Poll{
+		ID:       uuid.New().String(),
+		Question: question,
+		Options:  append([]string(nil), options...),
+		Counts:   make([]uint64, len(options)),
+		Voters:   make(map[string]bool),
+		Creator:  creator,
+		Deadline: time.Now().Add(duration),
+	}
+	raw, err := json.Marshal(p)
+	if err != nil {
+		return Poll{}, err
+	}
+	if err := CurrentStore().Set([]byte(pollPrefix+p.ID), raw); err != nil {
+		return Poll{}, err
+	}
+	return p, nil
+}
+
+// VotePoll casts a vote on the given poll option index.
+func VotePoll(id string, voter Address, option int) error {
+	if CurrentStore() == nil {
+		return fmt.Errorf("kv store not initialised")
+	}
+	raw, err := CurrentStore().Get([]byte(pollPrefix + id))
+	if err != nil {
+		return ErrNotFound
+	}
+	var p Poll
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return err
+	}
+	if p.Closed || time.Now().After(p.Deadline) {
+		return fmt.Errorf("poll closed")
+	}
+	addr := voter.Hex()
+	if p.Voters[addr] {
+		return fmt.Errorf("already voted")
+	}
+	if option < 0 || option >= len(p.Options) {
+		return fmt.Errorf("invalid option")
+	}
+	if led := CurrentLedger(); led != nil {
+		if led.BalanceOf(voter) == 0 {
+			return ErrUnauthorized
+		}
+	}
+	p.Voters[addr] = true
+	p.Counts[option]++
+	updated, _ := json.Marshal(&p)
+	if err := CurrentStore().Set([]byte(pollPrefix+id), updated); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ClosePoll marks a poll as closed regardless of deadline.
+func ClosePoll(id string) error {
+	if CurrentStore() == nil {
+		return fmt.Errorf("kv store not initialised")
+	}
+	raw, err := CurrentStore().Get([]byte(pollPrefix + id))
+	if err != nil {
+		return ErrNotFound
+	}
+	var p Poll
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return err
+	}
+	if p.Closed {
+		return ErrInvalidState
+	}
+	p.Closed = true
+	updated, _ := json.Marshal(&p)
+	return CurrentStore().Set([]byte(pollPrefix+id), updated)
+}
+
+// GetPoll retrieves a poll by ID.
+func GetPoll(id string) (Poll, error) {
+	if CurrentStore() == nil {
+		return Poll{}, fmt.Errorf("kv store not initialised")
+	}
+	raw, err := CurrentStore().Get([]byte(pollPrefix + id))
+	if err != nil {
+		return Poll{}, ErrNotFound
+	}
+	var p Poll
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return Poll{}, err
+	}
+	return p, nil
+}
+
+// ListPolls returns all polls in the store.
+func ListPolls() ([]Poll, error) {
+	if CurrentStore() == nil {
+		return nil, fmt.Errorf("kv store not initialised")
+	}
+	it := CurrentStore().Iterator([]byte(pollPrefix), nil)
+	var out []Poll
+	for it.Next() {
+		var p Poll
+		if err := json.Unmarshal(it.Value(), &p); err == nil {
+			out = append(out, p)
+		}
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	return out, it.Close()
+}


### PR DESCRIPTION
## Summary
- implement a new polls management module
- wire polls functions into opcode dispatcher and gas schedule
- expose CLI commands for creating and voting on polls
- register the new CLI module
- document the feature in README, CLI guide and whitepaper

## Testing
- `go vet ./core/... ./cmd/cli/...` *(fails: loanpool.go etc.)*
- `go build ./core/... ./cmd/cli/...` *(fails: loanpool.go etc.)*
- `go test ./core/... ./cmd/cli/...` *(fails: loanpool.go etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688c276548e883209655b9469fc71d3f