### PR TITLE
Add connection pool module and CLI command

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -65,6 +65,7 @@ all modules from the core library. Highlights include:
 - `green_technology` – sustainability features
 - `ledger` – low level ledger inspection
 - `network` – libp2p networking helpers
+- `connpool` – manage reusable outbound connections
 - `replication` – snapshot and replicate data
 - `rollups` – manage rollup batches
 - `security` – cryptographic utilities

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -20,11 +20,12 @@ All services are optional and run as independent modules that plug into the core
 ## Synnergy Network Architecture
 At a high level the network consists of:
 1. **Peer-to-Peer Network** – Validators communicate using libp2p with gossip-based transaction propagation.
-2. **Consensus Engine** – A hybrid approach combines Proof of History (PoH) and Proof of Stake (PoS) with pluggable modules for alternative algorithms.
-3. **Ledger** – Blocks contain sub-blocks that optimize for data availability. Smart contracts and token transfers are recorded here.
-4. **Virtual Machine** – The dispatcher assigns a 24-bit opcode to every protocol function. Gas is charged before execution using a deterministic cost table.
-5. **Storage Nodes** – Off-chain storage is coordinated through specialized nodes for cheap archiving and retrieval.
-6. **Rollups and Sharding** – Sidechains and rollup batches scale the system horizontally while maintaining security guarantees.
+2. **Connection Pools** – Reusable outbound connections reduce handshake overhead and speed up cross-module communication.
+3. **Consensus Engine** – A hybrid approach combines Proof of History (PoH) and Proof of Stake (PoS) with pluggable modules for alternative algorithms.
+4. **Ledger** – Blocks contain sub-blocks that optimize for data availability. Smart contracts and token transfers are recorded here.
+5. **Virtual Machine** – The dispatcher assigns a 24-bit opcode to every protocol function. Gas is charged before execution using a deterministic cost table.
+6. **Storage Nodes** – Off-chain storage is coordinated through specialized nodes for cheap archiving and retrieval.
+7. **Rollups and Sharding** – Sidechains and rollup batches scale the system horizontally while maintaining security guarantees.
 Each layer is intentionally separated so enterprises can replace components as needed (e.g., swap the consensus engine or choose a different storage back end).
 
 ## Synthron Coin

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -23,6 +23,7 @@ The following command groups expose the same functionality available in the core
 - **green_technology** – View energy metrics and toggle any experimental sustainability features.
 - **ledger** – Inspect blocks, query balances and perform administrative token operations via the ledger daemon.
 - **network** – Manage peer connections and print networking statistics.
+- **connpool** – Manage reusable outbound connections.
 - **replication** – Trigger snapshot creation and replicate the ledger to new nodes.
 - **rollups** – Create rollup batches or inspect existing ones.
 - **security** – Key generation, signing utilities and password helpers.
@@ -254,6 +255,14 @@ needed in custom tooling.
 | `peers` | List connected peers. |
 | `broadcast <topic> <data>` | Publish data on the network. |
 | `subscribe <topic>` | Subscribe to a topic. |
+
+### connpool
+
+| Sub-command | Description |
+|-------------|-------------|
+| `stats` | Show pool statistics. |
+| `dial <addr>` | Dial an address using the pool. |
+| `close` | Close the pool. |
 
 ### replication
 

--- a/synnergy-network/cmd/cli/connection_pool.go
+++ b/synnergy-network/cmd/cli/connection_pool.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+	"synnergy-network/core"
+)
+
+var (
+	connPool *core.ConnPool
+	cpOnce   sync.Once
+)
+
+func cpInit(cmd *cobra.Command, _ []string) error {
+	cpOnce.Do(func() {
+		d := core.NewDialer(5*time.Second, 30*time.Second)
+		connPool = core.NewConnPool(d, 4, time.Minute)
+	})
+	return nil
+}
+
+func cpStats(cmd *cobra.Command, _ []string) error {
+	if connPool == nil {
+		return fmt.Errorf("connection pool not initialised")
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "idle connections: %d\n", connPool.Stats())
+	return nil
+}
+
+func cpDial(cmd *cobra.Command, args []string) error {
+	if connPool == nil {
+		return fmt.Errorf("connection pool not initialised")
+	}
+	if len(args) != 1 {
+		return fmt.Errorf("dial requires <addr>")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := connPool.Acquire(ctx, args[0])
+	if err != nil {
+		return err
+	}
+	connPool.Release(conn)
+	fmt.Fprintln(cmd.OutOrStdout(), "dial ok")
+	return nil
+}
+
+func cpClose(cmd *cobra.Command, _ []string) error {
+	if connPool != nil {
+		connPool.Close()
+		connPool = nil
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "pool closed")
+	return nil
+}
+
+var connPoolCmd = &cobra.Command{
+	Use:               "connpool",
+	Short:             "Manage network connection pool",
+	PersistentPreRunE: cpInit,
+}
+
+func init() {
+	connPoolCmd.AddCommand(&cobra.Command{
+		Use:   "stats",
+		Short: "Show pool statistics",
+		RunE:  cpStats,
+	})
+	connPoolCmd.AddCommand(&cobra.Command{
+		Use:   "dial <addr>",
+		Short: "Dial address using the pool",
+		Args:  cobra.ExactArgs(1),
+		RunE:  cpDial,
+	})
+	connPoolCmd.AddCommand(&cobra.Command{
+		Use:   "close",
+		Short: "Close the pool",
+		RunE:  cpClose,
+	})
+}
+
+var ConnPoolCmd = connPoolCmd

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -21,6 +21,7 @@ func RegisterRoutes(root *cobra.Command) {
 		AICmd,
 		AMMCmd,
 		PoolsCmd,
+		ConnPoolCmd,
 		AuthCmd,
 		CharityCmd,
 		LoanCmd,

--- a/synnergy-network/core/connection_pool.go
+++ b/synnergy-network/core/connection_pool.go
@@ -1,0 +1,137 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"time"
+)
+
+// Connection represents a pooled network connection.
+type pooledConn struct {
+	net.Conn
+	addr     string
+	lastUsed time.Time
+}
+
+// ConnPool manages reusable network connections keyed by address.
+type ConnPool struct {
+	dialer    *Dialer
+	mu        sync.Mutex
+	conns     map[string][]*pooledConn
+	maxIdle   int
+	idleTTL   time.Duration
+	closing   chan struct{}
+	closeOnce sync.Once
+}
+
+// NewConnPool creates a connection pool using the supplied Dialer. maxIdle defines
+// how many idle connections per address are kept. idleTTL specifies how long a
+// connection may remain idle before being closed.
+func NewConnPool(d *Dialer, maxIdle int, idleTTL time.Duration) *ConnPool {
+	cp := &ConnPool{
+		dialer:  d,
+		conns:   make(map[string][]*pooledConn),
+		maxIdle: maxIdle,
+		idleTTL: idleTTL,
+		closing: make(chan struct{}),
+	}
+	go cp.reaper()
+	return cp
+}
+
+// Acquire returns a connection for addr from the pool or establishes a new one.
+func (cp *ConnPool) Acquire(ctx context.Context, addr string) (net.Conn, error) {
+	cp.mu.Lock()
+	list := cp.conns[addr]
+	n := len(list)
+	if n > 0 {
+		c := list[n-1]
+		cp.conns[addr] = list[:n-1]
+		cp.mu.Unlock()
+		c.lastUsed = time.Now()
+		return c, nil
+	}
+	cp.mu.Unlock()
+	if cp.dialer == nil {
+		return nil, errors.New("connpool: dialer not configured")
+	}
+	conn, err := cp.dialer.Dial(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+	return &pooledConn{Conn: conn, addr: addr, lastUsed: time.Now()}, nil
+}
+
+// Release returns the connection to the pool. Connections not created via
+// Acquire are simply closed.
+func (cp *ConnPool) Release(conn net.Conn) {
+	pc, ok := conn.(*pooledConn)
+	if !ok {
+		_ = conn.Close()
+		return
+	}
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	if cp.maxIdle > 0 && len(cp.conns[pc.addr]) < cp.maxIdle {
+		pc.lastUsed = time.Now()
+		cp.conns[pc.addr] = append(cp.conns[pc.addr], pc)
+		return
+	}
+	_ = pc.Close()
+}
+
+// Close closes all connections and stops background cleanup.
+func (cp *ConnPool) Close() {
+	cp.closeOnce.Do(func() {
+		close(cp.closing)
+		cp.mu.Lock()
+		defer cp.mu.Unlock()
+		for _, list := range cp.conns {
+			for _, c := range list {
+				_ = c.Close()
+			}
+		}
+		cp.conns = make(map[string][]*pooledConn)
+	})
+}
+
+// Stats returns the total number of idle connections managed by the pool.
+func (cp *ConnPool) Stats() int {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	count := 0
+	for _, list := range cp.conns {
+		count += len(list)
+	}
+	return count
+}
+
+// reaper closes idle connections after the configured TTL.
+func (cp *ConnPool) reaper() {
+	ticker := time.NewTicker(cp.idleTTL / 2)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			cutoff := time.Now().Add(-cp.idleTTL)
+			cp.mu.Lock()
+			for addr, list := range cp.conns {
+				i := 0
+				for _, c := range list {
+					if c.lastUsed.Before(cutoff) {
+						_ = c.Close()
+						continue
+					}
+					list[i] = c
+					i++
+				}
+				cp.conns[addr] = list[:i]
+			}
+			cp.mu.Unlock()
+		case <-cp.closing:
+			return
+		}
+	}
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -271,6 +271,11 @@ var gasTable map[Opcode]uint64
    Dial:            2_000,
    SetBroadcaster:  500,
    GlobalBroadcast: 1_000,
+   NewConnPool:     8_000,
+   AcquireConn:     500,
+   ReleaseConn:     200,
+   ClosePool:       400,
+   PoolStats:       100,
    // Broadcast & Subscribe already priced
 
    // ----------------------------------------------------------------------
@@ -847,6 +852,11 @@ var gasNames = map[string]uint64{
 	"Dial":            2_000,
 	"SetBroadcaster":  500,
 	"GlobalBroadcast": 1_000,
+	"NewConnPool":     8_000,
+	"AcquireConn":     500,
+	"ReleaseConn":     200,
+	"ClosePool":       400,
+	"PoolStats":       100,
 	// Broadcast & Subscribe already priced
 
 	// ----------------------------------------------------------------------

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -96,21 +96,22 @@ func wrap(name string) OpcodeFunc {
 //
 // Category map:
 //
-//	0x01 AI                     0x0F Liquidity
-//	0x02 AMM                    0x10 Loanpool
-//	0x03 Authority              0x11 Network
-//	0x04 Charity                0x12 Replication
-//	0x05 Coin                   0x13 Rollups
-//	0x06 Compliance             0x14 Security
-//	0x07 Consensus              0x15 Sharding
-//	0x08 Contracts              0x16 Sidechains
-//	0x09 CrossChain             0x17 StateChannel
-//	0x0A Data                   0x18 Storage
-//	0x0B FaultTolerance         0x19 Tokens
-//	0x0C Governance             0x1A Transactions
-//	0x0D GreenTech              0x1B Utilities
-//	0x0E Ledger                 0x1C VirtualMachine
-//	                            0x1D Wallet
+//		0x01 AI                     0x0F Liquidity
+//		0x02 AMM                    0x10 Loanpool
+//		0x03 Authority              0x11 Network
+//		0x04 Charity                0x12 Replication
+//		0x05 Coin                   0x13 Rollups
+//		0x06 Compliance             0x14 Security
+//		0x07 Consensus              0x15 Sharding
+//		0x08 Contracts              0x16 Sidechains
+//		0x09 CrossChain             0x17 StateChannel
+//		0x0A Data                   0x18 Storage
+//		0x0B FaultTolerance         0x19 Tokens
+//		0x0C Governance             0x1A Transactions
+//		0x0D GreenTech              0x1B Utilities
+//		0x0E Ledger                 0x1C VirtualMachine
+//		                            0x1D Wallet
+//	                                 0x1E ConnPool
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,13 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// ConnPool (0x1E)
+	{"NewConnPool", 0x1E0001},
+	{"AcquireConn", 0x1E0002},
+	{"ReleaseConn", 0x1E0003},
+	{"ClosePool", 0x1E0004},
+	{"PoolStats", 0x1E0005},
 }
 
 // init wires the catalogue into the live dispatcher.


### PR DESCRIPTION
## Summary
- implement `ConnPool` for reusing outbound connections
- expose connection pool commands via new CLI file
- wire connpool command in CLI index
- price new opcodes and register them in the dispatcher
- document connpool in README, CLI guide and whitepaper

## Testing
- `go vet ./core/... ./cmd/cli` *(fails: cmd/cli/loanpool.go uses logrus.Logger)*
- `go build ./core/...`
- `go test ./core/...`


------
https://chatgpt.com/codex/tasks/task_e_688c331b31b08320881d8f964681f247