### PR TITLE
Add IPFS module and CLI integration

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -72,6 +72,7 @@ all modules from the core library. Highlights include:
 - `sidechain` – launch and interact with sidechains
 - `state_channel` – open and settle payment channels
 - `storage` – interact with on‑chain storage providers
+- `ipfs` – manage IPFS pins and retrieval through the gateway
 - `tokens` – ERC‑20 style token commands
 - `transactions` – build and sign transactions
 - `utility_functions` – assorted helpers

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -10,7 +10,7 @@ Synnergy started as a research project exploring novel consensus models and VM d
 The Synnergy ecosystem brings together several services:
 - **Core Ledger and Consensus** – The canonical ledger stores blocks and coordinates the validator set.
 - **Virtual Machine** – A modular VM executes smart contracts compiled to WASM or EVM-compatible bytecode.
-- **Data Layer** – Integrated IPFS-style storage allows assets and off-chain data to be referenced on-chain.
+- **Data Layer** – Integrated IPFS-style storage allows assets and off-chain data to be referenced on-chain. A dedicated IPFS module broadcasts pinned CIDs through consensus and lets clients unpin data when no longer needed.
 - **AI Compliance** – A built-in AI service scans transactions for fraud patterns, KYC signals, and anomalies.
 - **DEX and AMM** – Native modules manage liquidity pools and cross-chain swaps.
 - **Governance** – Token holders can create proposals and vote on protocol upgrades.

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -341,6 +341,14 @@ needed in custom tooling.
 | `deal:get` | Get details for a storage deal. |
 | `deal:list` | List storage deals. |
 
+### ipfs
+
+| Sub-command | Description |
+|-------------|-------------|
+| `add` | Add a file to the configured IPFS gateway. |
+| `get` | Fetch a CID and write to stdout or a file. |
+| `unpin` | Remove a CID from the gateway pinset. |
+
 ### tokens
 
 | Sub-command | Description |

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -29,6 +29,7 @@ func RegisterRoutes(root *cobra.Command) {
 		DataCmd,
 		ChannelRoute,
 		StorageRoute,
+		IPFSRoute,
 		UtilityRoute,
 	)
 

--- a/synnergy-network/cmd/cli/ipfs.go
+++ b/synnergy-network/cmd/cli/ipfs.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/joho/godotenv"
+	logrus "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"synnergy-network/core"
+)
+
+var (
+	ipfsLog  = logrus.New()
+	ipfsCfg  = core.StorageConfig{}
+	ipfsInit bool
+)
+
+func initIPFSMiddleware(cmd *cobra.Command, _ []string) {
+	if ipfsInit {
+		return
+	}
+	_ = godotenv.Load()
+	if ipfsCfg.IPFSGateway == "" {
+		ipfsCfg.IPFSGateway = os.Getenv("IPFS_GATEWAY")
+	}
+	if ipfsCfg.CacheDir == "" {
+		ipfsCfg.CacheDir = os.TempDir()
+	}
+	if ipfsCfg.GatewayTimeout == 0 {
+		ipfsCfg.GatewayTimeout = 30 * time.Second
+	}
+	if err := core.InitIPFS(&ipfsCfg, ipfsLog); err != nil {
+		panic(err)
+	}
+	ipfsInit = true
+}
+
+func addFileHandler(cmd *cobra.Command, args []string) {
+	file, _ := cmd.Flags().GetString("file")
+	payerHex, _ := cmd.Flags().GetString("payer")
+	if file == "" || payerHex == "" {
+		_ = cmd.Usage()
+		panic("--file and --payer required")
+	}
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		panic(err)
+	}
+	addr, err := core.ParseAddress(payerHex)
+	if err != nil {
+		panic(err)
+	}
+	cid, err := core.AddFile(context.Background(), data, addr)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(cid)
+}
+
+func getFileHandler(cmd *cobra.Command, args []string) {
+	cid, _ := cmd.Flags().GetString("cid")
+	out, _ := cmd.Flags().GetString("out")
+	if cid == "" {
+		_ = cmd.Usage()
+		panic("--cid required")
+	}
+	data, err := core.GetFile(context.Background(), cid)
+	if err != nil {
+		panic(err)
+	}
+	if out == "-" || out == "" {
+		os.Stdout.Write(data)
+		return
+	}
+	if err := os.WriteFile(out, data, 0o644); err != nil {
+		panic(err)
+	}
+}
+
+func unpinHandler(cmd *cobra.Command, args []string) {
+	cid, _ := cmd.Flags().GetString("cid")
+	if cid == "" {
+		_ = cmd.Usage()
+		panic("--cid required")
+	}
+	if err := core.UnpinFile(context.Background(), cid); err != nil {
+		panic(err)
+	}
+	fmt.Println("unpinned")
+}
+
+var ipfsCmd = &cobra.Command{
+	Use:              "ipfs",
+	Short:            "Interact with the IPFS gateway",
+	PersistentPreRun: initIPFSMiddleware,
+}
+
+var ipfsAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a file to IPFS",
+	Run:   addFileHandler,
+}
+
+var ipfsGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Retrieve a file by CID",
+	Run:   getFileHandler,
+}
+
+var ipfsUnpinCmd = &cobra.Command{
+	Use:   "unpin",
+	Short: "Unpin a CID from the gateway",
+	Run:   unpinHandler,
+}
+
+func init() {
+	ipfsAddCmd.Flags().String("file", "", "File to upload [required]")
+	ipfsAddCmd.Flags().String("payer", "", "Address paying storage rent [required]")
+	ipfsGetCmd.Flags().String("cid", "", "CID to fetch [required]")
+	ipfsGetCmd.Flags().String("out", "-", "Output file or '-' for STDOUT")
+	ipfsUnpinCmd.Flags().String("cid", "", "CID to unpin [required]")
+
+	ipfsCmd.AddCommand(ipfsAddCmd)
+	ipfsCmd.AddCommand(ipfsGetCmd)
+	ipfsCmd.AddCommand(ipfsUnpinCmd)
+}
+
+// IPFSRoute is the exported command group.
+var IPFSRoute = ipfsCmd

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -368,6 +368,9 @@ var gasTable map[Opcode]uint64
    ListListings:  1_000,
    GetDeal:       1_000,
    ListDeals:     1_000,
+   IPFS_Add:     5_000,
+   IPFS_Get:     4_000,
+   IPFS_Unpin:   3_000,
    // Pin & Retrieve already priced
 
    // ----------------------------------------------------------------------
@@ -944,6 +947,9 @@ var gasNames = map[string]uint64{
 	"ListListings":  1_000,
 	"GetDeal":       1_000,
 	"ListDeals":     1_000,
+	"IPFS_Add":      5_000,
+	"IPFS_Get":      4_000,
+	"IPFS_Unpin":    3_000,
 	// Pin & Retrieve already priced
 
 	// ----------------------------------------------------------------------

--- a/synnergy-network/core/ipfs.go
+++ b/synnergy-network/core/ipfs.go
@@ -1,0 +1,99 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	logrus "github.com/sirupsen/logrus"
+)
+
+// IPFSService provides high level helpers for interacting with an IPFS gateway.
+// It wraps the Storage module so ledger charging and local caching work
+// transparently.
+type IPFSService struct {
+	storage *Storage
+	client  *http.Client
+	gateway string
+	logger  *logrus.Logger
+}
+
+var (
+	ipfsOnce sync.Once
+	ipfsSvc  *IPFSService
+)
+
+// InitIPFS initialises the global IPFS service using the provided configuration.
+// The ledger from helpers.CurrentLedger() is used for rent charging.
+func InitIPFS(cfg *StorageConfig, lg *logrus.Logger) error {
+	var err error
+	ipfsOnce.Do(func() {
+		if lg == nil {
+			lg = logrus.New()
+		}
+		var storage *Storage
+		storage, err = NewStorage(cfg, lg, nil)
+		if err != nil {
+			return
+		}
+		ipfsSvc = &IPFSService{
+			storage: storage,
+			client:  &http.Client{Timeout: cfg.GatewayTimeout},
+			gateway: cfg.IPFSGateway,
+			logger:  lg,
+		}
+	})
+	return err
+}
+
+// IPFS returns the global service if initialised.
+func IPFS() *IPFSService { return ipfsSvc }
+
+// AddFile pins the given data via the configured gateway and broadcasts the CID.
+func AddFile(ctx context.Context, data []byte, payer Address) (string, error) {
+	if ipfsSvc == nil {
+		return "", errors.New("ipfs service not initialised")
+	}
+	cid, _, err := ipfsSvc.storage.Pin(ctx, data, payer)
+	if err != nil {
+		return "", err
+	}
+	_ = Broadcast("ipfs:add", []byte(cid))
+	ipfsSvc.logger.Infof("ipfs added %s", cid)
+	return cid, nil
+}
+
+// GetFile retrieves data for the given CID using the storage cache and gateway.
+func GetFile(ctx context.Context, cid string) ([]byte, error) {
+	if ipfsSvc == nil {
+		return nil, errors.New("ipfs service not initialised")
+	}
+	return ipfsSvc.storage.Retrieve(ctx, cid)
+}
+
+// UnpinFile removes a CID from the gateway pinset and broadcasts the event.
+func UnpinFile(ctx context.Context, cid string) error {
+	if ipfsSvc == nil {
+		return errors.New("ipfs service not initialised")
+	}
+	url := fmt.Sprintf("%s/api/v0/pin/rm?arg=%s", ipfsSvc.gateway, cid)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := ipfsSvc.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 128))
+		return fmt.Errorf("gateway unpin %d: %s", resp.StatusCode, string(b))
+	}
+	_ = Broadcast("ipfs:unpin", []byte(cid))
+	ipfsSvc.logger.Infof("ipfs unpinned %s", cid)
+	return nil
+}

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -401,6 +401,9 @@ var catalogue = []struct {
 	{"ListListings", 0x18000B},
 	{"GetDeal", 0x18000C},
 	{"ListDeals", 0x18000D},
+	{"IPFS_Add", 0x18000E},
+	{"IPFS_Get", 0x18000F},
+	{"IPFS_Unpin", 0x180010},
 
 	// Tokens (0x19)
 	{"ID", 0x190001},


### PR DESCRIPTION
## Summary
- add new `core/ipfs.go` implementing gateway operations
- register IPFS opcodes and gas costs
- add CLI commands under `ipfs`
- expose the command group in `index.go`
- document the IPFS module in README, CLI guide and whitepaper

## Testing
- `go vet ./core/... ./cmd/cli` (fails: loanpool, state_channel etc.)
- `go build ./core/... ./cmd/cli` (fails: multiple existing errors)
- `go mod tidy`


------
https://chatgpt.com/codex/tasks/task_e_688c357b52c8832089d6624098245fc3