### PR TITLE
Add bootstrap node service and CLI

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -65,6 +65,7 @@ all modules from the core library. Highlights include:
 - `green_technology` – sustainability features
 - `ledger` – low level ledger inspection
 - `network` – libp2p networking helpers
+- `bootstrap` – run a dedicated bootstrap node for peers
 - `replication` – snapshot and replicate data
 - `rollups` – manage rollup batches
 - `security` – cryptographic utilities
@@ -93,7 +94,7 @@ packages.
 Runtime settings are defined using YAML files in `cmd/config/`.  The CLI loads
 `default.yaml` by default and merges any environment specific file if the
 `SYNN_ENV` environment variable is set (for example `SYNN_ENV=prod`).
-`bootstrap.yaml` provides a template for running a dedicated bootstrap node.
+`bootstrap.yaml` provides a template for running a dedicated bootstrap node. You can launch it via `synnergy bootstrap start` and point other nodes to its address.
 The configuration schema is documented in [`cmd/config/config_guide.md`](cmd/config/config_guide.md).
 
 ## Running a Local Network

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -20,6 +20,7 @@ All services are optional and run as independent modules that plug into the core
 ## Synnergy Network Architecture
 At a high level the network consists of:
 1. **Peer-to-Peer Network** – Validators communicate using libp2p with gossip-based transaction propagation.
+   Dedicated bootstrap nodes can be run using the CLI to help new peers discover the network.
 2. **Consensus Engine** – A hybrid approach combines Proof of History (PoH) and Proof of Stake (PoS) with pluggable modules for alternative algorithms.
 3. **Ledger** – Blocks contain sub-blocks that optimize for data availability. Smart contracts and token transfers are recorded here.
 4. **Virtual Machine** – The dispatcher assigns a 24-bit opcode to every protocol function. Gas is charged before execution using a deterministic cost table.

--- a/synnergy-network/cmd/cli/bootstrap_node.go
+++ b/synnergy-network/cmd/cli/bootstrap_node.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"synnergy-network/core"
+)
+
+var (
+	bootNode *core.BootstrapNode
+	bootMu   sync.RWMutex
+)
+
+func bootEnvOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func bootEnvOrInt(k string, def int) int {
+	if v := os.Getenv(k); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func bootInit(cmd *cobra.Command, _ []string) error {
+	if bootNode != nil {
+		return nil
+	}
+	_ = godotenv.Load()
+
+	lv, err := logrus.ParseLevel(viper.GetString("logging.level"))
+	if err != nil {
+		return err
+	}
+	logrus.SetLevel(lv)
+
+	netCfg := core.Config{
+		ListenAddr:     viper.GetString("network.listen_addr"),
+		BootstrapPeers: viper.GetStringSlice("network.bootstrap_peers"),
+		DiscoveryTag:   viper.GetString("network.discovery_tag"),
+	}
+	wal := bootEnvOr("LEDGER_WAL", "./ledger.wal")
+	snap := bootEnvOr("LEDGER_SNAPSHOT", "./ledger.snap")
+	interval := bootEnvOrInt("LEDGER_SNAPSHOT_INTERVAL", 100)
+	ledCfg := core.LedgerConfig{WALPath: wal, SnapshotPath: snap, SnapshotInterval: interval}
+
+	repCfg := &core.ReplicationConfig{MaxConcurrent: 2, ChunksPerSec: 10, RetryBackoff: time.Second,
+		PeerThreshold: 1, Fanout: 2, RequestTimeout: 5 * time.Second, SyncBatchSize: 100}
+
+	node, err := core.NewBootstrapNode(&core.BootstrapConfig{Network: netCfg, Ledger: ledCfg, Replication: repCfg})
+	if err != nil {
+		return err
+	}
+	bootMu.Lock()
+	bootNode = node
+	bootMu.Unlock()
+	return nil
+}
+
+func bootStart(cmd *cobra.Command, _ []string) error {
+	bootMu.RLock()
+	b := bootNode
+	bootMu.RUnlock()
+	if b == nil {
+		return fmt.Errorf("not initialised")
+	}
+	b.Start()
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+		<-sig
+		_ = b.Stop()
+		os.Exit(0)
+	}()
+	fmt.Fprintln(cmd.OutOrStdout(), "bootstrap node started")
+	return nil
+}
+
+func bootStop(cmd *cobra.Command, _ []string) error {
+	bootMu.RLock()
+	b := bootNode
+	bootMu.RUnlock()
+	if b == nil {
+		fmt.Fprintln(cmd.OutOrStdout(), "not running")
+		return nil
+	}
+	_ = b.Stop()
+	bootMu.Lock()
+	bootNode = nil
+	bootMu.Unlock()
+	fmt.Fprintln(cmd.OutOrStdout(), "stopped")
+	return nil
+}
+
+func bootPeers(cmd *cobra.Command, _ []string) error {
+	bootMu.RLock()
+	b := bootNode
+	bootMu.RUnlock()
+	if b == nil {
+		return fmt.Errorf("not running")
+	}
+	for _, p := range b.Peers() {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\n", p.ID, p.Addr)
+	}
+	return nil
+}
+
+var bootRootCmd = &cobra.Command{Use: "bootstrap", Short: "Run bootstrap node", PersistentPreRunE: bootInit}
+var bootStartCmd = &cobra.Command{Use: "start", Short: "Start bootstrap node", RunE: bootStart}
+var bootStopCmd = &cobra.Command{Use: "stop", Short: "Stop bootstrap node", RunE: bootStop}
+var bootPeersCmd = &cobra.Command{Use: "peers", Short: "List peers", RunE: bootPeers}
+
+func init() { bootRootCmd.AddCommand(bootStartCmd, bootStopCmd, bootPeersCmd) }
+
+var BootstrapCmd = bootRootCmd
+
+func RegisterBootstrap(root *cobra.Command) { root.AddCommand(BootstrapCmd) }

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -23,6 +23,7 @@ The following command groups expose the same functionality available in the core
 - **green_technology** – View energy metrics and toggle any experimental sustainability features.
 - **ledger** – Inspect blocks, query balances and perform administrative token operations via the ledger daemon.
 - **network** – Manage peer connections and print networking statistics.
+- **bootstrap** – Start a dedicated bootstrap node for new peers.
 - **replication** – Trigger snapshot creation and replicate the ledger to new nodes.
 - **rollups** – Create rollup batches or inspect existing ones.
 - **security** – Key generation, signing utilities and password helpers.
@@ -254,6 +255,14 @@ needed in custom tooling.
 | `peers` | List connected peers. |
 | `broadcast <topic> <data>` | Publish data on the network. |
 | `subscribe <topic>` | Subscribe to a topic. |
+
+### bootstrap
+
+| Sub-command | Description |
+|-------------|-------------|
+| `start` | Start the bootstrap node. |
+| `stop` | Stop the bootstrap node. |
+| `peers` | List peers connected to the bootstrap node. |
 
 ### replication
 

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -11,6 +11,7 @@ func RegisterRoutes(root *cobra.Command) {
 	// modules with exported command variables
 	root.AddCommand(
 		NetworkCmd,
+		BootstrapCmd,
 		ConsensusCmd,
 		TokensCmd,
 		CoinCmd,

--- a/synnergy-network/core/bootstrap_node.go
+++ b/synnergy-network/core/bootstrap_node.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// BootstrapNode bundles networking with optional replication to help new
+// peers join the network. It runs a libp2p node and exposes a thin service
+// surface compatible with the VM opcode dispatcher.
+
+type BootstrapNode struct {
+	net    *Node
+	rep    *Replicator // optional, may be nil
+	led    *Ledger
+	ctx    context.Context
+	cancel context.CancelFunc
+	mu     sync.RWMutex
+}
+
+// BootstrapConfig aggregates the required configuration sections.
+type BootstrapConfig struct {
+	Network     Config
+	Ledger      LedgerConfig
+	Replication *ReplicationConfig
+}
+
+// NewBootstrapNode initialises networking and, if configured, the replication
+// service. It returns a node ready to be started.
+func NewBootstrapNode(cfg *BootstrapConfig) (*BootstrapNode, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	n, err := NewNode(cfg.Network)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	led, err := NewLedger(cfg.Ledger)
+	if err != nil {
+		cancel()
+		_ = n.Close()
+		return nil, err
+	}
+	// Replication requires a PeerManager implementation; the basic Node does
+	// not satisfy this interface yet, so replication is optional.
+	var rep *Replicator
+	if cfg.Replication != nil {
+		logrus.Warn("replication disabled: Node lacks PeerManager support")
+	}
+	return &BootstrapNode{net: n, rep: rep, led: led, ctx: ctx, cancel: cancel}, nil
+}
+
+// Start launches the bootstrap services. It is safe to call multiple times.
+func (b *BootstrapNode) Start() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.rep != nil {
+		b.rep.Start()
+	}
+	go b.net.ListenAndServe()
+}
+
+// Stop gracefully shuts down the node and replication service.
+func (b *BootstrapNode) Stop() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.rep != nil {
+		b.rep.Stop()
+	}
+	b.cancel()
+	return b.net.Close()
+}
+
+// DialSeed connects to a list of peers. It proxies to the underlying network node.
+func (b *BootstrapNode) DialSeed(peers []string) error {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.net.DialSeed(peers)
+}
+
+// Peers returns the current peer list known to the node.
+func (b *BootstrapNode) Peers() []*Peer {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.net.Peers()
+}
+
+// Ledger exposes the underlying ledger for integrations.
+func (b *BootstrapNode) Ledger() *Ledger { return b.led }

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -271,6 +271,11 @@ var gasTable map[Opcode]uint64
    Dial:            2_000,
    SetBroadcaster:  500,
    GlobalBroadcast: 1_000,
+   NewBootstrapNode: 20_000,
+   Bootstrap_Start: 8_000,
+   Bootstrap_Stop: 4_000,
+   Bootstrap_Peers: 500,
+   Bootstrap_DialSeed: 2_000,
    // Broadcast & Subscribe already priced
 
    // ----------------------------------------------------------------------
@@ -837,16 +842,21 @@ var gasNames = map[string]uint64{
 	// ----------------------------------------------------------------------
 	// Networking
 	// ----------------------------------------------------------------------
-	"NewNode":         18_000,
-	"HandlePeerFound": 1_500,
-	"DialSeed":        2_000,
-	"ListenAndServe":  8_000,
-	"Close":           500,
-	"Peers":           400,
-	"NewDialer":       2_000,
-	"Dial":            2_000,
-	"SetBroadcaster":  500,
-	"GlobalBroadcast": 1_000,
+	"NewNode":            18_000,
+	"HandlePeerFound":    1_500,
+	"DialSeed":           2_000,
+	"ListenAndServe":     8_000,
+	"Close":              500,
+	"Peers":              400,
+	"NewDialer":          2_000,
+	"Dial":               2_000,
+	"SetBroadcaster":     500,
+	"GlobalBroadcast":    1_000,
+	"NewBootstrapNode":   20_000,
+	"Bootstrap_Start":    8_000,
+	"Bootstrap_Stop":     4_000,
+	"Bootstrap_Peers":    500,
+	"Bootstrap_DialSeed": 2_000,
 	// Broadcast & Subscribe already priced
 
 	// ----------------------------------------------------------------------

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -314,6 +314,11 @@ var catalogue = []struct {
 	{"Dial", 0x11000A},
 	{"SetBroadcaster", 0x11000B},
 	{"GlobalBroadcast", 0x11000C},
+	{"NewBootstrapNode", 0x11000D},
+	{"Bootstrap_Start", 0x11000E},
+	{"Bootstrap_Stop", 0x11000F},
+	{"Bootstrap_Peers", 0x110010},
+	{"Bootstrap_DialSeed", 0x110011},
 
 	// Replication (0x12)
 	{"NewReplicator", 0x120001},


### PR DESCRIPTION
## Summary
- implement `BootstrapNode` in core
- add bootstrap node CLI commands
- register bootstrap opcodes and gas costs
- expose bootstrap route in CLI index
- document bootstrap usage in README, CLI guide and whitepaper

## Testing
- `go vet ./core`
- `go vet cmd/cli/bootstrap_node.go`
- `go build ./cmd/cli/bootstrap_node.go`
- `go test ./core`

------
https://chatgpt.com/codex/tasks/task_e_688c32f0140c8320a96fca5fd433c4f3