### PR TITLE
Add basic Kademlia module

### DIFF
--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -30,6 +30,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ChannelRoute,
 		StorageRoute,
 		UtilityRoute,
+		KademliaCmd,
 	)
 
 	// modules that expose constructors

--- a/synnergy-network/cmd/cli/kademlia.go
+++ b/synnergy-network/cmd/cli/kademlia.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/spf13/cobra"
+
+	"synnergy-network/core"
+)
+
+var (
+	kadDHT  *core.Kademlia
+	kadOnce sync.Once
+)
+
+func kadInit(cmd *cobra.Command, _ []string) error {
+	var err error
+	kadOnce.Do(func() {
+		id, _ := cmd.Flags().GetString("id")
+		if id == "" {
+			id = "local"
+		}
+		kadDHT = core.NewKademlia(core.NodeID(id))
+	})
+	return err
+}
+
+func kadStore(cmd *cobra.Command, args []string) error {
+	kadDHT.Store(args[0], []byte(args[1]))
+	fmt.Fprintln(cmd.OutOrStdout(), "stored")
+	return nil
+}
+
+func kadGet(cmd *cobra.Command, args []string) error {
+	val, ok := kadDHT.Lookup(args[0])
+	if !ok {
+		fmt.Fprintln(cmd.OutOrStdout(), "not found")
+		return nil
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", string(val))
+	return nil
+}
+
+func kadAddPeer(cmd *cobra.Command, args []string) error {
+	kadDHT.AddPeer(core.NodeID(args[0]))
+	fmt.Fprintln(cmd.OutOrStdout(), "peer added")
+	return nil
+}
+
+var kademliaCmd = &cobra.Command{
+	Use:               "kademlia",
+	Short:             "lightweight Kademlia DHT",
+	PersistentPreRunE: kadInit,
+}
+
+var kadStoreCmd = &cobra.Command{Use: "store <key> <value>", Args: cobra.ExactArgs(2), RunE: kadStore}
+var kadGetCmd = &cobra.Command{Use: "get <key>", Args: cobra.ExactArgs(1), RunE: kadGet}
+var kadAddPeerCmd = &cobra.Command{Use: "addpeer <id>", Args: cobra.ExactArgs(1), RunE: kadAddPeer}
+
+func init() {
+	kademliaCmd.PersistentFlags().String("id", "local", "node identifier")
+	kademliaCmd.AddCommand(kadStoreCmd, kadGetCmd, kadAddPeerCmd)
+}
+
+var KademliaCmd = kademliaCmd
+
+func RegisterKademlia(root *cobra.Command) { root.AddCommand(KademliaCmd) }

--- a/synnergy-network/core/kademlia.go
+++ b/synnergy-network/core/kademlia.go
@@ -1,0 +1,112 @@
+package core
+
+import (
+	"crypto/sha1"
+	"math/big"
+	"sort"
+	"sync"
+)
+
+// Kademlia implements a minimal in-memory Kademlia DHT used for
+// experimentation. It stores values locally and tracks peer IDs in
+// 160 binary distance buckets.
+type Kademlia struct {
+	id      NodeID
+	buckets [160][]NodeID
+	store   map[[20]byte][]byte
+	mu      sync.RWMutex
+}
+
+// NewKademlia creates a new Kademlia instance bound to the given node ID.
+func NewKademlia(id NodeID) *Kademlia {
+	return &Kademlia{
+		id:    id,
+		store: make(map[[20]byte][]byte),
+	}
+}
+
+// AddPeer inserts a peer into the appropriate distance bucket.
+func (k *Kademlia) AddPeer(id NodeID) {
+	if id == k.id {
+		return
+	}
+	idx := k.bucketIndex(id)
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	list := k.buckets[idx]
+	for _, p := range list {
+		if p == id {
+			return
+		}
+	}
+	k.buckets[idx] = append(list, id)
+}
+
+// Store saves a value under the given key. The key is hashed with SHA1 to
+// produce the internal 160 bit key used by the DHT.
+func (k *Kademlia) Store(key string, value []byte) {
+	var hash [20]byte = sha1.Sum([]byte(key))
+	k.mu.Lock()
+	k.store[hash] = append([]byte(nil), value...)
+	k.mu.Unlock()
+}
+
+// Lookup retrieves a value by key. It returns the value and true if present.
+func (k *Kademlia) Lookup(key string) ([]byte, bool) {
+	var hash [20]byte = sha1.Sum([]byte(key))
+	k.mu.RLock()
+	val, ok := k.store[hash]
+	k.mu.RUnlock()
+	if ok {
+		cp := append([]byte(nil), val...)
+		return cp, true
+	}
+	return nil, false
+}
+
+// Nearest returns up to count peer IDs with XOR distance closest to target.
+func (k *Kademlia) Nearest(target NodeID, count int) []NodeID {
+	idx := k.bucketIndex(target)
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	peers := make([]NodeID, 0, count)
+	for i := idx; i < len(k.buckets) && len(peers) < count; i++ {
+		peers = append(peers, k.buckets[i]...)
+	}
+	if len(peers) > count {
+		peers = peers[:count]
+	}
+	sort.Slice(peers, func(i, j int) bool {
+		di := k.distance(peers[i], target)
+		dj := k.distance(peers[j], target)
+		return di.Cmp(dj) < 0
+	})
+	if len(peers) > count {
+		peers = peers[:count]
+	}
+	return peers
+}
+
+func (k *Kademlia) bucketIndex(id NodeID) int {
+	a := sha1.Sum([]byte(k.id))
+	b := sha1.Sum([]byte(id))
+	var diff [20]byte
+	for i := 0; i < len(diff); i++ {
+		diff[i] = a[i] ^ b[i]
+	}
+	bn := new(big.Int).SetBytes(diff[:])
+	if bn.Sign() == 0 {
+		return 159
+	}
+	return 159 - bn.BitLen() + 1
+}
+
+func (k *Kademlia) distance(a NodeID, b NodeID) *big.Int {
+	aa := sha1.Sum([]byte(a))
+	bb := sha1.Sum([]byte(b))
+	var diff [20]byte
+	for i := 0; i < len(diff); i++ {
+		diff[i] = aa[i] ^ bb[i]
+	}
+	return new(big.Int).SetBytes(diff[:])
+}


### PR DESCRIPTION
## Summary
- add experimental `core/kademlia.go` with an in-memory DHT
- expose a `kademlia` command group in the CLI
- register the command group in `index.go`

## Testing
- `go vet ./core` *(pass)*
- `go vet ./cmd/cli` *(fails: loanpool.go build issue)*
- `go build ./core/...` *(pass)*
- `go build ./cmd/cli/...` *(fails: loanpool.go build issue)*
- `go test ./core/...` *(pass)*
- `go test ./cmd/cli` *(fails: build issue)*

------
https://chatgpt.com/codex/tasks/task_e_688c33545dd88320b46e37ab907d38d8