### PR TITLE
Add distributed network coordination module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -66,6 +66,7 @@ all modules from the core library. Highlights include:
 - `ledger` – low level ledger inspection
 - `network` – libp2p networking helpers
 - `replication` – snapshot and replicate data
+- `coordination` – coordinate distributed nodes and broadcast ledger state
 - `rollups` – manage rollup batches
 - `security` – cryptographic utilities
 - `sharding` – shard management

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -119,6 +119,8 @@ Synnergy employs a hybrid consensus combining Proof of History for ordering and 
 ## Transaction Distribution Guide
 Transactions are propagated through a gossip network. Nodes maintain a mempool and relay validated transactions to peers. When a validator proposes a sub-block, it selects transactions from its pool based on fee priority and time of arrival. After consensus, the finalized block is broadcast to all peers and applied to local state. Replication modules ensure ledger data remains consistent even under network partitions or DDoS attempts.
 
+To improve operational awareness across clusters, a lightweight **Distributed Network Coordination** service periodically broadcasts the current ledger height and can distribute test tokens for bootstrap scenarios. This module hooks into the existing networking layer and ledger without introducing consensus dependencies. Enterprises can run the coordinator alongside replication to monitor progress and trigger synchronisation tasks.
+
 ## Financial and Numerical Forecasts
 The following projections outline potential adoption metrics and pricing scenarios. These figures are purely illustrative and not financial advice.
 

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -24,6 +24,7 @@ The following command groups expose the same functionality available in the core
 - **ledger** – Inspect blocks, query balances and perform administrative token operations via the ledger daemon.
 - **network** – Manage peer connections and print networking statistics.
 - **replication** – Trigger snapshot creation and replicate the ledger to new nodes.
+- **coordination** – Coordinate distributed nodes and broadcast ledger state.
 - **rollups** – Create rollup batches or inspect existing ones.
 - **security** – Key generation, signing utilities and password helpers.
 - **sharding** – Migrate data between shards and check shard status.
@@ -265,6 +266,15 @@ needed in custom tooling.
 | `replicate <block-hash>` | Gossip a known block. |
 | `request <block-hash>` | Request a block from peers. |
 | `sync` | Synchronize blocks from peers. |
+
+### coordination
+
+| Sub-command | Description |
+|-------------|-------------|
+| `start` | Start coordination background tasks. |
+| `stop` | Stop coordination tasks. |
+| `broadcast` | Broadcast the current ledger height. |
+| `mint <addr> <token> <amount>` | Mint tokens via the coordinator. |
 
 ### rollups
 

--- a/synnergy-network/cmd/cli/distributed_network_coordination.go
+++ b/synnergy-network/cmd/cli/distributed_network_coordination.go
@@ -1,0 +1,123 @@
+package cli
+
+// Command-line access to the DistributedCoordinator module.
+// Provides helpers to start/stop the background loop, broadcast the
+// ledger height and distribute tokens for testing.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"synnergy-network/core"
+)
+
+var (
+	coordInstance *core.DistributedCoordinator
+	coordCtx      context.Context
+	coordCancel   context.CancelFunc
+)
+
+func coordInit(cmd *cobra.Command, _ []string) error {
+	if coordInstance != nil {
+		return nil
+	}
+	// Initialise global ledger if not already done
+	path := viper.GetString("LEDGER_PATH")
+	if path == "" {
+		path = "./ledger.db"
+	}
+	if err := core.InitLedger(path); err != nil {
+		return err
+	}
+	led := core.CurrentLedger()
+	bc := core.Broadcast
+	coordInstance = core.NewCoordinator(led, bc, nil)
+	return nil
+}
+
+var coordCmd = &cobra.Command{
+	Use:               "coord",
+	Aliases:           []string{"coordination"},
+	Short:             "Distributed network coordination helpers",
+	PersistentPreRunE: coordInit,
+}
+
+var coordStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start coordination background tasks",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		coordCtx, coordCancel = context.WithCancel(cmd.Context())
+		coordInstance.StartCoordinator(coordCtx)
+		fmt.Fprintln(cmd.OutOrStdout(), "coordination started")
+		return nil
+	},
+}
+
+var coordStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop coordination background tasks",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if coordCancel != nil {
+			coordCancel()
+		}
+		coordInstance.StopCoordinator()
+		fmt.Fprintln(cmd.OutOrStdout(), "coordination stopped")
+		return nil
+	},
+}
+
+var coordBroadcastCmd = &cobra.Command{
+	Use:   "broadcast",
+	Short: "Broadcast current ledger height",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := coordInstance.BroadcastLedgerHeight(); err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "height broadcasted")
+		return nil
+	},
+}
+
+var coordMintCmd = &cobra.Command{
+	Use:   "mint <addr> <token> <amount>",
+	Args:  cobra.ExactArgs(3),
+	Short: "Mint tokens via the coordinator",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := core.StringToAddress(args[0])
+		if err != nil {
+			return err
+		}
+		token := args[1]
+		amt, err := parseUint(args[2])
+		if err != nil {
+			return err
+		}
+		if err := coordInstance.DistributeToken(addr, token, amt); err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "minted")
+		return nil
+	},
+}
+
+func parseUint(s string) (uint64, error) {
+	var v uint64
+	_, err := fmt.Sscan(s, &v)
+	if err != nil {
+		return 0, fmt.Errorf("invalid number %q", s)
+	}
+	return v, nil
+}
+
+func init() {
+	coordCmd.AddCommand(coordStartCmd)
+	coordCmd.AddCommand(coordStopCmd)
+	coordCmd.AddCommand(coordBroadcastCmd)
+	coordCmd.AddCommand(coordMintCmd)
+}
+
+// CoordinationCmd exported for root registration.
+var CoordinationCmd = coordCmd

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -27,6 +27,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ComplianceCmd,
 		CrossChainCmd,
 		DataCmd,
+		CoordinationCmd,
 		ChannelRoute,
 		StorageRoute,
 		UtilityRoute,

--- a/synnergy-network/core/distributed_network_coordination.go
+++ b/synnergy-network/core/distributed_network_coordination.go
@@ -1,0 +1,115 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// DistributedCoordinator orchestrates coordination tasks between nodes.
+// It broadcasts ledger progress, distributes tokens and exposes a
+// lightweight synchronization helper. The coordinator is designed to
+// integrate with the existing ledger, networking and consensus modules.
+//
+// All methods are concurrency‑safe and return detailed errors on failure.
+type DistributedCoordinator struct {
+	led *Ledger
+	bc  BroadcasterFunc
+	log *logrus.Logger
+
+	mu     sync.Mutex
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewCoordinator creates a new coordinator instance. A broadcaster from the
+// network package must be supplied. If logger is nil, logrus.StandardLogger()
+// is used.
+func NewCoordinator(l *Ledger, bc BroadcasterFunc, logger *logrus.Logger) *DistributedCoordinator {
+	if logger == nil {
+		logger = logrus.StandardLogger()
+	}
+	return &DistributedCoordinator{led: l, bc: bc, log: logger}
+}
+
+// StartCoordinator launches a background loop that periodically broadcasts the
+// ledger height to peers. Calling StartCoordinator twice has no effect.
+func (dc *DistributedCoordinator) StartCoordinator(ctx context.Context) {
+	dc.mu.Lock()
+	if dc.cancel != nil {
+		dc.mu.Unlock()
+		return
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	dc.ctx, dc.cancel = ctx, cancel
+	dc.mu.Unlock()
+
+	go dc.loop()
+	dc.log.Info("distributed coordinator started")
+}
+
+func (dc *DistributedCoordinator) loop() {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-dc.ctx.Done():
+			return
+		case <-ticker.C:
+			if err := dc.BroadcastLedgerHeight(); err != nil {
+				dc.log.Warnf("broadcast height: %v", err)
+			}
+		}
+	}
+}
+
+// StopCoordinator stops the background loop.
+func (dc *DistributedCoordinator) StopCoordinator() {
+	dc.mu.Lock()
+	if dc.cancel != nil {
+		dc.cancel()
+		dc.cancel = nil
+	}
+	dc.mu.Unlock()
+	dc.log.Info("distributed coordinator stopped")
+}
+
+// BroadcastLedgerHeight sends the current block height to peers via the
+// configured broadcaster.
+func (dc *DistributedCoordinator) BroadcastLedgerHeight() error {
+	if dc.bc == nil {
+		return fmt.Errorf("coordinator: broadcaster not set")
+	}
+	if dc.led == nil {
+		return fmt.Errorf("coordinator: ledger not available")
+	}
+	height := dc.led.LastHeight()
+	msg := []byte(fmt.Sprintf("%d", height))
+	return dc.bc("coord_height", msg)
+}
+
+// DistributeToken mints the specified amount of a token to the given address.
+func (dc *DistributedCoordinator) DistributeToken(addr Address, tokenID string, amt uint64) error {
+	if dc.led == nil {
+		return fmt.Errorf("coordinator: ledger not available")
+	}
+	if amt == 0 {
+		return fmt.Errorf("coordinator: amount must be positive")
+	}
+	return dc.led.MintToken(addr, tokenID, amt)
+}
+
+// SyncOnce performs a single ledger synchronization step by broadcasting the
+// current height and returning it to the caller.
+func (dc *DistributedCoordinator) SyncOnce(ctx context.Context) (uint64, error) {
+	if err := dc.BroadcastLedgerHeight(); err != nil {
+		return 0, err
+	}
+	if dc.led == nil {
+		return 0, fmt.Errorf("coordinator: ledger not available")
+	}
+	return dc.led.LastHeight(), nil
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -284,6 +284,15 @@ var gasTable map[Opcode]uint64
    // Hash & Start already priced
 
    // ----------------------------------------------------------------------
+   // Distributed Coordination
+   // ----------------------------------------------------------------------
+   NewCoordinator:         10_000,
+   StartCoordinator:        5_000,
+   StopCoordinator:         5_000,
+   BroadcastLedgerHeight:   3_000,
+   DistributeToken:         5_000,
+
+   // ----------------------------------------------------------------------
    // Roll-ups
    // ----------------------------------------------------------------------
    NewAggregator:     15_000,
@@ -857,6 +866,15 @@ var gasNames = map[string]uint64{
 	"RequestMissing": 4_000,
 	"Synchronize":    25_000,
 	"Stop":           3_000,
+	// ----------------------------------------------------------------------
+	// Distributed Coordination
+	// ----------------------------------------------------------------------
+	"NewCoordinator":        10_000,
+	"StartCoordinator":      5_000,
+	"StopCoordinator":       5_000,
+	"BroadcastLedgerHeight": 3_000,
+	"DistributeToken":       5_000,
+
 	// Hash & Start already priced
 
 	// ----------------------------------------------------------------------

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -111,6 +111,7 @@ func wrap(name string) OpcodeFunc {
 //	0x0D GreenTech              0x1B Utilities
 //	0x0E Ledger                 0x1C VirtualMachine
 //	                            0x1D Wallet
+//			0x1E Coordination
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,12 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+	// Coordination (0x1E)
+	{"NewCoordinator", 0x1E0001},
+	{"StartCoordinator", 0x1E0002},
+	{"StopCoordinator", 0x1E0003},
+	{"BroadcastLedgerHeight", 0x1E0004},
+	{"DistributeToken", 0x1E0005},
 }
 
 // init wires the catalogue into the live dispatcher.


### PR DESCRIPTION
## Summary
- add DistributedCoordinator in core for network coordination
- expose coordination CLI commands
- register new command in CLI index
- document coordination module in README, CLI guide, and whitepaper
- integrate opcodes and gas prices for coordination operations

## Testing
- `go vet ./core/...` *(passed)*
- `go vet ./cmd/cli` *(failed: build errors in other packages)*
- `go build ./core/...` *(passed)*
- `go build ./cmd/cli` *(failed: build errors in other packages)*
- `go test ./core/...` *(passed)*
- `go test ./cmd/cli` *(failed: build errors in other packages)*

------
https://chatgpt.com/codex/tasks/task_e_688c332ee7b4832099217ffadaa04ae5