### PR TITLE
Add transaction fee distribution module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -74,6 +74,7 @@ all modules from the core library. Highlights include:
 - `storage` – interact with on‑chain storage providers
 - `tokens` – ERC‑20 style token commands
 - `transactions` – build and sign transactions
+- `transaction_distribution` – split transaction fees between miner and treasury
 - `utility_functions` – assorted helpers
 - `virtual_machine` – run the on‑chain VM service
 - `wallet` – mnemonic generation and signing

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -119,6 +119,8 @@ Synnergy employs a hybrid consensus combining Proof of History for ordering and 
 ## Transaction Distribution Guide
 Transactions are propagated through a gossip network. Nodes maintain a mempool and relay validated transactions to peers. When a validator proposes a sub-block, it selects transactions from its pool based on fee priority and time of arrival. After consensus, the finalized block is broadcast to all peers and applied to local state. Replication modules ensure ledger data remains consistent even under network partitions or DDoS attempts.
 
+Synnergy includes a dedicated **Transaction Distribution** module that automatically splits each transaction fee once a block is committed. Half of the fee rewards the block producer while the remainder is allocated between the LoanPool and community CharityPool. This mechanism keeps incentives aligned and channels a portion of every transaction toward ecosystem development and philanthropic efforts.
+
 ## Financial and Numerical Forecasts
 The following projections outline potential adoption metrics and pricing scenarios. These figures are purely illustrative and not financial advice.
 

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -32,6 +32,7 @@ The following command groups expose the same functionality available in the core
 - **storage** – Configure the backing key/value store and inspect content.
 - **tokens** – Register new token types and move balances between accounts.
 - **transactions** – Build raw transactions, sign them and broadcast to the network.
+- **transaction_distribution** – Distribute transaction fees between stakeholders.
 - **utility_functions** – Miscellaneous helpers shared by other command groups.
 - **virtual_machine** – Execute scripts in the built‑in VM for testing.
 - **wallet** – Generate mnemonics, derive addresses and sign transactions.

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -17,6 +17,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ContractsCmd,
 		VMCmd,
 		TransactionsCmd,
+		TxDistributionCmd(),
 		WalletCmd,
 		AICmd,
 		AMMCmd,

--- a/synnergy-network/cmd/cli/transaction_distribution.go
+++ b/synnergy-network/cmd/cli/transaction_distribution.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	core "synnergy-network/core"
+)
+
+var txdCmd = &cobra.Command{
+	Use:   "txdist",
+	Short: "Distribute transaction fees",
+}
+
+var txdDistributeCmd = &cobra.Command{
+	Use:   "distribute",
+	Short: "simulate fee distribution",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fromStr := viper.GetString("from")
+		minerStr := viper.GetString("miner")
+		feeStr := viper.GetString("fee")
+		if fromStr == "" || minerStr == "" || feeStr == "" {
+			return fmt.Errorf("from, miner and fee required")
+		}
+		from, err := core.StringToAddress(fromStr)
+		if err != nil {
+			return err
+		}
+		minerBytes, err := hexToBytes(minerStr)
+		if err != nil {
+			return err
+		}
+		fee, err := strconv.ParseUint(feeStr, 10, 64)
+		if err != nil {
+			return err
+		}
+		dist := core.CurrentTxDistributor()
+		if dist == nil {
+			return fmt.Errorf("distributor not initialised")
+		}
+		if err := dist.DistributeFees(from, minerBytes, fee); err != nil {
+			return err
+		}
+		fmt.Println("distribution complete")
+		return nil
+	},
+}
+
+func init() {
+	txdDistributeCmd.Flags().String("from", "", "sender address hex")
+	txdDistributeCmd.Flags().String("miner", "", "miner public key hex")
+	txdDistributeCmd.Flags().String("fee", "", "fee amount")
+	_ = viper.BindPFlags(txdDistributeCmd.Flags())
+
+	txdCmd.AddCommand(txdDistributeCmd)
+}
+
+// TxDistributionCmd exposes the root command.
+func TxDistributionCmd() *cobra.Command { return txdCmd }
+
+func hexToBytes(str string) ([]byte, error) {
+	str = strings.TrimPrefix(str, "0x")
+	return hex.DecodeString(str)
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -460,6 +460,8 @@ var gasTable map[Opcode]uint64
    AddTx:          6_000,
    PickTxs:        1_500,
    TxPoolSnapshot: 800,
+   NewTxDistributor: 8_000,
+   DistributeFees:   1_500,
    // Sign already priced
 
    // ----------------------------------------------------------------------
@@ -1030,12 +1032,14 @@ var gasNames = map[string]uint64{
 	// ----------------------------------------------------------------------
 	// Transactions
 	// ----------------------------------------------------------------------
-	"VerifySig":      3_500,
-	"ValidateTx":     5_000,
-	"NewTxPool":      12_000,
-	"AddTx":          6_000,
-	"PickTxs":        1_500,
-	"TxPoolSnapshot": 800,
+	"VerifySig":        3_500,
+	"ValidateTx":       5_000,
+	"NewTxPool":        12_000,
+	"AddTx":            6_000,
+	"PickTxs":          1_500,
+	"TxPoolSnapshot":   800,
+	"NewTxDistributor": 8_000,
+	"DistributeFees":   1_500,
 	// Sign already priced
 
 	// ----------------------------------------------------------------------

--- a/synnergy-network/core/helpers.go
+++ b/synnergy-network/core/helpers.go
@@ -10,6 +10,9 @@ var (
 	globalLedger *Ledger
 	authSetOnce  sync.Once
 	globalAuth   *AuthoritySet
+
+	distOnce   sync.Once
+	globalDist *TxDistributor
 )
 
 // InitLedger initialises the global ledger using OpenLedger at the given path.
@@ -31,6 +34,14 @@ func InitAuthoritySet(set *AuthoritySet) {
 
 // CurrentAuthoritySet returns the global authority set if initialised.
 func CurrentAuthoritySet() *AuthoritySet { return globalAuth }
+
+// InitTxDistributor initialises the global fee distributor.
+func InitTxDistributor(l *Ledger) {
+	distOnce.Do(func() { globalDist = NewTxDistributor(l) })
+}
+
+// CurrentTxDistributor returns the fee distributor if initialised.
+func CurrentTxDistributor() *TxDistributor { return globalDist }
 
 // ------------------------------------------------------------------
 // TF gRPC stub client for AI module wiring

--- a/synnergy-network/core/ledger.go
+++ b/synnergy-network/core/ledger.go
@@ -232,6 +232,15 @@ func (l *Ledger) applyBlock(block *Block, persist bool) error {
 			l.TokenBalances[fromHex] -= tr.Amount
 			l.TokenBalances[toHex] += tr.Amount
 		}
+
+		// ---- Fee distribution ----------------------------------------
+		fee := tx.GasLimit * tx.GasPrice
+		dist := CurrentTxDistributor()
+		if dist != nil && fee > 0 {
+			if err := dist.DistributeFees(tx.From, block.Header.MinerPk, fee); err != nil {
+				logrus.Warnf("fee distribution: %v", err)
+			}
+		}
 	}
 
 	// 4. Persistence & snapshots ---------------------------------------------

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -439,6 +439,8 @@ var catalogue = []struct {
 	{"AddTx", 0x1A0005},
 	{"PickTxs", 0x1A0006},
 	{"TxPoolSnapshot", 0x1A0007},
+	{"NewTxDistributor", 0x1A0008},
+	{"DistributeFees", 0x1A0009},
 
 	// Utilities (0x1B) – EVM-compatible arithmetic & crypto
 	{"Short", 0x1B0001},

--- a/synnergy-network/core/transaction_distribution.go
+++ b/synnergy-network/core/transaction_distribution.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// TxDistributor splits transaction fees between network stakeholders.
+// 50%% of the fee goes to the miner, 30%% to the LoanPool treasury and
+// the remaining 20%% funds the CharityPool.
+//
+// It uses the ledger to move funds directly from the transaction sender
+// to the target accounts. The miner address is derived from the public key
+// stored in the block header.
+type TxDistributor struct {
+	ledger *Ledger
+	mu     sync.Mutex
+}
+
+// NewTxDistributor returns a fee distributor bound to a ledger instance.
+func NewTxDistributor(ledger *Ledger) *TxDistributor {
+	return &TxDistributor{ledger: ledger}
+}
+
+// AddressFromPubKey converts a compressed secp256k1 public key to an Address.
+func AddressFromPubKey(pub []byte) (Address, error) {
+	key, err := crypto.UnmarshalPubkey(pub)
+	if err != nil {
+		return Address{}, err
+	}
+	return FromCommon(crypto.PubkeyToAddress(*key)), nil
+}
+
+// DistributeFees moves the transaction fee from the sender to the
+// miner, LoanPoolAccount and CharityPoolAccount according to the
+// distribution percentages described above.
+func (d *TxDistributor) DistributeFees(from Address, minerPk []byte, fee uint64) error {
+	if d.ledger == nil {
+		return errors.New("distributor: nil ledger")
+	}
+	if fee == 0 {
+		return nil
+	}
+
+	minerAddr, err := AddressFromPubKey(minerPk)
+	if err != nil {
+		return fmt.Errorf("decode miner: %w", err)
+	}
+
+	minerShare := fee / 2
+	loanShare := fee * 30 / 100
+	charityShare := fee - minerShare - loanShare
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if err := d.ledger.Transfer(from, minerAddr, minerShare); err != nil {
+		return err
+	}
+	if err := d.ledger.Transfer(from, LoanPoolAccount, loanShare); err != nil {
+		return err
+	}
+	if err := d.ledger.Transfer(from, CharityPoolAccount, charityShare); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add new core module `transaction_distribution.go` for fee sharing
- expose fee distribution via new CLI command group
- wire TxDistribution command into CLI index
- integrate fee distribution in ledger
- register opcodes and gas prices for new functions
- document new command in README, CLI guide, and whitepaper

## Testing
- `go vet core` *(passes)*
- `go vet cmd/cli/transaction_distribution.go` *(passes)*
- `go build core/...` *(passes)*
- `go build cmd/cli/transaction_distribution.go` *(passes)*
- `go test ./core/...` *(passes)*
- `go vet ./cmd/cli` *(fails: loanpool.go etc.)*
- `go build ./cmd/cli` *(fails: loanpool.go etc.)*
- `go test ./cmd/cli/...` *(fails: loanpool.go etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688c4235103c8320bf73f6615f8034c3