### PR TITLE
Add governance timelock module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -62,6 +62,7 @@ all modules from the core library. Highlights include:
 - `data` – inspect and manage raw data storage
 - `fault_tolerance` – simulate faults and backups
 - `governance` – DAO style governance commands
+- `timelock` – schedule and execute delayed proposals
 - `green_technology` – sustainability features
 - `ledger` – low level ledger inspection
 - `network` – libp2p networking helpers

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -56,6 +56,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `data` – Low-level debugging of key/value storage and oracles.
 - `fault_tolerance` – Simulate network failures and snapshot recovery.
 - `governance` – Create proposals and cast votes.
+- `timelock` – Delay proposal execution via a queue.
 - `green_technology` – Manage energy tracking and carbon offsets.
 - `ledger` – Inspect blocks, accounts, and token metrics.
 - `liquidity_pools` – Create pools and provide liquidity.

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -20,6 +20,7 @@ The following command groups expose the same functionality available in the core
 - **data** – Inspect raw key/value pairs in the underlying data store for debugging.
 - **fault_tolerance** – Inject faults, simulate network partitions and test recovery procedures.
 - **governance** – Create proposals, cast votes and check DAO parameters.
+- **timelock** – Manage delayed proposal execution.
 - **green_technology** – View energy metrics and toggle any experimental sustainability features.
 - **ledger** – Inspect blocks, query balances and perform administrative token operations via the ledger daemon.
 - **network** – Manage peer connections and print networking statistics.
@@ -199,6 +200,15 @@ needed in custom tooling.
 | `execute <proposal-id>` | Execute a proposal after the deadline. |
 | `get <proposal-id>` | Display a single proposal. |
 | `list` | List all proposals. |
+
+### timelock
+
+| Sub-command | Description |
+|-------------|-------------|
+| `queue <proposal-id>` | Queue a proposal with a delay. |
+| `cancel <proposal-id>` | Remove a queued proposal. |
+| `execute` | Execute all due proposals. |
+| `list` | List queued proposals. |
 
 ### green_technology
 

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -23,6 +23,7 @@ func RegisterRoutes(root *cobra.Command) {
 		PoolsCmd,
 		AuthCmd,
 		CharityCmd,
+		TimelockCmd,
 		LoanCmd,
 		ComplianceCmd,
 		CrossChainCmd,

--- a/synnergy-network/cmd/cli/timelock.go
+++ b/synnergy-network/cmd/cli/timelock.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+var (
+	tl     *core.Timelock
+	tlOnce sync.Once
+	tlLog  = logrus.StandardLogger()
+)
+
+func timelockInit(cmd *cobra.Command, _ []string) error {
+	var err error
+	tlOnce.Do(func() {
+		_ = godotenv.Load()
+		lvl := os.Getenv("LOG_LEVEL")
+		if lvl == "" {
+			lvl = "info"
+		}
+		lv, e := logrus.ParseLevel(lvl)
+		if e != nil {
+			err = e
+			return
+		}
+		tlLog.SetLevel(lv)
+		tl = core.NewTimelock()
+	})
+	return err
+}
+
+func tlHandleQueue(cmd *cobra.Command, args []string) error {
+	durStr, _ := cmd.Flags().GetString("delay")
+	delay, err := time.ParseDuration(durStr)
+	if err != nil {
+		return err
+	}
+	return tl.QueueProposal(args[0], delay)
+}
+
+func tlHandleCancel(cmd *cobra.Command, args []string) error {
+	return tl.CancelProposal(args[0])
+}
+
+func tlHandleExecute(cmd *cobra.Command, _ []string) error {
+	executed := tl.ExecuteReady()
+	for _, id := range executed {
+		fmt.Fprintln(cmd.OutOrStdout(), id)
+	}
+	return nil
+}
+
+func tlHandleList(cmd *cobra.Command, _ []string) error {
+	entries := tl.ListTimelocks()
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(entries)
+}
+
+var timelockCmd = &cobra.Command{
+	Use:               "timelock",
+	Short:             "Governance timelock operations",
+	PersistentPreRunE: timelockInit,
+}
+
+var tlQueueCmd = &cobra.Command{Use: "queue <proposal-id>", Args: cobra.ExactArgs(1), RunE: tlHandleQueue, Short: "Queue a proposal"}
+var tlCancelCmd = &cobra.Command{Use: "cancel <proposal-id>", Args: cobra.ExactArgs(1), RunE: tlHandleCancel, Short: "Cancel a queued proposal"}
+var tlExecuteCmd = &cobra.Command{Use: "execute", RunE: tlHandleExecute, Short: "Execute due proposals"}
+var tlListCmd = &cobra.Command{Use: "list", RunE: tlHandleList, Short: "List queued proposals"}
+
+func init() {
+	tlQueueCmd.Flags().String("delay", "24h", "time until execution")
+	timelockCmd.AddCommand(tlQueueCmd, tlCancelCmd, tlExecuteCmd, tlListCmd)
+}
+
+var TimelockCmd = timelockCmd

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -193,6 +193,11 @@ var gasTable map[Opcode]uint64
    ExecuteProposal: 15_000,
    GetProposal:     1_000,
    ListProposals:   2_000,
+   NewTimelock:     4_000,
+   QueueProposal:   3_000,
+   CancelProposal:  3_000,
+   ExecuteReady:    5_000,
+   ListTimelocks:   1_000,
 
    // ----------------------------------------------------------------------
    // Green Technology
@@ -769,6 +774,11 @@ var gasNames = map[string]uint64{
 	"ExecuteProposal": 15_000,
 	"GetProposal":     1_000,
 	"ListProposals":   2_000,
+	"NewTimelock":     4_000,
+	"QueueProposal":   3_000,
+	"CancelProposal":  3_000,
+	"ExecuteReady":    5_000,
+	"ListTimelocks":   1_000,
 
 	// ----------------------------------------------------------------------
 	// Green Technology

--- a/synnergy-network/core/governance_timelock.go
+++ b/synnergy-network/core/governance_timelock.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// TimelockEntry represents a queued governance proposal with its execution time.
+type TimelockEntry struct {
+	ID        string    `json:"id"`
+	ExecuteAt time.Time `json:"execute_at"`
+}
+
+// Timelock coordinates delayed execution of governance proposals. It is
+// concurrency-safe and designed to be invoked by the consensus service each
+// block so that due proposals are executed automatically.
+type Timelock struct {
+	mu    sync.Mutex
+	queue map[string]*TimelockEntry
+}
+
+// Errors returned by timelock operations.
+var (
+	ErrAlreadyQueued = errors.New("proposal already queued")
+	ErrNotQueued     = errors.New("proposal not queued")
+)
+
+// NewTimelock initialises an empty timelock queue.
+func NewTimelock() *Timelock {
+	return &Timelock{queue: make(map[string]*TimelockEntry)}
+}
+
+// QueueProposal schedules a proposal for execution after the provided delay.
+// It returns ErrAlreadyQueued if the proposal was already queued.
+func (t *Timelock) QueueProposal(id string, delay time.Duration) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, exists := t.queue[id]; exists {
+		return ErrAlreadyQueued
+	}
+	t.queue[id] = &TimelockEntry{ID: id, ExecuteAt: time.Now().Add(delay)}
+	return nil
+}
+
+// CancelProposal removes a queued proposal from the timelock.
+func (t *Timelock) CancelProposal(id string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.queue[id]; !ok {
+		return ErrNotQueued
+	}
+	delete(t.queue, id)
+	return nil
+}
+
+// List returns a snapshot of all queued proposals.
+func (t *Timelock) ListTimelocks() []TimelockEntry {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]TimelockEntry, 0, len(t.queue))
+	for _, e := range t.queue {
+		out = append(out, *e)
+	}
+	return out
+}
+
+// ExecuteReady executes all proposals whose delay has passed. It returns the
+// list of proposal IDs that were executed. Errors from ExecuteProposal are
+// ignored but logged inside ExecuteProposal itself.
+func (t *Timelock) ExecuteReady() []string {
+	now := time.Now()
+	t.mu.Lock()
+	ready := make([]string, 0)
+	for id, e := range t.queue {
+		if !e.ExecuteAt.After(now) {
+			ready = append(ready, id)
+			delete(t.queue, id)
+		}
+	}
+	t.mu.Unlock()
+	for _, id := range ready {
+		_ = ExecuteProposal(id)
+	}
+	return ready
+}

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -238,6 +238,11 @@ var catalogue = []struct {
 	{"ExecuteProposal", 0x0C0008},
 	{"GetProposal", 0x0C0009},
 	{"ListProposals", 0x0C000A},
+	{"NewTimelock", 0x0C000B},
+	{"QueueProposal", 0x0C000C},
+	{"CancelProposal", 0x0C000D},
+	{"ExecuteReady", 0x0C000E},
+	{"ListTimelocks", 0x0C000F},
 
 	// GreenTech (0x0D)
 	{"InitGreenTech", 0x0D0001},


### PR DESCRIPTION
## Summary
- implement `Timelock` queue in core
- register new governance opcodes and gas costs
- expose `timelock` CLI commands
- wire timelock into CLI index
- document timelock command in README, CLI guide and Whitepaper

## Testing
- `go vet ./core` *(passed)*
- `go vet ./cmd/cli` *(failed: loanpool.go not compiling)*
- `go build ./core/... ./cmd/cli` *(failed: build errors in cmd/cli)*
- `go test ./core/...` *(passed)*
- `go test ./cmd/cli` *(failed: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c2aa7adf88320a207f22aa2899ed3