### PR TITLE
Add DAO staking module and CLI

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -72,6 +72,7 @@ all modules from the core library. Highlights include:
 - `sidechain` – launch and interact with sidechains
 - `state_channel` – open and settle payment channels
 - `storage` – interact with on‑chain storage providers
+- `staking` – lock and release tokens for governance
 - `tokens` – ERC‑20 style token commands
 - `transactions` – build and sign transactions
 - `utility_functions` – assorted helpers

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -32,6 +32,7 @@ The native asset powering the network is `SYNTHRON` (ticker: THRON). It has thre
 - **Payment and Transaction Fees** – Every on-chain action consumes gas priced in THRON.
 - **Staking** – Validators must lock tokens to participate in consensus and receive block rewards.
 - **Governance** – Token holders vote on protocol parameters, feature releases, and treasury expenditures.
+- **DAO Staking** – Users may stake THRON to earn voting power in the on-chain DAO.
 
 ### Token Distribution
 Initial supply is minted at genesis with a gradual release schedule:

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -30,6 +30,7 @@ The following command groups expose the same functionality available in the core
 - **sidechain** – Launch side chains or interact with remote side‑chain nodes.
 - **state_channel** – Open, close and settle payment channels.
 - **storage** – Configure the backing key/value store and inspect content.
+- **staking** – Stake and unstake tokens for DAO governance.
 - **tokens** – Register new token types and move balances between accounts.
 - **transactions** – Build raw transactions, sign them and broadcast to the network.
 - **utility_functions** – Miscellaneous helpers shared by other command groups.
@@ -340,6 +341,15 @@ needed in custom tooling.
 | `deal:close` | Close a storage deal and release funds. |
 | `deal:get` | Get details for a storage deal. |
 | `deal:list` | List storage deals. |
+
+### staking
+
+| Sub-command | Description |
+|-------------|-------------|
+| `stake <addr> <amt>` | Stake tokens to participate in governance. |
+| `unstake <addr> <amt>` | Unstake previously locked tokens. |
+| `balance <addr>` | Show staked balance of an address. |
+| `total` | Display the total amount staked. |
 
 ### tokens
 

--- a/synnergy-network/cmd/cli/dao_staking.go
+++ b/synnergy-network/cmd/cli/dao_staking.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+var (
+	stakeOnce   sync.Once
+	stakeLedger *core.Ledger
+	stakeMgr    *core.DAOStaking
+)
+
+func stakeInit(cmd *cobra.Command, _ []string) error {
+	var err error
+	stakeOnce.Do(func() {
+		_ = godotenv.Load()
+		wal := envOr("LEDGER_WAL", "./ledger.wal")
+		snap := envOr("LEDGER_SNAPSHOT", "./ledger.snap")
+		interval := envOrInt("LEDGER_SNAPSHOT_INTERVAL", 100)
+		stakeLedger, err = core.NewLedger(core.LedgerConfig{
+			WALPath:          wal,
+			SnapshotPath:     snap,
+			SnapshotInterval: interval,
+		})
+		if err != nil {
+			return
+		}
+		core.InitDAOStaking(logrus.StandardLogger(), stakeLedger)
+		stakeMgr = core.StakingManager()
+	})
+	return err
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func envOrInt(k string, def int) int {
+	if v := os.Getenv(k); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+// -----------------------------------------------------------------------------
+// Commands
+// -----------------------------------------------------------------------------
+
+var stakeCmd = &cobra.Command{Use: "staking", Short: "DAO staking", PersistentPreRunE: stakeInit}
+
+var stakeDoCmd = &cobra.Command{
+	Use:   "stake <addr> <amount>",
+	Short: "Lock tokens for governance",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := core.StringToAddress(args[0])
+		if err != nil {
+			return err
+		}
+		amt, err := strconv.ParseUint(args[1], 10, 64)
+		if err != nil {
+			return err
+		}
+		return stakeMgr.Stake(addr, amt)
+	},
+}
+
+var stakeUnCmd = &cobra.Command{
+	Use:   "unstake <addr> <amount>",
+	Short: "Release staked tokens",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := core.StringToAddress(args[0])
+		if err != nil {
+			return err
+		}
+		amt, err := strconv.ParseUint(args[1], 10, 64)
+		if err != nil {
+			return err
+		}
+		return stakeMgr.Unstake(addr, amt)
+	},
+}
+
+var stakeBalCmd = &cobra.Command{
+	Use:   "balance <addr>",
+	Short: "Show staked balance",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := core.StringToAddress(args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Println(stakeMgr.StakedOf(addr))
+		return nil
+	},
+}
+
+var stakeTotalCmd = &cobra.Command{
+	Use:   "total",
+	Short: "Total staked tokens",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(stakeMgr.TotalStaked())
+		return nil
+	},
+}
+
+func init() { stakeCmd.AddCommand(stakeDoCmd, stakeUnCmd, stakeBalCmd, stakeTotalCmd) }
+
+// StakingCmd exported for CLI index
+var StakingCmd = stakeCmd
+
+func RegisterStaking(root *cobra.Command) { root.AddCommand(StakingCmd) }

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -30,6 +30,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ChannelRoute,
 		StorageRoute,
 		UtilityRoute,
+		StakingCmd,
 	)
 
 	// modules that expose constructors

--- a/synnergy-network/core/dao_staking.go
+++ b/synnergy-network/core/dao_staking.go
@@ -1,0 +1,141 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+)
+
+// DAOStaking manages token staking for governance participation.
+// Balances are persisted in the ledger key/value store under the
+// prefix "dao:stake:". The total locked amount is tracked separately
+// for quick access by consensus or reward modules.
+
+type DAOStaking struct {
+	logger *log.Logger
+	ledger StateRW
+	mu     sync.Mutex
+}
+
+var (
+	stakingOnce sync.Once
+	stakingMgr  *DAOStaking
+)
+
+// InitDAOStaking initialises the global staking manager. It must be
+// called before using any staking operations.
+func InitDAOStaking(lg *log.Logger, led StateRW) {
+	stakingOnce.Do(func() {
+		stakingMgr = &DAOStaking{logger: lg, ledger: led}
+	})
+}
+
+// StakingManager returns the singleton staking engine.
+func StakingManager() *DAOStaking { return stakingMgr }
+
+const (
+	stakePrefix = "dao:stake:"
+	totalKey    = "dao:stake:total"
+)
+
+// Stake locks the given amount of the base coin from addr.
+func (s *DAOStaking) Stake(addr Address, amt uint64) error {
+	if s == nil || s.ledger == nil {
+		return errors.New("staking not initialised")
+	}
+	if amt == 0 {
+		return errors.New("zero amount")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.ledger.Transfer(addr, AddressZero, amt); err != nil {
+		return err
+	}
+
+	bal := s.stakedOf(addr)
+	bal += amt
+	b, _ := json.Marshal(bal)
+	if err := s.ledger.SetState([]byte(stakePrefix+addr.String()), b); err != nil {
+		return err
+	}
+
+	tot := s.totalLocked() + amt
+	tb, _ := json.Marshal(tot)
+	if err := s.ledger.SetState([]byte(totalKey), tb); err != nil {
+		return err
+	}
+	s.logger.Printf("stake %d from %s", amt, addr.Short())
+	return nil
+}
+
+// Unstake releases previously locked coins back to addr.
+func (s *DAOStaking) Unstake(addr Address, amt uint64) error {
+	if s == nil || s.ledger == nil {
+		return errors.New("staking not initialised")
+	}
+	if amt == 0 {
+		return errors.New("zero amount")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	bal := s.stakedOf(addr)
+	if bal < amt {
+		return fmt.Errorf("insufficient staked balance")
+	}
+	bal -= amt
+	b, _ := json.Marshal(bal)
+	if err := s.ledger.SetState([]byte(stakePrefix+addr.String()), b); err != nil {
+		return err
+	}
+
+	tot := s.totalLocked() - amt
+	tb, _ := json.Marshal(tot)
+	if err := s.ledger.SetState([]byte(totalKey), tb); err != nil {
+		return err
+	}
+
+	if err := s.ledger.Transfer(AddressZero, addr, amt); err != nil {
+		return err
+	}
+	s.logger.Printf("unstake %d to %s", amt, addr.Short())
+	return nil
+}
+
+// StakedOf returns the current staked amount for addr.
+func (s *DAOStaking) StakedOf(addr Address) uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stakedOf(addr)
+}
+
+// TotalStaked returns the total tokens locked across all accounts.
+func (s *DAOStaking) TotalStaked() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.totalLocked()
+}
+
+func (s *DAOStaking) stakedOf(addr Address) uint64 {
+	raw, _ := s.ledger.GetState([]byte(stakePrefix + addr.String()))
+	if len(raw) == 0 {
+		return 0
+	}
+	var bal uint64
+	_ = json.Unmarshal(raw, &bal)
+	return bal
+}
+
+func (s *DAOStaking) totalLocked() uint64 {
+	raw, _ := s.ledger.GetState([]byte(totalKey))
+	if len(raw) == 0 {
+		return 0
+	}
+	var tot uint64
+	_ = json.Unmarshal(raw, &tot)
+	return tot
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -193,6 +193,10 @@ var gasTable map[Opcode]uint64
    ExecuteProposal: 15_000,
    GetProposal:     1_000,
    ListProposals:   2_000,
+   DAO_Stake:       5_000,
+   DAO_Unstake:     5_000,
+   DAO_Staked:      500,
+   DAO_TotalStaked: 500,
 
    // ----------------------------------------------------------------------
    // Green Technology
@@ -769,6 +773,10 @@ var gasNames = map[string]uint64{
 	"ExecuteProposal": 15_000,
 	"GetProposal":     1_000,
 	"ListProposals":   2_000,
+	"DAO_Stake":       5_000,
+	"DAO_Unstake":     5_000,
+	"DAO_Staked":      500,
+	"DAO_TotalStaked": 500,
 
 	// ----------------------------------------------------------------------
 	// Green Technology

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -238,6 +238,10 @@ var catalogue = []struct {
 	{"ExecuteProposal", 0x0C0008},
 	{"GetProposal", 0x0C0009},
 	{"ListProposals", 0x0C000A},
+	{"DAO_Stake", 0x0C000B},
+	{"DAO_Unstake", 0x0C000C},
+	{"DAO_Staked", 0x0C000D},
+	{"DAO_TotalStaked", 0x0C000E},
 
 	// GreenTech (0x0D)
 	{"InitGreenTech", 0x0D0001},


### PR DESCRIPTION
## Summary
- introduce `DAOStaking` core module with stake and unstake logic
- register new DAO staking opcodes and gas costs
- add `staking` CLI commands and expose via CLI index
- document staking commands in README, CLI guide, and whitepaper

## Testing
- `go vet ./...` *(fails: cmd/cli package errors)*
- `go build ./core/...`
- `go build ./cmd/cli/...` *(fails: cmd/cli package errors)*
- `go test ./core/...`


------
https://chatgpt.com/codex/tasks/task_e_688c287b457883209425f8152609ca2c