### PR TITLE
Add contract management module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -58,6 +58,7 @@ all modules from the core library. Highlights include:
 - `compliance` – perform KYC/AML checks
 - `consensus` – control the consensus engine
 - `contracts` – deploy and invoke smart contracts
+- `contractops` – administrative tasks such as pausing and upgrading contracts
 - `cross_chain` – configure asset bridges
 - `data` – inspect and manage raw data storage
 - `fault_tolerance` – simulate faults and backups

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -52,6 +52,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `compliance` – Perform KYC/AML verification and auditing.
 - `consensus` – Start or inspect the consensus node.
 - `contracts` – Deploy and invoke smart contracts.
+- `contractops` – Pause, upgrade and transfer ownership of contracts.
 - `cross_chain` – Bridge assets to and from external chains.
 - `data` – Low-level debugging of key/value storage and oracles.
 - `fault_tolerance` – Simulate network failures and snapshot recovery.

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -16,6 +16,7 @@ The following command groups expose the same functionality available in the core
 - **compliance** – Run KYC/AML checks on addresses and export audit reports.
 - **consensus** – Start, stop or inspect the node's consensus service. Provides status metrics for debugging.
 - **contracts** – Deploy, upgrade and invoke smart contracts stored on chain.
+- **contractops** – Administrative operations like pausing and transferring ownership.
 - **cross_chain** – Bridge assets to or from other chains using lock and release commands.
 - **data** – Inspect raw key/value pairs in the underlying data store for debugging.
 - **fault_tolerance** – Inject faults, simulate network partitions and test recovery procedures.
@@ -141,6 +142,16 @@ needed in custom tooling.
 | `invoke <address>` | Invoke a contract method. |
 | `list` | List deployed contracts. |
 | `info <address>` | Show Ricardian manifest for a contract. |
+
+### contractops
+
+| Sub-command | Description |
+|-------------|-------------|
+| `transfer <addr> <newOwner>` | Transfer contract ownership. |
+| `pause <addr>` | Pause contract execution. |
+| `resume <addr>` | Resume a paused contract. |
+| `upgrade <addr> <wasm>` | Replace contract bytecode. |
+| `info <addr>` | Display owner and paused status. |
 
 ### cross_chain
 

--- a/synnergy-network/cmd/cli/contract_management.go
+++ b/synnergy-network/cmd/cli/contract_management.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/joho/godotenv"
+	"github.com/spf13/cobra"
+	"github.com/wasmerio/wasmer-go/wasmer"
+
+	"synnergy-network/core"
+)
+
+var (
+	cmOnce    sync.Once
+	cmManager *core.ContractManager
+)
+
+func cmInit(cmd *cobra.Command, _ []string) error {
+	var err error
+	cmOnce.Do(func() {
+		_ = godotenv.Load()
+		path := os.Getenv("LEDGER_PATH")
+		if path == "" {
+			path = "./ledger.db"
+		}
+		if err = core.InitLedger(path); err != nil {
+			return
+		}
+		led := core.CurrentLedger()
+		if core.GetContractRegistry() == nil {
+			st, _ := core.NewInMemory()
+			vm := core.NewHeavyVM(st, core.NewGasMeter(8_000_000), wasmer.NewEngine())
+			core.InitContracts(led, vm)
+		}
+		cmManager = core.NewContractManager(led, core.GetContractRegistry())
+	})
+	return err
+}
+
+func cmHandleTransfer(cmd *cobra.Command, args []string) error {
+	addrBytes, err := hex.DecodeString(args[0])
+	if err != nil {
+		return err
+	}
+	var addr core.Address
+	copy(addr[:], addrBytes)
+	newBytes, err := hex.DecodeString(args[1])
+	if err != nil {
+		return err
+	}
+	var newAddr core.Address
+	copy(newAddr[:], newBytes)
+	return cmManager.TransferOwnership(addr, newAddr)
+}
+
+func cmHandlePause(cmd *cobra.Command, args []string) error {
+	b, err := hex.DecodeString(args[0])
+	if err != nil {
+		return err
+	}
+	var a core.Address
+	copy(a[:], b)
+	return cmManager.PauseContract(a)
+}
+
+func cmHandleResume(cmd *cobra.Command, args []string) error {
+	b, err := hex.DecodeString(args[0])
+	if err != nil {
+		return err
+	}
+	var a core.Address
+	copy(a[:], b)
+	return cmManager.ResumeContract(a)
+}
+
+func cmHandleUpgrade(cmd *cobra.Command, args []string) error {
+	b, err := hex.DecodeString(args[0])
+	if err != nil {
+		return err
+	}
+	var addr core.Address
+	copy(addr[:], b)
+	code, err := os.ReadFile(args[1])
+	if err != nil {
+		return err
+	}
+	gas, _ := cmd.Flags().GetUint64("gas")
+	return cmManager.UpgradeContract(addr, code, gas)
+}
+
+func cmHandleInfo(cmd *cobra.Command, args []string) error {
+	b, err := hex.DecodeString(args[0])
+	if err != nil {
+		return err
+	}
+	var a core.Address
+	copy(a[:], b)
+	info, err := cmManager.ContractInfo(a)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(info))
+	return nil
+}
+
+var contractMgmtCmd = &cobra.Command{
+	Use:               "contractops",
+	Short:             "Manage deployed contracts",
+	PersistentPreRunE: cmInit,
+}
+
+var cmTransferCmd = &cobra.Command{Use: "transfer <addr> <newOwner>", Args: cobra.ExactArgs(2), RunE: cmHandleTransfer}
+var cmPauseCmd = &cobra.Command{Use: "pause <addr>", Args: cobra.ExactArgs(1), RunE: cmHandlePause}
+var cmResumeCmd = &cobra.Command{Use: "resume <addr>", Args: cobra.ExactArgs(1), RunE: cmHandleResume}
+var cmUpgradeCmd = &cobra.Command{Use: "upgrade <addr> <wasm>", Args: cobra.ExactArgs(2), RunE: cmHandleUpgrade}
+var cmInfoCmd = &cobra.Command{Use: "info <addr>", Args: cobra.ExactArgs(1), RunE: cmHandleInfo}
+
+func init() {
+	cmUpgradeCmd.Flags().Uint64("gas", 200000, "gas limit")
+	contractMgmtCmd.AddCommand(cmTransferCmd, cmPauseCmd, cmResumeCmd, cmUpgradeCmd, cmInfoCmd)
+}
+
+// ContractMgmtCmd exposes the root command.
+var ContractMgmtCmd = contractMgmtCmd
+
+func RegisterContractMgmt(root *cobra.Command) { root.AddCommand(ContractMgmtCmd) }

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -15,6 +15,7 @@ func RegisterRoutes(root *cobra.Command) {
 		TokensCmd,
 		CoinCmd,
 		ContractsCmd,
+		ContractMgmtCmd,
 		VMCmd,
 		TransactionsCmd,
 		WalletCmd,

--- a/synnergy-network/core/contract_management.go
+++ b/synnergy-network/core/contract_management.go
@@ -1,0 +1,137 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"sync"
+)
+
+// ContractManager provides administrative lifecycle operations for
+// deployed smart contracts. It persists metadata via the Ledger
+// using well known key prefixes so state survives restarts.
+//
+// Functions are concurrency safe and integrate with the existing
+// ContractRegistry and VM.
+
+type ContractManager struct {
+	ledger *Ledger
+	reg    *ContractRegistry
+	mu     sync.RWMutex
+}
+
+// Prefixes used when storing state in the ledger key/value store.
+const (
+	ownerPrefix  = "contract:owner:"
+	pausedPrefix = "contract:paused:"
+)
+
+// NewContractManager wires the manager with the given ledger and
+// contract registry.
+func NewContractManager(led *Ledger, reg *ContractRegistry) *ContractManager {
+	return &ContractManager{ledger: led, reg: reg}
+}
+
+// TransferOwnership assigns a new owner for the contract. The address
+// is persisted in the ledger so it can be queried later.
+func (cm *ContractManager) TransferOwnership(addr, newOwner Address) error {
+	if cm.ledger == nil || cm.reg == nil {
+		return errors.New("contract manager not initialised")
+	}
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if _, ok := cm.reg.byAddr[addr]; !ok {
+		return errors.New("contract not found")
+	}
+	return cm.ledger.SetState(ownerKey(addr), newOwner.Bytes())
+}
+
+// OwnerOf fetches the currently assigned owner of a contract. If no
+// owner has been recorded an empty Address is returned.
+func (cm *ContractManager) OwnerOf(addr Address) (Address, error) {
+	if cm.ledger == nil {
+		return Address{}, errors.New("ledger not available")
+	}
+	b, err := cm.ledger.GetState(ownerKey(addr))
+	if err != nil {
+		return Address{}, err
+	}
+	var out Address
+	copy(out[:], b)
+	return out, nil
+}
+
+// PauseContract marks the contract as paused. The VM should reject
+// calls when this flag is set. The manager only records state.
+func (cm *ContractManager) PauseContract(addr Address) error {
+	if cm.ledger == nil {
+		return errors.New("ledger not available")
+	}
+	return cm.ledger.SetState(pausedKey(addr), []byte{1})
+}
+
+// ResumeContract clears the paused flag.
+func (cm *ContractManager) ResumeContract(addr Address) error {
+	if cm.ledger == nil {
+		return errors.New("ledger not available")
+	}
+	return cm.ledger.SetState(pausedKey(addr), []byte{0})
+}
+
+// IsPaused reports whether a contract is currently paused.
+func (cm *ContractManager) IsPaused(addr Address) bool {
+	if cm.ledger == nil {
+		return false
+	}
+	b, err := cm.ledger.GetState(pausedKey(addr))
+	return err == nil && len(b) > 0 && b[0] == 1
+}
+
+// UpgradeContract replaces the bytecode for a deployed contract and
+// updates the registry entry. Existing paused state is preserved.
+func (cm *ContractManager) UpgradeContract(addr Address, code []byte, gas uint64) error {
+	if cm.ledger == nil || cm.reg == nil {
+		return errors.New("contract manager not initialised")
+	}
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	sc, ok := cm.reg.byAddr[addr]
+	if !ok {
+		return errors.New("contract not found")
+	}
+	if cm.IsPaused(addr) {
+		return errors.New("contract is paused")
+	}
+	hash := sha256.Sum256(code)
+	sc.Bytecode = code
+	sc.CodeHash = hash
+	sc.GasLimit = gas
+	if err := cm.ledger.SetState(contractKey(addr), code); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ContractInfo returns a JSON blob describing the contract including
+// owner and paused status.
+func (cm *ContractManager) ContractInfo(addr Address) ([]byte, error) {
+	if cm.reg == nil {
+		return nil, errors.New("registry not initialised")
+	}
+	cm.mu.RLock()
+	sc, ok := cm.reg.byAddr[addr]
+	cm.mu.RUnlock()
+	if !ok {
+		return nil, errors.New("contract not found")
+	}
+	owner, _ := cm.OwnerOf(addr)
+	info := struct {
+		*SmartContract
+		Owner  Address `json:"owner"`
+		Paused bool    `json:"paused"`
+	}{sc, owner, cm.IsPaused(addr)}
+	return json.MarshalIndent(info, "", "  ")
+}
+
+func ownerKey(addr Address) []byte  { return append([]byte(ownerPrefix), addr.Bytes()...) }
+func pausedKey(addr Address) []byte { return append([]byte(pausedPrefix), addr.Bytes()...) }

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -136,6 +136,11 @@ var gasTable map[Opcode]uint64
    CompileWASM:   45_000,
    Invoke:        7_000,
    Deploy:        25_000,
+   TransferOwnership: 5_000,
+   PauseContract:     3_000,
+   ResumeContract:    3_000,
+   UpgradeContract:   20_000,
+   ContractInfo:      1_000,
 
    // ----------------------------------------------------------------------
    // Cross-Chain
@@ -708,10 +713,15 @@ var gasNames = map[string]uint64{
 	// ----------------------------------------------------------------------
 	// Contracts (WASM / EVM‐compat)
 	// ----------------------------------------------------------------------
-	"InitContracts": 15_000,
-	"CompileWASM":   45_000,
-	"Invoke":        7_000,
-	"Deploy":        25_000,
+	"InitContracts":     15_000,
+	"CompileWASM":       45_000,
+	"Invoke":            7_000,
+	"Deploy":            25_000,
+	"TransferOwnership": 5_000,
+	"PauseContract":     3_000,
+	"ResumeContract":    3_000,
+	"UpgradeContract":   20_000,
+	"ContractInfo":      1_000,
 
 	// ----------------------------------------------------------------------
 	// Cross-Chain

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -189,6 +189,11 @@ var catalogue = []struct {
 	{"CompileWASM", 0x080002},
 	{"Invoke", 0x080003},
 	{"Deploy", 0x080004},
+	{"TransferOwnership", 0x080005},
+	{"PauseContract", 0x080006},
+	{"ResumeContract", 0x080007},
+	{"UpgradeContract", 0x080008},
+	{"ContractInfo", 0x080009},
 
 	// Cross-Chain (0x09)
 	{"RegisterBridge", 0x090001},


### PR DESCRIPTION
## Summary
- add core contract management implementation with upgrade and pause logic
- wire new contractops CLI for administrative operations
- expose new command in cli index
- assign gas costs and opcodes for management functions
- document contractops commands in README, cli_guide and whitepaper

## Testing
- `go vet ./cmd/cli/... ./core/...` *(fails: cmd/cli/loanpool.go: cannot use logrus.StandardLogger as *log.Logger)*
- `go build ./core/...`
- `go test ./core/...`
- `go test ./cmd/cli` *(fails to build due to existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_688c34d209948320896e71d02adfea2f