### PR TITLE
Add regulatory management module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -77,6 +77,7 @@ all modules from the core library. Highlights include:
 - `utility_functions` – assorted helpers
 - `virtual_machine` – run the on‑chain VM service
 - `wallet` – mnemonic generation and signing
+- `regulator` – manage approved regulators and enforce rules
 
 More details for each command can be found in `cmd/cli/cli_guide.md`.
 

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -14,6 +14,7 @@ The Synnergy ecosystem brings together several services:
 - **AI Compliance** – A built-in AI service scans transactions for fraud patterns, KYC signals, and anomalies.
 - **DEX and AMM** – Native modules manage liquidity pools and cross-chain swaps.
 - **Governance** – Token holders can create proposals and vote on protocol upgrades.
+- **Regulatory Management** – Maintain regulator lists and enforce jurisdictional rules.
 - **Developer Tooling** – CLI modules, RPC services, and SDKs make integration straightforward.
 All services are optional and run as independent modules that plug into the core.
 
@@ -95,6 +96,7 @@ All high-level functions in the protocol are mapped to unique 24-bit opcodes of 
 0x0D  GreenTech              0x1B  Utilities
 0x0E  Ledger                 0x1C  VirtualMachine
                                  0x1D  Wallet
+                                 0x1E  Regulatory
 ```
 The complete list of opcodes along with their handlers can be inspected in `core/opcode_dispatcher.go`. Tools like `synnergy opcodes` dump the catalogue in `<FunctionName>=<Hex>` format to aid audits.
 

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -35,6 +35,7 @@ The following command groups expose the same functionality available in the core
 - **utility_functions** – Miscellaneous helpers shared by other command groups.
 - **virtual_machine** – Execute scripts in the built‑in VM for testing.
 - **wallet** – Generate mnemonics, derive addresses and sign transactions.
+- **regulator** – Manage on-chain regulators and rule checks.
 
 
 To use these groups, import the corresponding command constructor (e.g. `ledger.NewLedgerCommand()`) in your main program and attach it to the root `cobra.Command`.

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -18,6 +18,7 @@ func RegisterRoutes(root *cobra.Command) {
 		VMCmd,
 		TransactionsCmd,
 		WalletCmd,
+		RegulatoryCmd,
 		AICmd,
 		AMMCmd,
 		PoolsCmd,

--- a/synnergy-network/cmd/cli/regulatory_management.go
+++ b/synnergy-network/cmd/cli/regulatory_management.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+// ---------------------------------------------------------------------
+// Middleware
+// ---------------------------------------------------------------------
+func ensureRegMiddleware(cmd *cobra.Command, _ []string) error {
+	if core.CurrentLedger() == nil {
+		return errors.New("ledger not initialised")
+	}
+	if core.ListRegulators() == nil {
+		core.InitRegulatory(core.CurrentLedger())
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// Controller
+// ---------------------------------------------------------------------
+
+type RegController struct{}
+
+func (r *RegController) Register(id, name, juris string) error {
+	return core.RegisterRegulator(id, name, juris)
+}
+
+func (r *RegController) List() []core.Regulator { return core.ListRegulators() }
+
+// ---------------------------------------------------------------------
+// CLI commands
+// ---------------------------------------------------------------------
+
+var regCmd = &cobra.Command{
+	Use:               "regulator",
+	Short:             "Manage on-chain regulators",
+	PersistentPreRunE: ensureRegMiddleware,
+}
+
+var regRegisterCmd = &cobra.Command{
+	Use:   "register <id> <name> <jurisdiction>",
+	Short: "Register a new regulator",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := &RegController{}
+		if err := c.Register(args[0], args[1], args[2]); err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "regulator registered")
+		return nil
+	},
+}
+
+var regListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all regulators",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := &RegController{}
+		regs := c.List()
+		b, _ := json.MarshalIndent(regs, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(b))
+		return nil
+	},
+}
+
+func init() {
+	regCmd.AddCommand(regRegisterCmd)
+	regCmd.AddCommand(regListCmd)
+}
+
+// Export
+var RegulatoryCmd = regCmd

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1183,6 +1183,15 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+
+	// ---------------------------------------------------------------------
+	// Regulatory Management
+	// ---------------------------------------------------------------------
+	"InitRegulatory":    4_000,
+	"RegisterRegulator": 6_000,
+	"GetRegulator":      2_000,
+	"ListRegulators":    2_000,
+	"EvaluateRuleSet":   5_000,
 }
 
 func init() {

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -96,21 +96,22 @@ func wrap(name string) OpcodeFunc {
 //
 // Category map:
 //
-//	0x01 AI                     0x0F Liquidity
-//	0x02 AMM                    0x10 Loanpool
-//	0x03 Authority              0x11 Network
-//	0x04 Charity                0x12 Replication
-//	0x05 Coin                   0x13 Rollups
-//	0x06 Compliance             0x14 Security
-//	0x07 Consensus              0x15 Sharding
-//	0x08 Contracts              0x16 Sidechains
-//	0x09 CrossChain             0x17 StateChannel
-//	0x0A Data                   0x18 Storage
-//	0x0B FaultTolerance         0x19 Tokens
-//	0x0C Governance             0x1A Transactions
-//	0x0D GreenTech              0x1B Utilities
-//	0x0E Ledger                 0x1C VirtualMachine
-//	                            0x1D Wallet
+//		0x01 AI                     0x0F Liquidity
+//		0x02 AMM                    0x10 Loanpool
+//		0x03 Authority              0x11 Network
+//		0x04 Charity                0x12 Replication
+//		0x05 Coin                   0x13 Rollups
+//		0x06 Compliance             0x14 Security
+//		0x07 Consensus              0x15 Sharding
+//		0x08 Contracts              0x16 Sidechains
+//		0x09 CrossChain             0x17 StateChannel
+//		0x0A Data                   0x18 Storage
+//		0x0B FaultTolerance         0x19 Tokens
+//		0x0C Governance             0x1A Transactions
+//		0x0D GreenTech              0x1B Utilities
+//		0x0E Ledger                 0x1C VirtualMachine
+//		                            0x1D Wallet
+//	                                 0x1E Regulatory
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,13 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// Regulatory (0x1E)
+	{"InitRegulatory", 0x1E0001},
+	{"RegisterRegulator", 0x1E0002},
+	{"GetRegulator", 0x1E0003},
+	{"ListRegulators", 0x1E0004},
+	{"EvaluateRuleSet", 0x1E0005},
 }
 
 // init wires the catalogue into the live dispatcher.

--- a/synnergy-network/core/regulatory_management.go
+++ b/synnergy-network/core/regulatory_management.go
@@ -1,0 +1,108 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+)
+
+// Regulator represents an approved regulatory authority
+// allowed to enforce compliance policies on chain.
+type Regulator struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Jurisdiction string `json:"jurisdiction"`
+}
+
+var (
+	regMu      sync.RWMutex
+	regulators map[string]Regulator
+	regLedger  *Ledger
+)
+
+// InitRegulatory sets the ledger used for persistence. It must be
+// called before any other regulatory management function.
+func InitRegulatory(led *Ledger) {
+	regMu.Lock()
+	defer regMu.Unlock()
+	regLedger = led
+	if regulators == nil {
+		regulators = make(map[string]Regulator)
+	}
+}
+
+// RegisterRegulator records a new regulator in memory and on the ledger.
+func RegisterRegulator(id, name, jurisdiction string) error {
+	if id == "" || name == "" {
+		return errors.New("id and name required")
+	}
+	regMu.Lock()
+	defer regMu.Unlock()
+	if _, ok := regulators[id]; ok {
+		return errors.New("regulator exists")
+	}
+	r := Regulator{ID: id, Name: name, Jurisdiction: jurisdiction}
+	regulators[id] = r
+	if regLedger != nil {
+		b, _ := json.Marshal(r)
+		regLedger.SetState(regMgmtKey(id), b)
+	}
+	return nil
+}
+
+// GetRegulator retrieves a regulator from memory or ledger.
+func GetRegulator(id string) (Regulator, bool) {
+	regMu.RLock()
+	r, ok := regulators[id]
+	regMu.RUnlock()
+	if ok {
+		return r, true
+	}
+	if regLedger == nil {
+		return Regulator{}, false
+	}
+	b, _ := regLedger.GetState(regMgmtKey(id))
+	if len(b) == 0 {
+		return Regulator{}, false
+	}
+	if err := json.Unmarshal(b, &r); err != nil {
+		return Regulator{}, false
+	}
+	regMu.Lock()
+	regulators[id] = r
+	regMu.Unlock()
+	return r, true
+}
+
+// ListRegulators returns all currently registered regulators.
+func ListRegulators() []Regulator {
+	regMu.RLock()
+	list := make([]Regulator, 0, len(regulators))
+	for _, r := range regulators {
+		list = append(list, r)
+	}
+	regMu.RUnlock()
+	return list
+}
+
+// EvaluateRuleSet performs a minimal compliance check on a transaction.
+// In this prototype it ensures every output recipient holds an ID token.
+func EvaluateRuleSet(tx *Transaction) error {
+	if tx == nil {
+		return errors.New("nil tx")
+	}
+	regMu.RLock()
+	led := regLedger
+	regMu.RUnlock()
+	if led == nil {
+		return nil
+	}
+	for _, out := range tx.Outputs {
+		if !led.IsIDTokenHolder(out.Address) {
+			return errors.New("destination not verified")
+		}
+	}
+	return nil
+}
+
+func regMgmtKey(id string) []byte { return []byte("reg:" + id) }


### PR DESCRIPTION
## Summary
- implement `regulatory_management` module in core
- map new opcodes and gas costs
- expose `regulator` command group in CLI
- register new command in CLI index
- document regulator management in README, CLI guide and whitepaper

## Testing
- `go vet ./core/... ./cmd/cli/...` *(fails: loanpool.go incompatible types)*
- `go build ./core/...`
- `go test ./core/...`


------
https://chatgpt.com/codex/tasks/task_e_688c278ebe80832093ba97005dd91881