### PR TITLE
Add token and node index packages

### DIFF
--- a/synnergy-network/core/Nodes/Nodes_Type_manual.md
+++ b/synnergy-network/core/Nodes/Nodes_Type_manual.md
@@ -1,0 +1,1 @@
+# Node Types Manual

--- a/synnergy-network/core/Nodes/authority_nodes/Authority_node_typr_manual.md
+++ b/synnergy-network/core/Nodes/authority_nodes/Authority_node_typr_manual.md
@@ -1,0 +1,1 @@
+# Authority Node Type Manual

--- a/synnergy-network/core/Nodes/authority_nodes/index.go
+++ b/synnergy-network/core/Nodes/authority_nodes/index.go
@@ -1,0 +1,9 @@
+package authority_nodes
+
+import "synnergy-network/core/Nodes"
+
+// AuthorityNodeInterface extends NodeInterface with authority-specific actions.
+type AuthorityNodeInterface interface {
+	Nodes.NodeInterface
+	PromoteAuthority(addr string) error
+}

--- a/synnergy-network/core/Nodes/index.go
+++ b/synnergy-network/core/Nodes/index.go
@@ -1,0 +1,11 @@
+package Nodes
+
+// NodeInterface defines minimal node behaviour independent from core types.
+type NodeInterface interface {
+	DialSeed([]string) error
+	Broadcast(topic string, data []byte) error
+	Subscribe(topic string) (<-chan []byte, error)
+	ListenAndServe()
+	Close() error
+	Peers() []string
+}

--- a/synnergy-network/core/Tokens/Tokens_manual.md
+++ b/synnergy-network/core/Tokens/Tokens_manual.md
@@ -1,0 +1,1 @@
+# Tokens Manual

--- a/synnergy-network/core/Tokens/index.go
+++ b/synnergy-network/core/Tokens/index.go
@@ -1,0 +1,6 @@
+package Tokens
+
+// TokenInterfaces consolidates token standard interfaces without core deps.
+type TokenInterfaces interface {
+	Meta() any
+}

--- a/synnergy-network/core/consensus.go
+++ b/synnergy-network/core/consensus.go
@@ -26,8 +26,13 @@ import (
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"math/big"
+	Tokens "synnergy-network/core/Tokens"
 	"time"
 )
+
+// Compile-time assertion to ensure the token interfaces are linked
+// Reference to TokenInterfaces for package usage
+var _ Tokens.TokenInterfaces
 
 // ---------------------------------------------------------------------
 // Consensus constants

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -16,6 +16,7 @@ import (
 	"log"
 	"net"
 	"sync"
+	Nodes "synnergy-network/core/Nodes"
 )
 
 func NewNode(cfg Config) (*Node, error) {
@@ -60,6 +61,9 @@ func NewNode(cfg Config) (*Node, error) {
 
 // Ensure Node implements mdns.Notifee
 var _ mdns.Notifee = (*Node)(nil)
+
+// Ensure Node conforms to the common node interface
+var _ Nodes.NodeInterface = (*NodeAdapter)(nil)
 
 // HandlePeerFound implements mdns.Notifee: connect to discovered peer.
 func (n *Node) HandlePeerFound(info peer.AddrInfo) {

--- a/synnergy-network/core/node.go
+++ b/synnergy-network/core/node.go
@@ -1,0 +1,39 @@
+package core
+
+import Nodes "synnergy-network/core/Nodes"
+
+// NodeAdapter adapts Node to the minimal Nodes.NodeInterface.
+type NodeAdapter struct{ *Node }
+
+func (n *NodeAdapter) DialSeed(seeds []string) error { return n.Node.DialSeed(seeds) }
+func (n *NodeAdapter) Broadcast(topic string, data []byte) error {
+	return n.Node.Broadcast(topic, data)
+}
+
+func (n *NodeAdapter) Subscribe(topic string) (<-chan []byte, error) {
+	ch, err := n.Node.Subscribe(topic)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan []byte)
+	go func() {
+		for msg := range ch {
+			out <- msg.Data
+		}
+	}()
+	return out, nil
+}
+
+func (n *NodeAdapter) ListenAndServe() { n.Node.ListenAndServe() }
+func (n *NodeAdapter) Close() error    { return n.Node.Close() }
+func (n *NodeAdapter) Peers() []string {
+	peers := n.Node.Peers()
+	out := make([]string, len(peers))
+	for i, p := range peers {
+		out[i] = string(p.ID)
+	}
+	return out
+}
+
+// Ensure NodeAdapter implements the interface
+var _ Nodes.NodeInterface = (*NodeAdapter)(nil)

--- a/synnergy-network/core/tokens.go
+++ b/synnergy-network/core/tokens.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"sort"
 	"sync"
+	Tokens "synnergy-network/core/Tokens"
 	"time"
 )
 
@@ -519,3 +520,6 @@ func (s *Stack) Push(v any) {
 func (s *Stack) Len() int {
 	return len(s.data)
 }
+
+// Reference to TokenInterfaces for package usage
+var _ Tokens.TokenInterfaces

--- a/synnergy-network/core/transactions.go
+++ b/synnergy-network/core/transactions.go
@@ -18,7 +18,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	Tokens "synnergy-network/core/Tokens"
 )
+
+// Static check to ensure token interfaces are available
+// Reference to TokenInterfaces for package usage
+var _ Tokens.TokenInterfaces
 
 // -----------------------------------------------------------------------------
 // Address helper (our 20-byte address type ↔ go-ethereum common.Address)
@@ -242,7 +247,6 @@ func (tp *TxPool) AddTx(tx *Transaction) error {
 
 	tp.lookup[tx.Hash] = tx
 	tp.queue = append(tp.queue, tx)
-
 
 	if len(tp.net.peers) > 0 {
 		if data, err := json.Marshal(tx); err == nil {


### PR DESCRIPTION
## Summary
- create `Tokens` and `Nodes` subdirectories with index interfaces
- add `NodeAdapter` implementing `Nodes.NodeInterface`
- reference the new interfaces in core modules
- document basic manuals for tokens and node types

## Testing
- `go vet ./core`
- `go vet ./core/Tokens`
- `go vet ./core/Nodes`
- `go vet ./core/Nodes/authority_nodes`
- `go build ./core`
- `go build ./core/Tokens`
- `go build ./core/Nodes`
- `go build ./core/Nodes/authority_nodes`
- `go test ./core`
- `go test ./core/Tokens`
- `go test ./core/Nodes`
- `go test ./core/Nodes/authority_nodes`


------
https://chatgpt.com/codex/tasks/task_e_688c421711688320afe5e572f802dc4d