### PR TITLE
Add Carbon Credit module with CLI integration

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -63,6 +63,7 @@ all modules from the core library. Highlights include:
 - `fault_tolerance` – simulate faults and backups
 - `governance` – DAO style governance commands
 - `green_technology` – sustainability features
+- `carbon_credit_system` – manage carbon offset projects and credits
 - `ledger` – low level ledger inspection
 - `network` – libp2p networking helpers
 - `replication` – snapshot and replicate data

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -57,6 +57,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `fault_tolerance` – Simulate network failures and snapshot recovery.
 - `governance` – Create proposals and cast votes.
 - `green_technology` – Manage energy tracking and carbon offsets.
+- `carbon_credit_system` – Track carbon projects and issue credits.
 - `ledger` – Inspect blocks, accounts, and token metrics.
 - `liquidity_pools` – Create pools and provide liquidity.
 - `loanpool` – Submit loan requests and disburse funds.
@@ -95,6 +96,7 @@ All high-level functions in the protocol are mapped to unique 24-bit opcodes of 
 0x0D  GreenTech              0x1B  Utilities
 0x0E  Ledger                 0x1C  VirtualMachine
                                  0x1D  Wallet
+                                 0x1E  CarbonCredit
 ```
 The complete list of opcodes along with their handlers can be inspected in `core/opcode_dispatcher.go`. Tools like `synnergy opcodes` dump the catalogue in `<FunctionName>=<Hex>` format to aid audits.
 

--- a/synnergy-network/cmd/cli/carbon_credit_system.go
+++ b/synnergy-network/cmd/cli/carbon_credit_system.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	core "synnergy-network/core"
+)
+
+func ensureCarbon(cmd *cobra.Command, _ []string) error {
+	if core.Carbon() != nil {
+		return nil
+	}
+	led := core.CurrentLedger()
+	if led == nil {
+		return fmt.Errorf("ledger not initialised")
+	}
+	core.InitCarbonEngine(led)
+	return nil
+}
+
+func mustHexCarbon(addr string) core.Address {
+	return mustHex(addr)
+}
+
+var carbonCmd = &cobra.Command{
+	Use:               "carbon",
+	Short:             "Carbon credit project management",
+	PersistentPreRunE: ensureCarbon,
+}
+
+var carbonRegisterCmd = &cobra.Command{
+	Use:   "register <owner> <name> <total>",
+	Short: "Register a new carbon project",
+	Args:  cobra.MinimumNArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		owner := mustHexCarbon(args[0])
+		name := args[1]
+		total, err := strconv.ParseUint(args[2], 10, 64)
+		if err != nil {
+			return fmt.Errorf("total uint64: %w", err)
+		}
+		id, err := core.Carbon().RegisterProject(owner, name, total)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("project %d registered\n", id)
+		return nil
+	},
+}
+
+var carbonIssueCmd = &cobra.Command{
+	Use:   "issue <projectID> <to> <amount>",
+	Short: "Issue credits from a project",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		pid, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("id uint64: %w", err)
+		}
+		to := mustHexCarbon(args[1])
+		amt, err := strconv.ParseUint(args[2], 10, 64)
+		if err != nil {
+			return fmt.Errorf("amount uint64: %w", err)
+		}
+		return core.Carbon().IssueCredits(pid, to, amt)
+	},
+}
+
+var carbonRetireCmd = &cobra.Command{
+	Use:   "retire <holder> <amount>",
+	Short: "Retire (burn) carbon credits",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		holder := mustHexCarbon(args[0])
+		amt, err := strconv.ParseUint(args[1], 10, 64)
+		if err != nil {
+			return fmt.Errorf("amount uint64: %w", err)
+		}
+		return core.Carbon().RetireCredits(holder, amt)
+	},
+}
+
+var carbonInfoCmd = &cobra.Command{
+	Use:   "info <projectID>",
+	Short: "Show project info",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		pid, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("id uint64: %w", err)
+		}
+		proj, ok := core.Carbon().ProjectInfo(pid)
+		if !ok {
+			return fmt.Errorf("project not found")
+		}
+		b, _ := json.MarshalIndent(proj, "", "  ")
+		fmt.Println(string(b))
+		return nil
+	},
+}
+
+var carbonListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all carbon projects",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		list, err := core.Carbon().ListProjects()
+		if err != nil {
+			return err
+		}
+		b, _ := json.MarshalIndent(list, "", "  ")
+		fmt.Println(string(b))
+		return nil
+	},
+}
+
+func init() {
+	carbonCmd.AddCommand(carbonRegisterCmd, carbonIssueCmd, carbonRetireCmd, carbonInfoCmd, carbonListCmd)
+}
+
+var CarbonCmd = carbonCmd

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -21,6 +21,7 @@ The following command groups expose the same functionality available in the core
 - **fault_tolerance** – Inject faults, simulate network partitions and test recovery procedures.
 - **governance** – Create proposals, cast votes and check DAO parameters.
 - **green_technology** – View energy metrics and toggle any experimental sustainability features.
+- **carbon_credit_system** – Manage carbon offset projects and credits.
 - **ledger** – Inspect blocks, query balances and perform administrative token operations via the ledger daemon.
 - **network** – Manage peer connections and print networking statistics.
 - **replication** – Trigger snapshot creation and replicate the ledger to new nodes.
@@ -210,6 +211,16 @@ needed in custom tooling.
 | `cert <validator-addr>` | Show the sustainability certificate. |
 | `throttle <validator-addr>` | Check if a validator should be throttled. |
 | `list` | List certificates for all validators. |
+
+### carbon_credit_system
+
+| Sub-command | Description |
+|-------------|-------------|
+| `register <owner> <name> <total>` | Register a carbon offset project. |
+| `issue <projectID> <to> <amount>` | Issue credits from a project. |
+| `retire <holder> <amount>` | Burn carbon credits permanently. |
+| `info <projectID>` | Show details of a project. |
+| `list` | List all projects. |
 
 ### ledger
 

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -30,6 +30,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ChannelRoute,
 		StorageRoute,
 		UtilityRoute,
+		CarbonCmd,
 	)
 
 	// modules that expose constructors

--- a/synnergy-network/core/carbon_credit_system.go
+++ b/synnergy-network/core/carbon_credit_system.go
@@ -1,0 +1,150 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// CarbonProject represents a verified carbon offset project recorded on chain.
+type CarbonProject struct {
+	ID        uint64  `json:"id"`
+	Name      string  `json:"name"`
+	Owner     Address `json:"owner"`
+	Total     uint64  `json:"total"`
+	Remaining uint64  `json:"remaining"`
+	Verified  bool    `json:"verified"`
+}
+
+// CarbonEngine manages carbon credit issuance and retirement. Projects are
+// stored on the ledger under the "ccs:proj:" prefix. Credits are minted using
+// the built‑in SYN-CO2 token.
+type CarbonEngine struct {
+	ledger  StateRW
+	mu      sync.Mutex
+	nextID  uint64
+	tokenID TokenID
+}
+
+var (
+	carbon     *CarbonEngine
+	carbonOnce sync.Once
+)
+
+// CarbonCreditTokenID is the TokenID used for carbon credit issuance.
+const CarbonCreditTokenID TokenID = TokenID(0x53000000 | uint32(StdSYN200)<<8)
+
+// InitCarbonEngine initialises the singleton engine.
+func InitCarbonEngine(led StateRW) {
+	carbonOnce.Do(func() {
+		carbon = &CarbonEngine{ledger: led, tokenID: CarbonCreditTokenID}
+		if b, err := led.GetState([]byte("ccs:nextID")); err == nil && len(b) > 0 {
+			_ = json.Unmarshal(b, &carbon.nextID)
+		}
+	})
+}
+
+// Carbon returns the global engine instance.
+func Carbon() *CarbonEngine { return carbon }
+
+func (e *CarbonEngine) projectKey(id uint64) []byte {
+	return []byte(fmt.Sprintf("ccs:proj:%d", id))
+}
+
+// RegisterProject creates a new carbon offset project owned by `owner`.
+func (e *CarbonEngine) RegisterProject(owner Address, name string, total uint64) (uint64, error) {
+	if name == "" || total == 0 {
+		return 0, errors.New("invalid project parameters")
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.nextID++
+	id := e.nextID
+	proj := CarbonProject{ID: id, Name: name, Owner: owner, Total: total, Remaining: total}
+	blob, _ := json.Marshal(proj)
+	if err := e.ledger.SetState(e.projectKey(id), blob); err != nil {
+		e.nextID--
+		return 0, err
+	}
+	b, _ := json.Marshal(e.nextID)
+	_ = e.ledger.SetState([]byte("ccs:nextID"), b)
+	return id, nil
+}
+
+func (e *CarbonEngine) getProject(id uint64) (*CarbonProject, error) {
+	b, err := e.ledger.GetState(e.projectKey(id))
+	if err != nil || len(b) == 0 {
+		return nil, fmt.Errorf("project %d not found", id)
+	}
+	var p CarbonProject
+	if err := json.Unmarshal(b, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// IssueCredits mints SYN‑CO2 tokens to `to` from the given project.
+func (e *CarbonEngine) IssueCredits(id uint64, to Address, amount uint64) error {
+	if amount == 0 {
+		return errors.New("amount > 0")
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	proj, err := e.getProject(id)
+	if err != nil {
+		return err
+	}
+	if proj.Remaining < amount {
+		return fmt.Errorf("insufficient project credits")
+	}
+	proj.Remaining -= amount
+	blob, _ := json.Marshal(proj)
+	if err := e.ledger.SetState(e.projectKey(id), blob); err != nil {
+		return err
+	}
+	tok, ok := GetToken(e.tokenID)
+	if !ok {
+		return fmt.Errorf("carbon credit token not found")
+	}
+	return tok.Mint(to, amount)
+}
+
+// RetireCredits burns SYN‑CO2 tokens from the holder's balance.
+func (e *CarbonEngine) RetireCredits(holder Address, amount uint64) error {
+	if amount == 0 {
+		return errors.New("amount > 0")
+	}
+	tok, ok := GetToken(e.tokenID)
+	if !ok {
+		return fmt.Errorf("carbon credit token not found")
+	}
+	return tok.Burn(holder, amount)
+}
+
+// ProjectInfo returns a project by id.
+func (e *CarbonEngine) ProjectInfo(id uint64) (*CarbonProject, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	proj, err := e.getProject(id)
+	if err != nil {
+		return nil, false
+	}
+	return proj, true
+}
+
+// ListProjects enumerates all projects in the ledger.
+func (e *CarbonEngine) ListProjects() ([]CarbonProject, error) {
+	iter := e.ledger.PrefixIterator([]byte("ccs:proj:"))
+	var list []CarbonProject
+	for iter.Next() {
+		var p CarbonProject
+		if err := json.Unmarshal(iter.Value(), &p); err != nil {
+			continue
+		}
+		list = append(list, p)
+	}
+	return list, nil
+}
+
+// End of carbon_credit_system.go

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1183,6 +1183,17 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+
+	// ---------------------------------------------------------------------
+	// Carbon Credit System
+	// ---------------------------------------------------------------------
+	"InitCarbonEngine": 8_000,
+	"Carbon":           2_000,
+	"RegisterProject":  5_000,
+	"IssueCredits":     5_000,
+	"RetireCredits":    3_000,
+	"ProjectInfo":      1_000,
+	"ListProjects":     1_000,
 }
 
 func init() {

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -96,21 +96,22 @@ func wrap(name string) OpcodeFunc {
 //
 // Category map:
 //
-//	0x01 AI                     0x0F Liquidity
-//	0x02 AMM                    0x10 Loanpool
-//	0x03 Authority              0x11 Network
-//	0x04 Charity                0x12 Replication
-//	0x05 Coin                   0x13 Rollups
-//	0x06 Compliance             0x14 Security
-//	0x07 Consensus              0x15 Sharding
-//	0x08 Contracts              0x16 Sidechains
-//	0x09 CrossChain             0x17 StateChannel
-//	0x0A Data                   0x18 Storage
-//	0x0B FaultTolerance         0x19 Tokens
-//	0x0C Governance             0x1A Transactions
-//	0x0D GreenTech              0x1B Utilities
-//	0x0E Ledger                 0x1C VirtualMachine
-//	                            0x1D Wallet
+//		0x01 AI                     0x0F Liquidity
+//		0x02 AMM                    0x10 Loanpool
+//		0x03 Authority              0x11 Network
+//		0x04 Charity                0x12 Replication
+//		0x05 Coin                   0x13 Rollups
+//		0x06 Compliance             0x14 Security
+//		0x07 Consensus              0x15 Sharding
+//		0x08 Contracts              0x16 Sidechains
+//		0x09 CrossChain             0x17 StateChannel
+//		0x0A Data                   0x18 Storage
+//		0x0B FaultTolerance         0x19 Tokens
+//		0x0C Governance             0x1A Transactions
+//		0x0D GreenTech              0x1B Utilities
+//		0x0E Ledger                 0x1C VirtualMachine
+//	                                 0x1D Wallet
+//	                                 0x1E CarbonCredit
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,15 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// CarbonCredit (0x1E)
+	{"InitCarbonEngine", 0x1E0001},
+	{"Carbon", 0x1E0002},
+	{"RegisterProject", 0x1E0003},
+	{"IssueCredits", 0x1E0004},
+	{"RetireCredits", 0x1E0005},
+	{"ProjectInfo", 0x1E0006},
+	{"ListProjects", 0x1E0007},
 }
 
 // init wires the catalogue into the live dispatcher.


### PR DESCRIPTION
## Summary
- implement new `carbon_credit_system.go` module for tracking carbon credit projects
- register carbon credit opcodes and gas prices
- add `carbon_credit_system` CLI commands and hook into command index
- document carbon credit commands in README, cli guide, and whitepaper

## Testing
- `go vet ./core/... ./cmd/cli` *(fails: ledger does not implement StateRW, other package errors)*
- `go build ./core/...` *(passed)*
- `go build ./cmd/cli` *(failed: package does not compile)*
- `go test ./core/...` *(passed)*

------
https://chatgpt.com/codex/tasks/task_e_688c358b8d488320a131dfa7432ee036