### PR TITLE
Add wallet management module and CLI

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -77,6 +77,7 @@ all modules from the core library. Highlights include:
 - `utility_functions` – assorted helpers
 - `virtual_machine` – run the on‑chain VM service
 - `wallet` – mnemonic generation and signing
+- `wallet_mgmt` – manage wallets and send SYNN directly via the ledger
 
 More details for each command can be found in `cmd/cli/cli_guide.md`.
 

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -73,6 +73,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `utility_functions` – Miscellaneous support utilities.
 - `virtual_machine` – Execute VM-level operations for debugging.
 - `wallet` – Create wallets and sign transfers.
+- `wallet_mgmt` – High level wallet manager for ledger payments.
 Each command group supports a help flag to display the individual sub-commands and options.
 
 ## Full Opcode and Operand Code Guide

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -35,6 +35,7 @@ The following command groups expose the same functionality available in the core
 - **utility_functions** – Miscellaneous helpers shared by other command groups.
 - **virtual_machine** – Execute scripts in the built‑in VM for testing.
 - **wallet** – Generate mnemonics, derive addresses and sign transactions.
+- **wallet_mgmt** – Manage wallets and submit ledger transfers.
 
 
 To use these groups, import the corresponding command constructor (e.g. `ledger.NewLedgerCommand()`) in your main program and attach it to the root `cobra.Command`.
@@ -388,3 +389,11 @@ needed in custom tooling.
 | `import` | Import an existing mnemonic. |
 | `address` | Derive an address from a wallet. |
 | `sign` | Sign a transaction JSON using the wallet. |
+
+### wallet_mgmt
+
+| Sub-command | Description |
+|-------------|-------------|
+| `create` | Create a wallet and print the mnemonic. |
+| `balance` | Show the SYNN balance for an address. |
+| `transfer` | Send SYNN from a mnemonic to a target address. |

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -18,6 +18,7 @@ func RegisterRoutes(root *cobra.Command) {
 		VMCmd,
 		TransactionsCmd,
 		WalletCmd,
+		WalletMgmtCmd,
 		AICmd,
 		AMMCmd,
 		PoolsCmd,

--- a/synnergy-network/cmd/cli/wallet_management.go
+++ b/synnergy-network/cmd/cli/wallet_management.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/joho/godotenv"
+	"github.com/spf13/cobra"
+	core "synnergy-network/core"
+)
+
+var (
+	wmLedger *core.Ledger
+	wm       *core.WalletManager
+)
+
+func wmInit(cmd *cobra.Command, _ []string) error {
+	if wm != nil {
+		return nil
+	}
+	_ = godotenv.Load()
+	var err error
+	wmLedger, err = core.NewLedger(core.LedgerConfig{})
+	if err != nil {
+		return err
+	}
+	wm = core.NewWalletManager(wmLedger)
+	return nil
+}
+
+var wmCmd = &cobra.Command{
+	Use:               "wallet_mgmt",
+	Short:             "High level wallet management",
+	PersistentPreRunE: wmInit,
+}
+
+var wmCreateCmd = &cobra.Command{
+	Use:   "create [bits]",
+	Short: "Create a new wallet",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		bits, err := strconv.Atoi(args[0])
+		if err != nil {
+			return err
+		}
+		_, mnemonic, err := wm.Create(bits)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), mnemonic)
+		return nil
+	},
+}
+
+var wmBalanceCmd = &cobra.Command{
+	Use:   "balance [addr]",
+	Short: "Show balance for address",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		addr, err := core.ParseAddress(args[0])
+		if err != nil {
+			return err
+		}
+		bal := wm.Balance(addr)
+		fmt.Fprintln(cmd.OutOrStdout(), bal)
+		return nil
+	},
+}
+
+var wmTransferCmd = &cobra.Command{
+	Use:   "transfer [mnemonic] [to] [amt]",
+	Short: "Transfer SYNN using mnemonic",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		w, err := core.WalletFromMnemonic(args[0], "")
+		if err != nil {
+			return err
+		}
+		to, err := core.ParseAddress(args[1])
+		if err != nil {
+			return err
+		}
+		amt, err := strconv.ParseUint(args[2], 10, 64)
+		if err != nil {
+			return err
+		}
+		tx, err := wm.Transfer(w, 0, 0, to, amt, 0)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%x\n", tx.Hash)
+		return nil
+	},
+}
+
+func init() {
+	wmCmd.AddCommand(wmCreateCmd, wmBalanceCmd, wmTransferCmd)
+}
+
+var WalletMgmtCmd = wmCmd
+
+func RegisterWalletMgmt(root *cobra.Command) { root.AddCommand(WalletMgmtCmd) }

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -607,6 +607,10 @@ var gasTable map[Opcode]uint64
    PrivateKey:          400,
    NewAddress:          500,
    SignTx:              3_000,
+   CreateWallet:        10_000,
+   ImportWallet:        5_000,
+   WalletBalance:       400,
+   WalletTransfer:      2_100,
 */
 
 // gasNames holds the gas cost associated with each opcode name. During init()
@@ -1183,6 +1187,10 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+	"CreateWallet":        10_000,
+	"ImportWallet":        5_000,
+	"WalletBalance":       400,
+	"WalletTransfer":      2_100,
 }
 
 func init() {

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -581,6 +581,10 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+	{"CreateWallet", 0x1D0007},
+	{"ImportWallet", 0x1D0008},
+	{"WalletBalance", 0x1D0009},
+	{"WalletTransfer", 0x1D000A},
 }
 
 // init wires the catalogue into the live dispatcher.

--- a/synnergy-network/core/wallet_management.go
+++ b/synnergy-network/core/wallet_management.go
@@ -1,0 +1,61 @@
+package core
+
+import (
+	"fmt"
+)
+
+// WalletManager wraps Ledger and HDWallet helpers to perform high level wallet operations.
+type WalletManager struct {
+	ledger *Ledger
+}
+
+// NewWalletManager creates a manager bound to the given ledger.
+func NewWalletManager(l *Ledger) *WalletManager {
+	return &WalletManager{ledger: l}
+}
+
+// Create generates a random HD wallet with the given entropy bits and returns it along
+// with the mnemonic phrase. The wallet is not persisted to disk.
+func (wm *WalletManager) Create(bits int) (*HDWallet, string, error) {
+	return NewRandomWallet(bits)
+}
+
+// Import constructs a wallet from the provided mnemonic and optional passphrase.
+func (wm *WalletManager) Import(mnemonic, passphrase string) (*HDWallet, error) {
+	return WalletFromMnemonic(mnemonic, passphrase)
+}
+
+// Balance returns the SYNN balance for the given address using the manager ledger.
+func (wm *WalletManager) Balance(addr Address) uint64 {
+	if wm.ledger == nil {
+		return 0
+	}
+	return wm.ledger.BalanceOf(addr)
+}
+
+// Transfer signs and submits a payment transaction from the wallet to the target address.
+// It also updates the ledger immediately by calling Ledger.Transfer.
+func (wm *WalletManager) Transfer(w *HDWallet, account, index uint32, to Address, amount, gasPrice uint64) (*Transaction, error) {
+	if wm.ledger == nil {
+		return nil, fmt.Errorf("ledger not initialised")
+	}
+	from, err := w.NewAddress(account, index)
+	if err != nil {
+		return nil, err
+	}
+	tx := &Transaction{
+		Type:     TxPayment,
+		To:       to,
+		Value:    amount,
+		GasPrice: gasPrice,
+		Nonce:    wm.ledger.NonceOf(from),
+	}
+	if err := w.SignTx(tx, account, index, gasPrice); err != nil {
+		return nil, err
+	}
+	if err := wm.ledger.Transfer(from, to, amount); err != nil {
+		return nil, err
+	}
+	wm.ledger.AddToPool(tx)
+	return tx, nil
+}


### PR DESCRIPTION
## Summary
- implement `WalletManager` in core for simple wallet operations
- update gas table and opcode dispatcher with new wallet functions
- add `wallet_management` CLI for creating wallets, querying balances and transferring funds
- register new CLI in index and document in README, CLI guide and whitepaper

## Testing
- `go vet ./cmd/... ./core/...` *(failed: context deadline)*
- `go build ./...` *(failed: context deadline)*
- `go test ./...` *(failed: context deadline)*

------
https://chatgpt.com/codex/tasks/task_e_688c3687ecc083208628fffb903c909e