### PR TITLE
Add firewall module and CLI

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -68,6 +68,7 @@ all modules from the core library. Highlights include:
 - `replication` – snapshot and replicate data
 - `rollups` – manage rollup batches
 - `security` – cryptographic utilities
+- `firewall` – manage block lists for addresses, tokens and peers
 - `sharding` – shard management
 - `sidechain` – launch and interact with sidechains
 - `state_channel` – open and settle payment channels

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -14,6 +14,7 @@ The Synnergy ecosystem brings together several services:
 - **AI Compliance** – A built-in AI service scans transactions for fraud patterns, KYC signals, and anomalies.
 - **DEX and AMM** – Native modules manage liquidity pools and cross-chain swaps.
 - **Governance** – Token holders can create proposals and vote on protocol upgrades.
+- **Firewall** – Runtime block lists restrict malicious addresses, tokens and IPs.
 - **Developer Tooling** – CLI modules, RPC services, and SDKs make integration straightforward.
 All services are optional and run as independent modules that plug into the core.
 
@@ -64,6 +65,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `replication` – Replicate and synchronize ledger data across nodes.
 - `rollups` – Manage rollup batches and fraud proofs.
 - `security` – Generate keys and sign payloads.
+- `firewall` – Enforce address, token and IP restrictions.
 - `sharding` – Split the ledger into shards and coordinate cross-shard messages.
 - `sidechain` – Launch or interact with auxiliary chains.
 - `state_channel` – Open and settle payment channels.

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -26,6 +26,7 @@ The following command groups expose the same functionality available in the core
 - **replication** – Trigger snapshot creation and replicate the ledger to new nodes.
 - **rollups** – Create rollup batches or inspect existing ones.
 - **security** – Key generation, signing utilities and password helpers.
+- **firewall** – Manage address, token and IP block lists.
 - **sharding** – Migrate data between shards and check shard status.
 - **sidechain** – Launch side chains or interact with remote side‑chain nodes.
 - **state_channel** – Open, close and settle payment channels.
@@ -291,6 +292,18 @@ needed in custom tooling.
 | `dilithium-sign` | Sign a message with a Dilithium key. |
 | `dilithium-verify` | Verify a Dilithium signature. |
 | `anomaly-score` | Compute an anomaly z-score from data. |
+
+### firewall
+
+| Sub-command | Description |
+|-------------|-------------|
+| `block-address <addr>` | Block a wallet address. |
+| `unblock-address <addr>` | Remove an address from the block list. |
+| `block-token <id>` | Block transfers of a token id. |
+| `unblock-token <id>` | Allow transfers of a token id. |
+| `block-ip <ip>` | Block a peer IP address. |
+| `unblock-ip <ip>` | Unblock a peer IP address. |
+| `list` | Display current firewall rules. |
 
 ### sharding
 

--- a/synnergy-network/cmd/cli/firewall.go
+++ b/synnergy-network/cmd/cli/firewall.go
@@ -1,0 +1,144 @@
+// cmd/cli/firewall.go - manage runtime firewall rules
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+
+	"github.com/spf13/cobra"
+	core "synnergy-network/core"
+)
+
+var (
+	firewallOnce sync.Once
+)
+
+func ensureFirewall(cmd *cobra.Command, _ []string) error {
+	firewallOnce.Do(func() { core.InitFirewall() })
+	return nil
+}
+
+var firewallCmd = &cobra.Command{
+	Use:               "firewall",
+	Short:             "Manage firewall rules",
+	PersistentPreRunE: ensureFirewall,
+}
+
+// block-address <hexaddr>
+var fwBlockAddrCmd = &cobra.Command{
+	Use:   "block-address <addr>",
+	Short: "Block a wallet address",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := core.ParseAddress(args[0])
+		if err != nil {
+			return err
+		}
+		core.CurrentFirewall().BlockAddress(addr)
+		fmt.Printf("address %s blocked\n", args[0])
+		return nil
+	},
+}
+
+var fwUnblockAddrCmd = &cobra.Command{
+	Use:   "unblock-address <addr>",
+	Short: "Remove address from block list",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := core.ParseAddress(args[0])
+		if err != nil {
+			return err
+		}
+		core.CurrentFirewall().UnblockAddress(addr)
+		fmt.Printf("address %s unblocked\n", args[0])
+		return nil
+	},
+}
+
+var fwBlockTokenCmd = &cobra.Command{
+	Use:   "block-token <id>",
+	Short: "Block transfers of a token id",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id64, err := strconv.ParseUint(args[0], 10, 32)
+		if err != nil {
+			return err
+		}
+		core.CurrentFirewall().BlockToken(core.TokenID(id64))
+		fmt.Printf("token %s blocked\n", args[0])
+		return nil
+	},
+}
+
+var fwUnblockTokenCmd = &cobra.Command{
+	Use:   "unblock-token <id>",
+	Short: "Allow transfers of a token id",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id64, err := strconv.ParseUint(args[0], 10, 32)
+		if err != nil {
+			return err
+		}
+		core.CurrentFirewall().UnblockToken(core.TokenID(id64))
+		fmt.Printf("token %s unblocked\n", args[0])
+		return nil
+	},
+}
+
+var fwBlockIPCmd = &cobra.Command{
+	Use:   "block-ip <ip>",
+	Short: "Block a peer IP address",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ip := args[0]
+		if err := core.CurrentFirewall().BlockIP(ip); err != nil {
+			return err
+		}
+		fmt.Printf("ip %s blocked\n", ip)
+		return nil
+	},
+}
+
+var fwUnblockIPCmd = &cobra.Command{
+	Use:   "unblock-ip <ip>",
+	Short: "Remove a peer IP from the block list",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		core.CurrentFirewall().UnblockIP(args[0])
+		fmt.Printf("ip %s unblocked\n", args[0])
+		return nil
+	},
+}
+
+var fwListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Display current firewall rules",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rules := core.CurrentFirewall().ListRules()
+		for _, a := range rules.Addresses {
+			fmt.Printf("addr %s\n", hex.EncodeToString(a[:]))
+		}
+		for _, t := range rules.Tokens {
+			fmt.Printf("token %d\n", t)
+		}
+		for _, ip := range rules.IPs {
+			if net.ParseIP(ip) != nil {
+				fmt.Printf("ip %s\n", ip)
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	firewallCmd.AddCommand(fwBlockAddrCmd, fwUnblockAddrCmd,
+		fwBlockTokenCmd, fwUnblockTokenCmd,
+		fwBlockIPCmd, fwUnblockIPCmd, fwListCmd)
+}
+
+// FirewallCmd is exported for registration in index.go
+var FirewallCmd = firewallCmd

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -29,6 +29,7 @@ func RegisterRoutes(root *cobra.Command) {
 		DataCmd,
 		ChannelRoute,
 		StorageRoute,
+		FirewallCmd,
 		UtilityRoute,
 	)
 

--- a/synnergy-network/core/firewall.go
+++ b/synnergy-network/core/firewall.go
@@ -1,0 +1,146 @@
+package core
+
+import (
+	"errors"
+	"net"
+	"sync"
+)
+
+// firewall.go - simple address/token/IP firewall for Synnergy Network
+
+var (
+	ErrAddrBlocked  = errors.New("address blocked by firewall")
+	ErrTokenBlocked = errors.New("token blocked by firewall")
+	ErrIPBlocked    = errors.New("ip blocked by firewall")
+)
+
+// Firewall maintains runtime block lists used by consensus and the ledger.
+// It is concurrency safe and integrates with transaction validation.
+type Firewall struct {
+	mu        sync.RWMutex
+	addresses map[Address]struct{}
+	tokens    map[TokenID]struct{}
+	ips       map[string]struct{}
+}
+
+// NewFirewall constructs an empty firewall instance.
+func NewFirewall() *Firewall {
+	return &Firewall{
+		addresses: make(map[Address]struct{}),
+		tokens:    make(map[TokenID]struct{}),
+		ips:       make(map[string]struct{}),
+	}
+}
+
+// BlockAddress prevents an account from sending or receiving funds.
+func (fw *Firewall) BlockAddress(a Address) {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	fw.addresses[a] = struct{}{}
+}
+
+// UnblockAddress removes an address from the block list.
+func (fw *Firewall) UnblockAddress(a Address) {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	delete(fw.addresses, a)
+}
+
+// IsAddressBlocked checks if an address is blocked.
+func (fw *Firewall) IsAddressBlocked(a Address) bool {
+	fw.mu.RLock()
+	defer fw.mu.RUnlock()
+	_, ok := fw.addresses[a]
+	return ok
+}
+
+// BlockToken disallows transfers of a specific token.
+func (fw *Firewall) BlockToken(id TokenID) {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	fw.tokens[id] = struct{}{}
+}
+
+// UnblockToken removes a token from the block list.
+func (fw *Firewall) UnblockToken(id TokenID) {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	delete(fw.tokens, id)
+}
+
+// IsTokenBlocked checks if a token is blocked.
+func (fw *Firewall) IsTokenBlocked(id TokenID) bool {
+	fw.mu.RLock()
+	defer fw.mu.RUnlock()
+	_, ok := fw.tokens[id]
+	return ok
+}
+
+// BlockIP bans a peer IP address from network participation.
+func (fw *Firewall) BlockIP(ip string) error {
+	if net.ParseIP(ip) == nil {
+		return errors.New("invalid ip")
+	}
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	fw.ips[ip] = struct{}{}
+	return nil
+}
+
+// UnblockIP removes an IP from the banned list.
+func (fw *Firewall) UnblockIP(ip string) {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	delete(fw.ips, ip)
+}
+
+// IsIPBlocked checks if an IP is blocked.
+func (fw *Firewall) IsIPBlocked(ip string) bool {
+	fw.mu.RLock()
+	defer fw.mu.RUnlock()
+	_, ok := fw.ips[ip]
+	return ok
+}
+
+// FirewallRules snapshots all current rules for inspection.
+type FirewallRules struct {
+	Addresses []Address
+	Tokens    []TokenID
+	IPs       []string
+}
+
+// ListRules returns the blocked addresses, tokens and IPs.
+func (fw *Firewall) ListRules() FirewallRules {
+	fw.mu.RLock()
+	defer fw.mu.RUnlock()
+	rules := FirewallRules{}
+	for a := range fw.addresses {
+		rules.Addresses = append(rules.Addresses, a)
+	}
+	for t := range fw.tokens {
+		rules.Tokens = append(rules.Tokens, t)
+	}
+	for ip := range fw.ips {
+		rules.IPs = append(rules.IPs, ip)
+	}
+	return rules
+}
+
+// CheckTx verifies whether a transaction violates any firewall rule.
+func (fw *Firewall) CheckTx(tx *Transaction) error {
+	if fw == nil || tx == nil {
+		return nil
+	}
+	if fw.IsAddressBlocked(tx.From) || fw.IsAddressBlocked(tx.To) {
+		return ErrAddrBlocked
+	}
+	for _, tt := range tx.TokenTransfers {
+		if fw.IsAddressBlocked(tt.From) || fw.IsAddressBlocked(tt.To) {
+			return ErrAddrBlocked
+		}
+		if fw.IsTokenBlocked(tt.Token) {
+			return ErrTokenBlocked
+		}
+	}
+	return nil
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1183,6 +1183,22 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+
+	// ----------------------------------------------------------------------
+	// Firewall
+	// ----------------------------------------------------------------------
+	"NewFirewall":               4_000,
+	"Firewall_BlockAddress":     1_000,
+	"Firewall_UnblockAddress":   1_000,
+	"Firewall_IsAddressBlocked": 500,
+	"Firewall_BlockToken":       1_000,
+	"Firewall_UnblockToken":     1_000,
+	"Firewall_IsTokenBlocked":   500,
+	"Firewall_BlockIP":          1_000,
+	"Firewall_UnblockIP":        1_000,
+	"Firewall_IsIPBlocked":      500,
+	"Firewall_ListRules":        1_000,
+	"Firewall_CheckTx":          2_000,
 }
 
 func init() {

--- a/synnergy-network/core/helpers.go
+++ b/synnergy-network/core/helpers.go
@@ -60,3 +60,16 @@ func NewFlatGasCalculator(p uint64) *FlatGasCalculator { return &FlatGasCalculat
 
 func (f *FlatGasCalculator) Estimate(_ []byte) (uint64, error)     { return 0, nil }
 func (f *FlatGasCalculator) Calculate(_ string, amt uint64) uint64 { return f.Price * amt }
+
+var (
+	firewallOnce   sync.Once
+	globalFirewall *Firewall
+)
+
+// InitFirewall initialises the global firewall instance.
+func InitFirewall() {
+	firewallOnce.Do(func() { globalFirewall = NewFirewall() })
+}
+
+// CurrentFirewall returns the global firewall if initialised.
+func CurrentFirewall() *Firewall { return globalFirewall }

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -581,6 +581,20 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// Firewall (0x1E)
+	{"NewFirewall", 0x1E0001},
+	{"Firewall_BlockAddress", 0x1E0002},
+	{"Firewall_UnblockAddress", 0x1E0003},
+	{"Firewall_IsAddressBlocked", 0x1E0004},
+	{"Firewall_BlockToken", 0x1E0005},
+	{"Firewall_UnblockToken", 0x1E0006},
+	{"Firewall_IsTokenBlocked", 0x1E0007},
+	{"Firewall_BlockIP", 0x1E0008},
+	{"Firewall_UnblockIP", 0x1E0009},
+	{"Firewall_IsIPBlocked", 0x1E000A},
+	{"Firewall_ListRules", 0x1E000B},
+	{"Firewall_CheckTx", 0x1E000C},
 }
 
 // init wires the catalogue into the live dispatcher.

--- a/synnergy-network/core/transactions.go
+++ b/synnergy-network/core/transactions.go
@@ -113,6 +113,11 @@ func (tp *TxPool) ValidateTx(tx *Transaction) error {
 	if err := tx.VerifySig(); err != nil {
 		return err
 	}
+	if fw := CurrentFirewall(); fw != nil {
+		if err := fw.CheckTx(tx); err != nil {
+			return err
+		}
+	}
 	// … other checks omitted …
 
 	if tx.Type == TxReversal {
@@ -242,7 +247,6 @@ func (tp *TxPool) AddTx(tx *Transaction) error {
 
 	tp.lookup[tx.Hash] = tx
 	tp.queue = append(tp.queue, tx)
-
 
 	if len(tp.net.peers) > 0 {
 		if data, err := json.Marshal(tx); err == nil {


### PR DESCRIPTION
## Summary
- implement new firewall module in core with address, token, and IP blocking
- expose firewall via helpers and integrate checks in transaction validation
- register firewall opcodes and gas costs
- add firewall CLI commands and register in `index.go`
- document firewall features in README, CLI guide and whitepaper

## Testing
- `go vet ./core/...` succeeded
- `go vet ./cmd/cli` failed: `loanpool.go:36:30: cannot use logrus.StandardLogger()`
- `go build ./core/...` succeeded
- `go build ./cmd/cli` failed: `loanpool.go:36:30: cannot use logrus.StandardLogger()`
- `go test ./core/...` passed

------
https://chatgpt.com/codex/tasks/task_e_688c333eca10832096d09dc852aed408