### PR TITLE
Add Merkle tree operations

### DIFF
--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -310,6 +310,9 @@ var gasTable map[Opcode]uint64
    DilithiumVerify:   5_000,
    PredictRisk:       2_000,
    AnomalyScore:      2_000,
+   BuildMerkleTree:   1_500,
+   MerkleProof:       1_200,
+   VerifyMerklePath:  1_200,
 
    // ----------------------------------------------------------------------
    // Sharding
@@ -886,6 +889,9 @@ var gasNames = map[string]uint64{
 	"DilithiumVerify":   5_000,
 	"PredictRisk":       2_000,
 	"AnomalyScore":      2_000,
+	"BuildMerkleTree":   1_500,
+	"MerkleProof":       1_200,
+	"VerifyMerklePath":  1_200,
 
 	// ----------------------------------------------------------------------
 	// Sharding

--- a/synnergy-network/core/merkle_tree_operations.go
+++ b/synnergy-network/core/merkle_tree_operations.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+)
+
+// BuildMerkleTree returns the level-by-level nodes of a Merkle tree built from
+// the provided leaves. Each leaf is hashed using SHA-256. The last slice
+// contains the single root hash.
+func BuildMerkleTree(leaves [][]byte) ([][][32]byte, error) {
+	if len(leaves) == 0 {
+		return nil, errors.New("no leaves")
+	}
+
+	// first level: hashed leaves
+	level := make([][32]byte, len(leaves))
+	for i, l := range leaves {
+		level[i] = sha256.Sum256(l)
+	}
+
+	tree := [][][32]byte{level}
+
+	for len(level) > 1 {
+		if len(level)%2 == 1 {
+			level = append(level, level[len(level)-1])
+		}
+		next := make([][32]byte, len(level)/2)
+		for i := 0; i < len(level); i += 2 {
+			next[i/2] = sha256.Sum256(append(level[i][:], level[i+1][:]...))
+		}
+		tree = append(tree, next)
+		level = next
+	}
+
+	return tree, nil
+}
+
+// MerkleProof returns a Merkle proof for the leaf at the given index along with
+// the tree's root hash. The proof slice is ordered from leaf level upwards.
+func MerkleProof(leaves [][]byte, index uint32) ([][]byte, [32]byte, error) {
+	if len(leaves) == 0 {
+		return nil, [32]byte{}, errors.New("no leaves")
+	}
+	if int(index) >= len(leaves) {
+		return nil, [32]byte{}, errors.New("index out of range")
+	}
+
+	tree, err := BuildMerkleTree(leaves)
+	if err != nil {
+		return nil, [32]byte{}, err
+	}
+
+	proof := make([][]byte, 0, len(tree)-1)
+	idx := int(index)
+	for i := 0; i < len(tree)-1; i++ {
+		level := tree[i]
+		if idx%2 == 0 {
+			proof = append(proof, level[idx+1][:])
+		} else {
+			proof = append(proof, level[idx-1][:])
+		}
+		idx /= 2
+	}
+
+	root := tree[len(tree)-1][0]
+	return proof, root, nil
+}
+
+// VerifyMerklePath checks whether the supplied proof reconstructs the provided
+// root for the given leaf and index. Proof hashes must be ordered from leaf
+// upwards.
+func VerifyMerklePath(root [32]byte, leaf []byte, proof [][]byte, index uint32) bool {
+	h := sha256.Sum256(leaf)
+	hash := h[:]
+	for _, p := range proof {
+		if index%2 == 0 {
+			pair := append(hash, p...)
+			sum := sha256.Sum256(pair)
+			hash = sum[:]
+		} else {
+			pair := append(p, hash...)
+			sum := sha256.Sum256(pair)
+			hash = sum[:]
+		}
+		index /= 2
+	}
+	return bytes.Equal(hash, root[:])
+}

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -349,6 +349,9 @@ var catalogue = []struct {
 	{"DilithiumVerify", 0x14000C},
 	{"PredictRisk", 0x14000D},
 	{"AnomalyScore", 0x14000E},
+	{"BuildMerkleTree", 0x14000F},
+	{"MerkleProof", 0x140010},
+	{"VerifyMerklePath", 0x140011},
 
 	// Sharding (0x15)
 	{"NewShardCoordinator", 0x150001},


### PR DESCRIPTION
## Summary
- add generic Merkle tree utilities
- map new utilities in `gas_table.go`
- register opcodes for the utilities in `opcode_dispatcher.go`

## Testing
- `go vet ./core`
- `go build ./core`
- `go test ./tests -run TestComputeMerkleRoot` *(fails: undefined types)*

------
https://chatgpt.com/codex/tasks/task_e_688c2938a97c83209621273144bed761