### PR TITLE
Add RPC WebRTC module

### DIFF
--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1183,6 +1183,15 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+
+	// ----------------------------------------------------------------------
+	// RPC / WebRTC
+	// ----------------------------------------------------------------------
+	"NewRPCWebRTC":    10_000,
+	"RPC_Serve":       5_000,
+	"RPC_Close":       1_000,
+	"RPC_ConnectPeer": 3_000,
+	"RPC_Broadcast":   1_500,
 }
 
 func init() {

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -96,21 +96,22 @@ func wrap(name string) OpcodeFunc {
 //
 // Category map:
 //
-//	0x01 AI                     0x0F Liquidity
-//	0x02 AMM                    0x10 Loanpool
-//	0x03 Authority              0x11 Network
-//	0x04 Charity                0x12 Replication
-//	0x05 Coin                   0x13 Rollups
-//	0x06 Compliance             0x14 Security
-//	0x07 Consensus              0x15 Sharding
-//	0x08 Contracts              0x16 Sidechains
-//	0x09 CrossChain             0x17 StateChannel
-//	0x0A Data                   0x18 Storage
-//	0x0B FaultTolerance         0x19 Tokens
-//	0x0C Governance             0x1A Transactions
-//	0x0D GreenTech              0x1B Utilities
-//	0x0E Ledger                 0x1C VirtualMachine
-//	                            0x1D Wallet
+//		0x01 AI                     0x0F Liquidity
+//		0x02 AMM                    0x10 Loanpool
+//		0x03 Authority              0x11 Network
+//		0x04 Charity                0x12 Replication
+//		0x05 Coin                   0x13 Rollups
+//		0x06 Compliance             0x14 Security
+//		0x07 Consensus              0x15 Sharding
+//		0x08 Contracts              0x16 Sidechains
+//		0x09 CrossChain             0x17 StateChannel
+//		0x0A Data                   0x18 Storage
+//		0x0B FaultTolerance         0x19 Tokens
+//		0x0C Governance             0x1A Transactions
+//		0x0D GreenTech              0x1B Utilities
+//		0x0E Ledger                 0x1C VirtualMachine
+//		                            0x1D Wallet
+//	                                 0x1E RPC
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,13 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// RPC (0x1E)
+	{"NewRPCWebRTC", 0x1E0001},
+	{"RPC_Serve", 0x1E0002},
+	{"RPC_Close", 0x1E0003},
+	{"RPC_ConnectPeer", 0x1E0004},
+	{"RPC_Broadcast", 0x1E0005},
 }
 
 // init wires the catalogue into the live dispatcher.

--- a/synnergy-network/core/rpc_webrtc.go
+++ b/synnergy-network/core/rpc_webrtc.go
@@ -1,0 +1,112 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// RPCWebRTC bridges HTTP RPC calls with WebRTC data channels.
+// It exposes minimal endpoints for transaction submission and
+// forwards messages to connected peers via WebRTC.
+type RPCWebRTC struct {
+	ledger    *Ledger
+	consensus *SynnergyConsensus
+
+	srv   *http.Server
+	peers map[string]*webrtc.PeerConnection
+	mu    sync.Mutex
+}
+
+// NewRPCWebRTC creates a new bridge instance.
+func NewRPCWebRTC(ledger *Ledger, cons *SynnergyConsensus) *RPCWebRTC {
+	return &RPCWebRTC{
+		ledger:    ledger,
+		consensus: cons,
+		peers:     make(map[string]*webrtc.PeerConnection),
+	}
+}
+
+// RPC_Serve starts an HTTP server exposing basic RPC endpoints.
+func (r *RPCWebRTC) RPC_Serve(addr string) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tx", r.handleTx)
+	r.srv = &http.Server{Addr: addr, Handler: mux}
+	return r.srv.ListenAndServe()
+}
+
+// RPC_Close gracefully shuts down the RPC server and all peer connections.
+func (r *RPCWebRTC) RPC_Close() error {
+	if r.srv != nil {
+		_ = r.srv.Shutdown(context.Background())
+	}
+	r.mu.Lock()
+	for id, p := range r.peers {
+		p.Close()
+		delete(r.peers, id)
+	}
+	r.mu.Unlock()
+	return nil
+}
+
+// RPC_ConnectPeer accepts a WebRTC offer and returns the answer SDP.
+func (r *RPCWebRTC) RPC_ConnectPeer(offerSDP string) (string, error) {
+	peer, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		return "", err
+	}
+	offer := webrtc.SessionDescription{Type: webrtc.SDPTypeOffer, SDP: offerSDP}
+	if err := peer.SetRemoteDescription(offer); err != nil {
+		return "", err
+	}
+	answer, err := peer.CreateAnswer(nil)
+	if err != nil {
+		return "", err
+	}
+	if err := peer.SetLocalDescription(answer); err != nil {
+		return "", err
+	}
+	r.mu.Lock()
+	id := fmt.Sprintf("%p", peer)
+	r.peers[id] = peer
+	r.mu.Unlock()
+	return answer.SDP, nil
+}
+
+// RPC_Broadcast sends data to all connected peers via a data channel named topic.
+func (r *RPCWebRTC) RPC_Broadcast(topic string, data []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id, peer := range r.peers {
+		dc, err := peer.CreateDataChannel(topic, nil)
+		if err != nil {
+			return fmt.Errorf("peer %s: %w", id, err)
+		}
+		if err := dc.Send(data); err != nil {
+			return fmt.Errorf("peer %s send: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func (r *RPCWebRTC) handleTx(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	var tx Transaction
+	if err := json.NewDecoder(req.Body).Decode(&tx); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if r.ledger == nil {
+		http.Error(w, "ledger not initialised", http.StatusInternalServerError)
+		return
+	}
+	r.ledger.AddToPool(&tx)
+	w.WriteHeader(http.StatusOK)
+}


### PR DESCRIPTION
## Summary
- introduce `RPCWebRTC` bridge for HTTP RPC and WebRTC communication
- add gas costs for RPC/WebRTC opcodes
- register RPC/WebRTC opcodes in dispatcher

## Testing
- `go vet ./core/...`
- `go build ./core`
- `go test ./core/...`


------
https://chatgpt.com/codex/tasks/task_e_688c33cc0d188320bf18790cfcb6839f