### PR TITLE
Add cross-chain bridge module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -59,6 +59,7 @@ all modules from the core library. Highlights include:
 - `consensus` – control the consensus engine
 - `contracts` – deploy and invoke smart contracts
 - `cross_chain` – configure asset bridges
+- `cross_chain_bridge` – manage cross-chain transfers
 - `data` – inspect and manage raw data storage
 - `fault_tolerance` – simulate faults and backups
 - `governance` – DAO style governance commands

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -55,6 +55,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `cross_chain` – Bridge assets to and from external chains.
 - `data` – Low-level debugging of key/value storage and oracles.
 - `fault_tolerance` – Simulate network failures and snapshot recovery.
+- `cross_chain_bridge` – Manage cross-chain transfers.
 - `governance` – Create proposals and cast votes.
 - `green_technology` – Manage energy tracking and carbon offsets.
 - `ledger` – Inspect blocks, accounts, and token metrics.

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -17,6 +17,7 @@ The following command groups expose the same functionality available in the core
 - **consensus** – Start, stop or inspect the node's consensus service. Provides status metrics for debugging.
 - **contracts** – Deploy, upgrade and invoke smart contracts stored on chain.
 - **cross_chain** – Bridge assets to or from other chains using lock and release commands.
+- **cross_chain_bridge** – Manage cross-chain token transfers.
 - **data** – Inspect raw key/value pairs in the underlying data store for debugging.
 - **fault_tolerance** – Inject faults, simulate network partitions and test recovery procedures.
 - **governance** – Create proposals, cast votes and check DAO parameters.
@@ -151,6 +152,15 @@ needed in custom tooling.
 | `get <bridge_id>` | Retrieve a bridge configuration. |
 | `authorize <relayer_addr>` | Whitelist a relayer address. |
 | `revoke <relayer_addr>` | Remove a relayer from the whitelist. |
+
+### cross_chain_bridge
+
+| Sub-command | Description |
+|-------------|-------------|
+| `deposit <bridge_id> <from> <to> <amount> [tokenID]` | Lock assets for bridging. |
+| `claim <transfer_id> <proof.json>` | Release assets using a proof. |
+| `get <id>` | Show a transfer record. |
+| `list` | List all transfers. |
 
 ### data
 

--- a/synnergy-network/cmd/cli/cross_chain_bridge.go
+++ b/synnergy-network/cmd/cli/cross_chain_bridge.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	core "synnergy-network/core"
+)
+
+// ---------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------
+
+func xbridgeParseAddr(hexStr string) (core.Address, error) {
+	var a core.Address
+	b, err := hex.DecodeString(strings.TrimPrefix(hexStr, "0x"))
+	if err != nil || len(b) != len(a) {
+		return a, fmt.Errorf("invalid address")
+	}
+	copy(a[:], b)
+	return a, nil
+}
+
+// ---------------------------------------------------------------------
+// Controller
+// ---------------------------------------------------------------------
+
+type BridgeTransferController struct{}
+
+func (c *BridgeTransferController) Deposit(bridgeID string, from, to core.Address, amt uint64, tok *uint64) (core.BridgeTransfer, error) {
+	asset := core.AssetRef{Kind: core.AssetCoin}
+	if tok != nil {
+		asset = core.AssetRef{Kind: core.AssetToken, TokenID: core.TokenID(*tok)}
+	}
+	ctx := &core.Context{Caller: from}
+	return core.StartBridgeTransfer(ctx, bridgeID, asset, to, amt)
+}
+
+func (c *BridgeTransferController) Claim(id string, proof core.Proof) error {
+	ctx := &core.Context{}
+	return core.CompleteBridgeTransfer(ctx, id, proof)
+}
+
+func (c *BridgeTransferController) Get(id string) (core.BridgeTransfer, error) {
+	return core.GetBridgeTransfer(id)
+}
+func (c *BridgeTransferController) List() ([]core.BridgeTransfer, error) {
+	return core.ListBridgeTransfers()
+}
+
+// ---------------------------------------------------------------------
+// CLI commands
+// ---------------------------------------------------------------------
+
+var xbridgeCmd = &cobra.Command{
+	Use:               "xbridge",
+	Short:             "Manage cross-chain bridge transfers",
+	PersistentPreRunE: ensureXChainInitialised,
+}
+
+var xbridgeDepositCmd = &cobra.Command{
+	Use:   "deposit <bridge_id> <from> <to> <amount> [tokenID]",
+	Short: "Lock assets for cross-chain transfer",
+	Args:  cobra.RangeArgs(4, 5),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bridgeID := args[0]
+		from, err := xbridgeParseAddr(args[1])
+		if err != nil {
+			return err
+		}
+		to, err := xbridgeParseAddr(args[2])
+		if err != nil {
+			return err
+		}
+		amt, err := strconv.ParseUint(args[3], 10, 64)
+		if err != nil {
+			return err
+		}
+		var token *uint64
+		if len(args) == 5 {
+			v, err := strconv.ParseUint(args[4], 10, 64)
+			if err != nil {
+				return err
+			}
+			token = &v
+		}
+		ctrl := &BridgeTransferController{}
+		rec, err := ctrl.Deposit(bridgeID, from, to, amt, token)
+		if err != nil {
+			return err
+		}
+		enc, _ := json.MarshalIndent(rec, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(enc))
+		return nil
+	},
+}
+
+var xbridgeClaimCmd = &cobra.Command{
+	Use:   "claim <transfer_id> <proof.json>",
+	Short: "Release a locked transfer using SPV proof",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		data, err := ioutil.ReadFile(args[1])
+		if err != nil {
+			return err
+		}
+		var p core.Proof
+		if err := json.Unmarshal(data, &p); err != nil {
+			return err
+		}
+		ctrl := &BridgeTransferController{}
+		if err := ctrl.Claim(args[0], p); err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "transfer released")
+		return nil
+	},
+}
+
+var xbridgeGetCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Show a transfer record",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctrl := &BridgeTransferController{}
+		rec, err := ctrl.Get(args[0])
+		if err != nil {
+			return err
+		}
+		enc, _ := json.MarshalIndent(rec, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(enc))
+		return nil
+	},
+}
+
+var xbridgeListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List transfer records",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		ctrl := &BridgeTransferController{}
+		recs, err := ctrl.List()
+		if err != nil {
+			return err
+		}
+		enc, _ := json.MarshalIndent(recs, "", "  ")
+		fmt.Fprintln(cmd.OutOrStdout(), string(enc))
+		return nil
+	},
+}
+
+func init() {
+	xbridgeCmd.AddCommand(xbridgeDepositCmd, xbridgeClaimCmd, xbridgeGetCmd, xbridgeListCmd)
+}
+
+// Export
+var XBridgeCmd = xbridgeCmd

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -26,6 +26,7 @@ func RegisterRoutes(root *cobra.Command) {
 		LoanCmd,
 		ComplianceCmd,
 		CrossChainCmd,
+		XBridgeCmd,
 		DataCmd,
 		ChannelRoute,
 		StorageRoute,

--- a/synnergy-network/core/cross_chain_bridge.go
+++ b/synnergy-network/core/cross_chain_bridge.go
@@ -1,0 +1,106 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// BridgeTransfer records a cross-chain transfer locked on this chain.
+type BridgeTransfer struct {
+	ID        string    `json:"id"`
+	BridgeID  string    `json:"bridge_id"`
+	From      Address   `json:"from"`
+	To        Address   `json:"to"`
+	Asset     AssetRef  `json:"asset"`
+	Amount    uint64    `json:"amount"`
+	Time      time.Time `json:"time"`
+	Completed bool      `json:"completed"`
+}
+
+// StartBridgeTransfer locks assets from the caller and records a transfer.
+func StartBridgeTransfer(ctx *Context, bridgeID string, asset AssetRef, to Address, amount uint64) (BridgeTransfer, error) {
+	if amount == 0 {
+		return BridgeTransfer{}, fmt.Errorf("amount must be positive")
+	}
+	if _, err := GetBridge(bridgeID); err != nil {
+		return BridgeTransfer{}, err
+	}
+	escrow := ModuleAddress("bridge:" + bridgeID)
+	if err := Transfer(ctx, asset, ctx.Caller, escrow, amount); err != nil {
+		return BridgeTransfer{}, err
+	}
+	bt := BridgeTransfer{
+		ID:       uuid.New().String(),
+		BridgeID: bridgeID,
+		From:     ctx.Caller,
+		To:       to,
+		Asset:    asset,
+		Amount:   amount,
+		Time:     time.Now().UTC(),
+	}
+	raw, _ := json.Marshal(bt)
+	if err := CurrentStore().Set([]byte("crosschain:transfer:"+bt.ID), raw); err != nil {
+		_ = Transfer(ctx, asset, escrow, ctx.Caller, amount)
+		return BridgeTransfer{}, err
+	}
+	Broadcast("bridge:transfer:new", raw)
+	return bt, nil
+}
+
+// CompleteBridgeTransfer releases locked assets after proof verification.
+func CompleteBridgeTransfer(ctx *Context, id string, proof Proof) error {
+	bt, err := GetBridgeTransfer(id)
+	if err != nil {
+		return err
+	}
+	if bt.Completed {
+		return fmt.Errorf("transfer already completed")
+	}
+	if !verifySPV(proof) {
+		return ErrInvalidProof
+	}
+	escrow := ModuleAddress("bridge:" + bt.BridgeID)
+	if err := Transfer(ctx, bt.Asset, escrow, bt.To, bt.Amount); err != nil {
+		return err
+	}
+	bt.Completed = true
+	raw, _ := json.Marshal(bt)
+	if err := CurrentStore().Set([]byte("crosschain:transfer:"+bt.ID), raw); err != nil {
+		return err
+	}
+	Broadcast("bridge:transfer:complete", raw)
+	return nil
+}
+
+// GetBridgeTransfer fetches a transfer record by ID.
+func GetBridgeTransfer(id string) (BridgeTransfer, error) {
+	raw, err := CurrentStore().Get([]byte("crosschain:transfer:" + id))
+	if err != nil {
+		return BridgeTransfer{}, ErrNotFound
+	}
+	var bt BridgeTransfer
+	if err := json.Unmarshal(raw, &bt); err != nil {
+		return BridgeTransfer{}, err
+	}
+	return bt, nil
+}
+
+// ListBridgeTransfers returns all transfer records sorted by creation time.
+func ListBridgeTransfers() ([]BridgeTransfer, error) {
+	it := CurrentStore().Iterator([]byte("crosschain:transfer:"), nil)
+	defer it.Close()
+	var out []BridgeTransfer
+	for it.Next() {
+		var bt BridgeTransfer
+		if err := json.Unmarshal(it.Value(), &bt); err != nil {
+			return nil, err
+		}
+		out = append(out, bt)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Time.Before(out[j].Time) })
+	return out, it.Error()
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -146,6 +146,10 @@ var gasTable map[Opcode]uint64
    LockAndMint:    30_000,
    BurnAndRelease: 30_000,
    GetBridge:      1_000,
+   StartBridgeTransfer:    25_000,
+   CompleteBridgeTransfer: 25_000,
+   GetBridgeTransfer:      1_000,
+   ListBridgeTransfers:    2_000,
 
    // ----------------------------------------------------------------------
    // Data / Oracle / IPFS Integration
@@ -716,12 +720,16 @@ var gasNames = map[string]uint64{
 	// ----------------------------------------------------------------------
 	// Cross-Chain
 	// ----------------------------------------------------------------------
-	"RegisterBridge": 20_000,
-	"AssertRelayer":  5_000,
-	"Iterator":       2_000,
-	"LockAndMint":    30_000,
-	"BurnAndRelease": 30_000,
-	"GetBridge":      1_000,
+	"RegisterBridge":         20_000,
+	"AssertRelayer":          5_000,
+	"Iterator":               2_000,
+	"LockAndMint":            30_000,
+	"BurnAndRelease":         30_000,
+	"GetBridge":              1_000,
+	"StartBridgeTransfer":    25_000,
+	"CompleteBridgeTransfer": 25_000,
+	"GetBridgeTransfer":      1_000,
+	"ListBridgeTransfers":    2_000,
 
 	// ----------------------------------------------------------------------
 	// Data / Oracle / IPFS Integration

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -197,6 +197,10 @@ var catalogue = []struct {
 	{"LockAndMint", 0x090004},
 	{"BurnAndRelease", 0x090005},
 	{"GetBridge", 0x090006},
+	{"StartBridgeTransfer", 0x090007},
+	{"CompleteBridgeTransfer", 0x090008},
+	{"GetBridgeTransfer", 0x090009},
+	{"ListBridgeTransfers", 0x09000A},
 
 	// Data (0x0A)
 	{"RegisterNode", 0x0A0001},


### PR DESCRIPTION
## Summary
- implement `cross_chain_bridge.go` in core with transfer logic
- expose bridge transfer commands in new CLI file
- wire XBridge command into CLI index
- register opcodes and gas costs for new functions
- document cross-chain bridge CLI in README, CLI guide, and Whitepaper

## Testing
- `go vet ./core`
- `go build ./core`
- `go test ./core/...`
- `go build ./cmd/cli` *(fails: loanpool.go and other files)*

------
https://chatgpt.com/codex/tasks/task_e_688c31b0b6b88320849506e7e6b796b5