### PR TITLE
Add AI enhanced smart contract module and CLI

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -51,6 +51,7 @@ Each file in `cmd/cli` registers its own group of commands with the root
 all modules from the core library. Highlights include:
 
 - `ai` – publish models and run inference jobs
+- `ai_contract` – manage AI enhanced contracts with risk checks
 - `amm` – swap tokens and manage liquidity pools
 - `authority_node` – validator registration and voting
 - `charity_pool` – query and disburse community funds

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -45,6 +45,7 @@ The supply inflates annually by 2% to maintain incentives and fund new initiativ
 ## Full CLI Guide and Index
 Synnergy comes with a powerful CLI built using the Cobra framework. Commands are grouped into modules mirroring the codebase. Below is a concise index; see `cmd/cli/cli_guide.md` for the detailed usage of each command group:
 - `ai` – Publish machine learning models and run inference jobs.
+- `ai_contract` – Deploy and interact with AI-enhanced contracts.
 - `amm` – Swap tokens and manage liquidity pools.
 - `authority_node` – Register validators and manage the authority set.
 - `charity_pool` – Contribute to or distribute from community charity funds.

--- a/synnergy-network/cmd/cli/ai_contract.go
+++ b/synnergy-network/cmd/cli/ai_contract.go
@@ -1,0 +1,173 @@
+package cli
+
+// cmd/cli/ai_contract.go - CLI for AI-enhanced smart contracts
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+// parseAddress converts a hex string to core.Address
+func parseAddressAddr(h string) (core.Address, error) {
+	var a core.Address
+	b, err := hex.DecodeString(strings.TrimPrefix(h, "0x"))
+	if err != nil || len(b) != len(a) {
+		return a, fmt.Errorf("invalid address %s", h)
+	}
+	copy(a[:], b)
+	return a, nil
+}
+
+// Controller wraps the core functions
+type AIContractController struct{}
+
+func (c *AIContractController) Deploy(wasm string, ric string, cid string, royalty uint16, gas uint64) (*core.AIEnhancedContract, error) {
+	code, err := ioutil.ReadFile(wasm)
+	if err != nil {
+		return nil, err
+	}
+	var ricData []byte
+	if ric != "" {
+		ricData, err = ioutil.ReadFile(ric)
+		if err != nil {
+			return nil, err
+		}
+	}
+	creator := core.ModuleAddress("cli")
+	return core.DeployAIContract(code, ricData, cid, royalty, creator, gas)
+}
+
+func (c *AIContractController) Invoke(addr core.Address, method string, argHex string, txPath string, threshold float32, gas uint64) ([]byte, error) {
+	args, err := hex.DecodeString(strings.TrimPrefix(argHex, "0x"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid args hex: %w", err)
+	}
+	raw, err := ioutil.ReadFile(txPath)
+	if err != nil {
+		return nil, fmt.Errorf("read tx file: %w", err)
+	}
+	var tx core.Transaction
+	if err := json.Unmarshal(raw, &tx); err != nil {
+		return nil, err
+	}
+	ctx := &core.Context{Caller: tx.From, GasLimit: gas}
+	return core.InvokeAIContract(ctx, addr, method, args, &tx, threshold)
+}
+
+func (c *AIContractController) UpdateModel(addr core.Address, cid string, royalty uint16) ([32]byte, error) {
+	creator := core.ModuleAddress("cli")
+	return core.UpdateAIModel(addr, cid, royalty, creator)
+}
+
+func (c *AIContractController) Model(addr core.Address) ([32]byte, error) {
+	return core.GetAIModel(addr)
+}
+
+var aiContractCmd = &cobra.Command{
+	Use:   "ai_contract",
+	Short: "Manage AI-enhanced smart contracts",
+}
+
+var deployAICmd = &cobra.Command{
+	Use:   "deploy [wasm] [cid]",
+	Short: "Deploy a contract and publish its AI model",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ric, _ := cmd.Flags().GetString("ric")
+		royalty, _ := cmd.Flags().GetUint16("royalty")
+		gas, _ := cmd.Flags().GetUint64("gas")
+		ctrl := &AIContractController{}
+		meta, err := ctrl.Deploy(args[0], ric, args[1], royalty, gas)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("contract %x deployed with model %x\n", meta.ContractAddr, meta.ModelHash)
+		return nil
+	},
+}
+
+var invokeAICmd = &cobra.Command{
+	Use:   "invoke [addr] [method] [args_hex] [tx.json]",
+	Short: "Invoke a contract after AI risk check",
+	Args:  cobra.ExactArgs(4),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		threshold, _ := cmd.Flags().GetFloat32("threshold")
+		gas, _ := cmd.Flags().GetUint64("gas")
+		addr, err := parseAddressAddr(args[0])
+		if err != nil {
+			return err
+		}
+		ctrl := &AIContractController{}
+		out, err := ctrl.Invoke(addr, args[1], args[2], args[3], threshold, gas)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("return: %x\n", out)
+		return nil
+	},
+}
+
+var updateModelCmd = &cobra.Command{
+	Use:   "update-model [addr] [cid]",
+	Short: "Publish a new AI model for a contract",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		royalty, _ := cmd.Flags().GetUint16("royalty")
+		addr, err := parseAddressAddr(args[0])
+		if err != nil {
+			return err
+		}
+		ctrl := &AIContractController{}
+		h, err := ctrl.UpdateModel(addr, args[1], royalty)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("new model hash: %x\n", h)
+		return nil
+	},
+}
+
+var getModelCmd = &cobra.Command{
+	Use:   "model [addr]",
+	Short: "Get AI model hash for a contract",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := parseAddressAddr(args[0])
+		if err != nil {
+			return err
+		}
+		ctrl := &AIContractController{}
+		h, err := ctrl.Model(addr)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("model hash: %x\n", h)
+		return nil
+	},
+}
+
+func init() {
+	deployAICmd.Flags().String("ric", "", "ricardian json path")
+	deployAICmd.Flags().Uint16("royalty", 0, "royalty basis points")
+	deployAICmd.Flags().Uint64("gas", 5_000_000, "gas limit")
+
+	invokeAICmd.Flags().Float32("threshold", 0.5, "max fraud score")
+	invokeAICmd.Flags().Uint64("gas", 500_000, "gas limit")
+
+	updateModelCmd.Flags().Uint16("royalty", 0, "royalty basis points")
+
+	aiContractCmd.AddCommand(deployAICmd)
+	aiContractCmd.AddCommand(invokeAICmd)
+	aiContractCmd.AddCommand(updateModelCmd)
+	aiContractCmd.AddCommand(getModelCmd)
+}
+
+// AIContractCmd exposes the root command for index.go
+var AIContractCmd = aiContractCmd

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -9,6 +9,7 @@ Most commands require environment variables or a configuration file to be presen
 The following command groups expose the same functionality available in the core modules. Each can be mounted on a root [`cobra.Command`](https://github.com/spf13/cobra).
 
 - **ai** – Tools for publishing ML models and running anomaly detection jobs via gRPC to the AI service. Useful for training pipelines and on‑chain inference.
+- **ai_contract** – Deploy and interact with AI-enhanced smart contracts.
 - **amm** – Swap tokens and manage liquidity pools. Includes helpers to quote routes and add/remove liquidity.
 - **authority_node** – Register new validators, vote on authority proposals and list the active electorate.
 - **charity_pool** – Query the community charity fund and trigger payouts for the current cycle.

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -19,6 +19,7 @@ func RegisterRoutes(root *cobra.Command) {
 		TransactionsCmd,
 		WalletCmd,
 		AICmd,
+		AIContractCmd,
 		AMMCmd,
 		PoolsCmd,
 		AuthCmd,

--- a/synnergy-network/core/ai_enhanced_contract.go
+++ b/synnergy-network/core/ai_enhanced_contract.go
@@ -1,0 +1,120 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// AIEnhancedContract ties a smart contract to an AI model hash.
+type AIEnhancedContract struct {
+	ContractAddr Address   `json:"contract"`
+	ModelHash    [32]byte  `json:"model_hash"`
+	Creator      Address   `json:"creator"`
+	DeployedAt   time.Time `json:"deployed_at"`
+}
+
+// DeployAIContract compiles and deploys a smart contract while publishing the
+// associated AI model. It returns the deployed contract address and model hash.
+func DeployAIContract(code []byte, ric []byte, modelCID string, royalty uint16, creator Address, gas uint64) (*AIEnhancedContract, error) {
+	if AI() == nil {
+		return nil, fmt.Errorf("AI engine not initialised")
+	}
+	reg := GetContractRegistry()
+	if reg == nil {
+		return nil, fmt.Errorf("contract registry not initialised")
+	}
+
+	// Publish model first so the hash can be stored alongside contract meta.
+	modelHash, err := AI().PublishModel(modelCID, creator, royalty)
+	if err != nil {
+		return nil, err
+	}
+
+	addr := DeriveContractAddress(creator, code)
+	if err := reg.Deploy(addr, code, ric, gas); err != nil {
+		return nil, err
+	}
+
+	meta := &AIEnhancedContract{
+		ContractAddr: addr,
+		ModelHash:    modelHash,
+		Creator:      creator,
+		DeployedAt:   time.Now().UTC(),
+	}
+
+	if led := CurrentLedger(); led != nil {
+		b, _ := json.Marshal(meta)
+		_ = led.SetState(aiContractKey(addr), b)
+	}
+
+	return meta, nil
+}
+
+// InvokeAIContract calls a contract method only if the given transaction passes
+// the AI fraud prediction threshold. The transaction is provided for scoring and
+// must match the invocation arguments.
+func InvokeAIContract(ctx *Context, addr Address, method string, args []byte, tx *Transaction, riskThreshold float32) ([]byte, error) {
+	if AI() == nil {
+		return nil, fmt.Errorf("AI engine not initialised")
+	}
+	reg := GetContractRegistry()
+	if reg == nil {
+		return nil, fmt.Errorf("contract registry not initialised")
+	}
+
+	score, err := AI().PredictAnomaly(tx)
+	if err != nil {
+		return nil, err
+	}
+	if score > riskThreshold {
+		return nil, fmt.Errorf("transaction risk %.2f above threshold %.2f", score, riskThreshold)
+	}
+
+	return reg.Invoke(ctx.Caller, addr, method, args, ctx.GasLimit)
+}
+
+// UpdateAIModel publishes a new model hash and associates it with the contract.
+func UpdateAIModel(addr Address, cid string, royalty uint16, creator Address) ([32]byte, error) {
+	if AI() == nil {
+		return [32]byte{}, fmt.Errorf("AI engine not initialised")
+	}
+
+	h, err := AI().PublishModel(cid, creator, royalty)
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	if led := CurrentLedger(); led != nil {
+		b, _ := json.Marshal(map[string][]byte{"model": h[:]})
+		_ = led.SetState(aiContractModelKey(addr), b)
+	}
+
+	return h, nil
+}
+
+// GetAIModel returns the current model hash associated with a contract.
+func GetAIModel(addr Address) ([32]byte, error) {
+	if led := CurrentLedger(); led != nil {
+		raw, err := led.GetState(aiContractModelKey(addr))
+		if err == nil && raw != nil {
+			var m map[string][]byte
+			if jsonErr := json.Unmarshal(raw, &m); jsonErr == nil {
+				var h [32]byte
+				if v, ok := m["model"]; ok && len(v) == 32 {
+					copy(h[:], v)
+					return h, nil
+				}
+			}
+		}
+	}
+	return [32]byte{}, fmt.Errorf("model not found")
+}
+
+func aiContractKey(addr Address) []byte {
+	return append([]byte("aicontract:"), addr[:]...)
+}
+
+func aiContractModelKey(addr Address) []byte {
+	return append([]byte("aicontract:model:"), addr[:]...)
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -52,6 +52,10 @@ var gasTable map[Opcode]uint64
    RentModel:      20_000,
    ReleaseEscrow:  12_000,
    PredictVolume:  15_000,
+   DeployAIContract: 50_000,
+   InvokeAIContract: 7_500,
+   UpdateAIModel:    20_000,
+   GetAIModel:       2_000,
 
    // ----------------------------------------------------------------------
    // Automated-Market-Maker
@@ -627,7 +631,11 @@ var gasNames = map[string]uint64{
 	"BuyModel":       30_000,
 	"RentModel":      20_000,
 	"ReleaseEscrow":  12_000,
-	"PredictVolume":  15_000,
+        "PredictVolume":  15_000,
+       "DeployAIContract": 50_000,
+       "InvokeAIContract": 7_500,
+       "UpdateAIModel":    20_000,
+       "GetAIModel":       2_000,
 
 	// ----------------------------------------------------------------------
 	// Automated-Market-Maker

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -117,7 +117,11 @@ var catalogue = []struct {
 	name string
 	op   Opcode
 }{
-	// AI (0x01) – pending implementation
+       // AI (0x01)
+       {"DeployAIContract", 0x010001},
+       {"InvokeAIContract", 0x010002},
+       {"UpdateAIModel", 0x010003},
+       {"GetAIModel", 0x010004},
 
 	// AMM (0x02)
 	{"SwapExactIn", 0x020001},


### PR DESCRIPTION
## Summary
- implement `AIEnhancedContract` with deployment/invoke/update helpers
- add CLI commands under `ai_contract`
- register opcodes and gas costs for new functions
- expose new CLI command via index
- document in README, CLI guide and whitepaper

## Testing
- `go vet ./core ./cmd/cli` *(fails: loanpool.go compile error)*
- `go build ./core`

------
https://chatgpt.com/codex/tasks/task_e_688c352fce1c8320b45097e616a2faaa