### PR TITLE
Add private transaction helpers and CLI

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -74,6 +74,7 @@ all modules from the core library. Highlights include:
 - `storage` – interact with on‑chain storage providers
 - `tokens` – ERC‑20 style token commands
 - `transactions` – build and sign transactions
+- `private_tx` – encrypt and submit private transactions
 - `utility_functions` – assorted helpers
 - `virtual_machine` – run the on‑chain VM service
 - `wallet` – mnemonic generation and signing

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -70,6 +70,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `storage` – Manage off-chain storage deals.
 - `tokens` – Issue and manage token contracts.
 - `transactions` – Build and broadcast transactions manually.
+- `private_tx` – Tools for encrypting data and submitting private transactions.
 - `utility_functions` – Miscellaneous support utilities.
 - `virtual_machine` – Execute VM-level operations for debugging.
 - `wallet` – Create wallets and sign transfers.

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -32,6 +32,7 @@ The following command groups expose the same functionality available in the core
 - **storage** – Configure the backing key/value store and inspect content.
 - **tokens** – Register new token types and move balances between accounts.
 - **transactions** – Build raw transactions, sign them and broadcast to the network.
+- **private_tx** – Encrypt data and submit private transactions.
 - **utility_functions** – Miscellaneous helpers shared by other command groups.
 - **virtual_machine** – Execute scripts in the built‑in VM for testing.
 - **wallet** – Generate mnemonics, derive addresses and sign transactions.
@@ -363,6 +364,14 @@ needed in custom tooling.
 | `verify` | Verify a signed transaction JSON. |
 | `submit` | Submit a signed transaction to the network. |
 | `pool` | List pending pool transaction hashes. |
+
+### private_tx
+
+| Sub-command | Description |
+|-------------|-------------|
+| `encrypt` | Encrypt transaction payload bytes. |
+| `decrypt` | Decrypt previously encrypted payload. |
+| `send` | Submit an encrypted transaction JSON file. |
 
 ### utility_functions
 

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -17,6 +17,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ContractsCmd,
 		VMCmd,
 		TransactionsCmd,
+		PrivateTxCmd,
 		WalletCmd,
 		AICmd,
 		AMMCmd,

--- a/synnergy-network/cmd/cli/private_transactions.go
+++ b/synnergy-network/cmd/cli/private_transactions.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"synnergy-network/core"
+)
+
+var (
+	ptPool   *core.TxPool
+	ptLedger *core.Ledger
+	ptLogger = logrus.StandardLogger()
+	ptOnce   sync.Once
+)
+
+func ptInit(cmd *cobra.Command, _ []string) error {
+	var err error
+	ptOnce.Do(func() {
+		_ = godotenv.Load()
+		lvl := os.Getenv("LOG_LEVEL")
+		if lvl == "" {
+			lvl = "info"
+		}
+		lv, e := logrus.ParseLevel(lvl)
+		if e != nil {
+			err = e
+			return
+		}
+		ptLogger.SetLevel(lv)
+		path := os.Getenv("LEDGER_PATH")
+		if path == "" {
+			err = fmt.Errorf("LEDGER_PATH not set")
+			return
+		}
+		ptLedger, e = core.OpenLedger(path)
+		if e != nil {
+			err = e
+			return
+		}
+		auth := core.NewAuthoritySet(ptLogger, ptLedger)
+		gas := core.NewFlatGasCalculator(10)
+		netSvc, nerr := core.NewNode(core.Config{ListenAddr: ":0", DiscoveryTag: "privtx"})
+		if nerr != nil {
+			err = nerr
+			return
+		}
+		ptPool = core.NewTxPool(nil, ptLedger, auth, gas, netSvc, 0)
+		go ptPool.Run(context.Background())
+	})
+	return err
+}
+
+func handlePTEncrypt(cmd *cobra.Command, _ []string) error {
+	payload, _ := cmd.Flags().GetString("payload")
+	keyStr, _ := cmd.Flags().GetString("key")
+	key, err := hex.DecodeString(strings.TrimPrefix(keyStr, "0x"))
+	if err != nil {
+		return err
+	}
+	tx := &core.Transaction{Payload: []byte(payload)}
+	if err := core.EncryptTxPayload(tx, key); err != nil {
+		return err
+	}
+	hexEnc, _ := core.EncodeEncryptedHex(tx)
+	fmt.Fprintln(cmd.OutOrStdout(), hexEnc)
+	return nil
+}
+
+func handlePTDecrypt(cmd *cobra.Command, _ []string) error {
+	cipherStr, _ := cmd.Flags().GetString("cipher")
+	keyStr, _ := cmd.Flags().GetString("key")
+	key, err := hex.DecodeString(strings.TrimPrefix(keyStr, "0x"))
+	if err != nil {
+		return err
+	}
+	data, err := hex.DecodeString(strings.TrimPrefix(cipherStr, "0x"))
+	if err != nil {
+		return err
+	}
+	tx := &core.Transaction{EncryptedPayload: data, Private: true}
+	plain, err := core.DecryptTxPayload(tx, key)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(plain))
+	return nil
+}
+
+func handlePTSend(cmd *cobra.Command, args []string) error {
+	raw, err := ioutil.ReadFile(args[0])
+	if err != nil {
+		return err
+	}
+	var tx core.Transaction
+	if err := json.Unmarshal(raw, &tx); err != nil {
+		return err
+	}
+	if err := core.SubmitPrivateTx(ptPool, &tx); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "tx %s submitted\n", tx.IDHex())
+	return nil
+}
+
+var privTxCmd = &cobra.Command{
+	Use:               "private_tx",
+	Short:             "Utilities for private transactions",
+	PersistentPreRunE: ptInit,
+}
+
+var ptEncryptCmd = &cobra.Command{Use: "encrypt", Short: "Encrypt payload", RunE: handlePTEncrypt}
+var ptDecryptCmd = &cobra.Command{Use: "decrypt", Short: "Decrypt payload", RunE: handlePTDecrypt}
+var ptSendCmd = &cobra.Command{Use: "send <file>", Short: "Submit private transaction", Args: cobra.ExactArgs(1), RunE: handlePTSend}
+
+func init() {
+	ptEncryptCmd.Flags().String("payload", "", "plaintext data")
+	ptEncryptCmd.Flags().String("key", "", "hex encryption key")
+	ptEncryptCmd.MarkFlagRequired("payload")
+	ptEncryptCmd.MarkFlagRequired("key")
+
+	ptDecryptCmd.Flags().String("cipher", "", "hex ciphertext")
+	ptDecryptCmd.Flags().String("key", "", "hex encryption key")
+	ptDecryptCmd.MarkFlagRequired("cipher")
+	ptDecryptCmd.MarkFlagRequired("key")
+
+	privTxCmd.AddCommand(ptEncryptCmd, ptDecryptCmd, ptSendCmd)
+}
+
+var PrivateTxCmd = privTxCmd
+
+func RegisterPrivateTx(root *cobra.Command) { root.AddCommand(PrivateTxCmd) }

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -460,6 +460,10 @@ var gasTable map[Opcode]uint64
    AddTx:          6_000,
    PickTxs:        1_500,
    TxPoolSnapshot: 800,
+   EncryptTxPayload: 3_500,
+   DecryptTxPayload: 3_000,
+   SubmitPrivateTx:  6_500,
+   EncodeEncryptedHex: 300,
    // Sign already priced
 
    // ----------------------------------------------------------------------
@@ -1030,12 +1034,16 @@ var gasNames = map[string]uint64{
 	// ----------------------------------------------------------------------
 	// Transactions
 	// ----------------------------------------------------------------------
-	"VerifySig":      3_500,
-	"ValidateTx":     5_000,
-	"NewTxPool":      12_000,
-	"AddTx":          6_000,
-	"PickTxs":        1_500,
-	"TxPoolSnapshot": 800,
+	"VerifySig":          3_500,
+	"ValidateTx":         5_000,
+	"NewTxPool":          12_000,
+	"AddTx":              6_000,
+	"PickTxs":            1_500,
+	"TxPoolSnapshot":     800,
+	"EncryptTxPayload":   3_500,
+	"DecryptTxPayload":   3_000,
+	"SubmitPrivateTx":    6_500,
+	"EncodeEncryptedHex": 300,
 	// Sign already priced
 
 	// ----------------------------------------------------------------------

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -439,6 +439,10 @@ var catalogue = []struct {
 	{"AddTx", 0x1A0005},
 	{"PickTxs", 0x1A0006},
 	{"TxPoolSnapshot", 0x1A0007},
+	{"EncryptTxPayload", 0x1A0008},
+	{"DecryptTxPayload", 0x1A0009},
+	{"SubmitPrivateTx", 0x1A000A},
+	{"EncodeEncryptedHex", 0x1A000B},
 
 	// Utilities (0x1B) – EVM-compatible arithmetic & crypto
 	{"Short", 0x1B0001},

--- a/synnergy-network/core/private_transactions.go
+++ b/synnergy-network/core/private_transactions.go
@@ -1,0 +1,69 @@
+package core
+
+// Private transactions helpers provide lightweight encryption and
+// submission logic so that payloads can be hidden from the public
+// ledger. Functions here integrate with the existing TxPool and
+// security package.
+
+import (
+	"encoding/hex"
+	"errors"
+)
+
+// EncryptTxPayload encrypts tx.Payload using the supplied key.
+// The encrypted data is stored in tx.EncryptedPayload and the
+// original payload is cleared. The tx.Private flag is set.
+func EncryptTxPayload(tx *Transaction, key []byte) error {
+	if tx == nil {
+		return errors.New("nil transaction")
+	}
+	if len(tx.Payload) == 0 {
+		return errors.New("empty payload")
+	}
+	blob, err := Encrypt(key, tx.Payload, nil)
+	if err != nil {
+		return err
+	}
+	tx.EncryptedPayload = blob
+	tx.Payload = nil
+	tx.Private = true
+	return nil
+}
+
+// DecryptTxPayload decrypts tx.EncryptedPayload using the key and
+// returns the plaintext payload. It does not modify the transaction
+// so that callers may decide whether to reveal the data.
+func DecryptTxPayload(tx *Transaction, key []byte) ([]byte, error) {
+	if tx == nil {
+		return nil, errors.New("nil transaction")
+	}
+	if !tx.Private {
+		return nil, errors.New("transaction not private")
+	}
+	if len(tx.EncryptedPayload) == 0 {
+		return nil, errors.New("missing encrypted payload")
+	}
+	return Decrypt(key, tx.EncryptedPayload, nil)
+}
+
+// SubmitPrivateTx validates and inserts the transaction into the
+// provided pool. It assumes the payload has already been encrypted
+// and the transaction signed.
+func SubmitPrivateTx(pool *TxPool, tx *Transaction) error {
+	if pool == nil || tx == nil {
+		return errors.New("pool or tx is nil")
+	}
+	return pool.AddTx(tx)
+}
+
+// EncodeEncryptedHex is a helper that returns the encrypted payload
+// as a hex string for easy transport or storage.
+func EncodeEncryptedHex(tx *Transaction) (string, error) {
+	if tx == nil {
+		return "", errors.New("nil transaction")
+	}
+	if len(tx.EncryptedPayload) == 0 {
+		return "", errors.New("no encrypted payload")
+	}
+	return hex.EncodeToString(tx.EncryptedPayload), nil
+}


### PR DESCRIPTION
## Summary
- add `core/private_transactions.go` implementing encryption helpers
- register new opcodes and gas costs
- expose PrivateTx CLI with encrypt/decrypt/send commands and register in index
- document new `private_tx` command group in README, CLI guide, and whitepaper

## Testing
- `go vet ./core/...` passed
- `go vet ./cmd/cli` failed: `loanpool.go` type errors
- `go build ./core/...` passed
- `go build ./cmd/cli` failed: `loanpool.go` and others do not compile
- `go test ./core/...` passed
- `go test ./cmd/cli/...` failed to build

------
https://chatgpt.com/codex/tasks/task_e_688c35b247748320a29edc34881c9d36