### PR TITLE
Add employment module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -61,6 +61,7 @@ all modules from the core library. Highlights include:
 - `cross_chain` – configure asset bridges
 - `data` – inspect and manage raw data storage
 - `fault_tolerance` – simulate faults and backups
+- `employment` – manage on-chain employment contracts and salaries
 - `governance` – DAO style governance commands
 - `green_technology` – sustainability features
 - `ledger` – low level ledger inspection

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -13,6 +13,7 @@ The Synnergy ecosystem brings together several services:
 - **Data Layer** – Integrated IPFS-style storage allows assets and off-chain data to be referenced on-chain.
 - **AI Compliance** – A built-in AI service scans transactions for fraud patterns, KYC signals, and anomalies.
 - **DEX and AMM** – Native modules manage liquidity pools and cross-chain swaps.
+- **Employment Contracts** – Manage job agreements and salary payments on-chain.
 - **Governance** – Token holders can create proposals and vote on protocol upgrades.
 - **Developer Tooling** – CLI modules, RPC services, and SDKs make integration straightforward.
 All services are optional and run as independent modules that plug into the core.
@@ -95,6 +96,7 @@ All high-level functions in the protocol are mapped to unique 24-bit opcodes of 
 0x0D  GreenTech              0x1B  Utilities
 0x0E  Ledger                 0x1C  VirtualMachine
                                  0x1D  Wallet
+0x1E  Employment           
 ```
 The complete list of opcodes along with their handlers can be inspected in `core/opcode_dispatcher.go`. Tools like `synnergy opcodes` dump the catalogue in `<FunctionName>=<Hex>` format to aid audits.
 

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -19,6 +19,7 @@ The following command groups expose the same functionality available in the core
 - **cross_chain** – Bridge assets to or from other chains using lock and release commands.
 - **data** – Inspect raw key/value pairs in the underlying data store for debugging.
 - **fault_tolerance** – Inject faults, simulate network partitions and test recovery procedures.
+- **employment** – Manage on-chain employment contracts and salaries.
 - **governance** – Create proposals, cast votes and check DAO parameters.
 - **green_technology** – View energy metrics and toggle any experimental sustainability features.
 - **ledger** – Inspect blocks, query balances and perform administrative token operations via the ledger daemon.
@@ -178,6 +179,7 @@ needed in custom tooling.
 | `oracle list` | List registered oracles. |
 
 ### fault_tolerance
+- **employment** – Manage on-chain employment contracts and salaries.
 
 | Sub-command | Description |
 |-------------|-------------|

--- a/synnergy-network/cmd/cli/employment.go
+++ b/synnergy-network/cmd/cli/employment.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	core "synnergy-network/core"
+)
+
+var empCtrl *EmploymentController
+
+func ensureEmployment(cmd *cobra.Command, _ []string) error {
+	if empCtrl != nil {
+		return nil
+	}
+	led := core.CurrentLedger()
+	if led == nil {
+		return errors.New("ledger not initialised")
+	}
+	core.InitEmployment(led)
+	empCtrl = &EmploymentController{reg: core.Employment()}
+	return nil
+}
+
+type EmploymentController struct{ reg *core.EmploymentRegistry }
+
+func (c *EmploymentController) Create(employer, employee string, salary uint64, hrs int) (string, error) {
+	emp, err := core.ParseAddress(employer)
+	if err != nil {
+		return "", err
+	}
+	worker, err := core.ParseAddress(employee)
+	if err != nil {
+		return "", err
+	}
+	start := time.Now().UTC()
+	end := start.Add(time.Duration(hrs) * time.Hour)
+	return c.reg.CreateJob(emp, worker, salary, start, end)
+}
+
+func (c *EmploymentController) Sign(id, addr string) error {
+	a, err := core.ParseAddress(addr)
+	if err != nil {
+		return err
+	}
+	return c.reg.SignJob(id, a)
+}
+
+func (c *EmploymentController) Hours(id string, h uint32) error {
+	return c.reg.RecordWork(id, h)
+}
+
+func (c *EmploymentController) Pay(id string) error { return c.reg.PaySalary(id) }
+
+func (c *EmploymentController) Show(id string) (core.EmploymentContract, error) {
+	ec, ok, err := c.reg.GetJob(id)
+	if err != nil {
+		return core.EmploymentContract{}, err
+	}
+	if !ok {
+		return core.EmploymentContract{}, errors.New("not found")
+	}
+	return ec, nil
+}
+
+var employmentCmd = &cobra.Command{Use: "employment", Short: "Employment contracts", PersistentPreRunE: ensureEmployment}
+
+var empCreateCmd = &cobra.Command{Use: "create <employer> <employee> <salary> <hours>", Args: cobra.ExactArgs(4), RunE: func(cmd *cobra.Command, args []string) error {
+	sal, err := strconv.ParseUint(args[2], 10, 64)
+	if err != nil {
+		return err
+	}
+	hrs, err := strconv.Atoi(args[3])
+	if err != nil {
+		return err
+	}
+	id, err := empCtrl.Create(args[0], args[1], sal, hrs)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), id)
+	return nil
+}}
+
+var empSignCmd = &cobra.Command{Use: "sign <id> <addr>", Args: cobra.ExactArgs(2), RunE: func(cmd *cobra.Command, args []string) error {
+	return empCtrl.Sign(args[0], args[1])
+}}
+
+var empHoursCmd = &cobra.Command{Use: "hours <id> <n>", Args: cobra.ExactArgs(2), RunE: func(cmd *cobra.Command, args []string) error {
+	n, err := strconv.ParseUint(args[1], 10, 32)
+	if err != nil {
+		return err
+	}
+	return empCtrl.Hours(args[0], uint32(n))
+}}
+
+var empPayCmd = &cobra.Command{Use: "pay <id>", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+	return empCtrl.Pay(args[0])
+}}
+
+var empShowCmd = &cobra.Command{Use: "show <id>", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
+	ec, err := empCtrl.Show(args[0])
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(ec)
+}}
+
+func init() {
+	employmentCmd.AddCommand(empCreateCmd, empSignCmd, empHoursCmd, empPayCmd, empShowCmd)
+}
+
+var EmploymentCmd = employmentCmd

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -30,6 +30,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ChannelRoute,
 		StorageRoute,
 		UtilityRoute,
+		EmploymentCmd,
 	)
 
 	// modules that expose constructors

--- a/synnergy-network/core/employment.go
+++ b/synnergy-network/core/employment.go
@@ -1,0 +1,154 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// EmploymentContract represents a simple on-chain employment agreement.
+type EmploymentContract struct {
+	ID            string    `json:"id"`
+	Employer      Address   `json:"employer"`
+	Employee      Address   `json:"employee"`
+	SalaryPerHour uint64    `json:"salary_per_hour"`
+	HoursWorked   uint32    `json:"hours_worked"`
+	Start         time.Time `json:"start"`
+	End           time.Time `json:"end"`
+	EmployerSign  bool      `json:"employer_sign"`
+	EmployeeSign  bool      `json:"employee_sign"`
+	Paid          bool      `json:"paid"`
+}
+
+// EmploymentRegistry stores contracts in the ledger key/value store.
+type EmploymentRegistry struct {
+	led    *Ledger
+	mu     sync.RWMutex
+	nextID uint64
+}
+
+var (
+	empOnce sync.Once
+	empReg  *EmploymentRegistry
+)
+
+// InitEmployment initialises the global employment registry.
+func InitEmployment(led *Ledger) {
+	empOnce.Do(func() {
+		empReg = &EmploymentRegistry{led: led, nextID: 1}
+	})
+}
+
+// Employment returns the current registry instance.
+func Employment() *EmploymentRegistry { return empReg }
+
+// CreateJob creates a new employment contract.
+func (r *EmploymentRegistry) CreateJob(employer, employee Address, salary uint64, start, end time.Time) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if salary == 0 {
+		return "", errors.New("salary zero")
+	}
+	if !start.Before(end) {
+		return "", errors.New("start must be before end")
+	}
+	id := fmt.Sprintf("emp:%d", r.nextID)
+	r.nextID++
+	c := EmploymentContract{ID: id, Employer: employer, Employee: employee, SalaryPerHour: salary, Start: start, End: end}
+	b, _ := json.Marshal(c)
+	if err := r.led.SetState([]byte(id), b); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// GetJob retrieves a contract by ID.
+func (r *EmploymentRegistry) GetJob(id string) (EmploymentContract, bool, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	raw, err := r.led.GetState([]byte(id))
+	if err != nil {
+		return EmploymentContract{}, false, err
+	}
+	if len(raw) == 0 {
+		return EmploymentContract{}, false, nil
+	}
+	var c EmploymentContract
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return EmploymentContract{}, false, err
+	}
+	return c, true, nil
+}
+
+// SignJob marks employer or employee signature.
+func (r *EmploymentRegistry) SignJob(id string, signer Address) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	raw, err := r.led.GetState([]byte(id))
+	if err != nil {
+		return err
+	}
+	var c EmploymentContract
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return err
+	}
+	if c.Paid {
+		return errors.New("contract closed")
+	}
+	if signer == c.Employer {
+		c.EmployerSign = true
+	} else if signer == c.Employee {
+		c.EmployeeSign = true
+	} else {
+		return errors.New("not a participant")
+	}
+	b, _ := json.Marshal(c)
+	return r.led.SetState([]byte(id), b)
+}
+
+// RecordWork increments worked hours.
+func (r *EmploymentRegistry) RecordWork(id string, hours uint32) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	raw, err := r.led.GetState([]byte(id))
+	if err != nil {
+		return err
+	}
+	var c EmploymentContract
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return err
+	}
+	if c.Paid {
+		return errors.New("contract closed")
+	}
+	c.HoursWorked += hours
+	b, _ := json.Marshal(c)
+	return r.led.SetState([]byte(id), b)
+}
+
+// PaySalary transfers salary and closes the contract.
+func (r *EmploymentRegistry) PaySalary(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	raw, err := r.led.GetState([]byte(id))
+	if err != nil {
+		return err
+	}
+	var c EmploymentContract
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return err
+	}
+	if c.Paid {
+		return errors.New("already paid")
+	}
+	total := uint64(c.HoursWorked) * c.SalaryPerHour
+	if err := r.led.Transfer(c.Employer, c.Employee, total); err != nil {
+		return err
+	}
+	c.Paid = true
+	b, _ := json.Marshal(c)
+	return r.led.SetState([]byte(id), b)
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1183,6 +1183,16 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+
+	// ----------------------------------------------------------------------
+	// Employment Contracts
+	// ----------------------------------------------------------------------
+	"InitEmployment": 10_000,
+	"CreateJob":      8_000,
+	"SignJob":        3_000,
+	"RecordWork":     1_000,
+	"PaySalary":      8_000,
+	"GetJob":         1_000,
 }
 
 func init() {

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -96,21 +96,22 @@ func wrap(name string) OpcodeFunc {
 //
 // Category map:
 //
-//	0x01 AI                     0x0F Liquidity
-//	0x02 AMM                    0x10 Loanpool
-//	0x03 Authority              0x11 Network
-//	0x04 Charity                0x12 Replication
-//	0x05 Coin                   0x13 Rollups
-//	0x06 Compliance             0x14 Security
-//	0x07 Consensus              0x15 Sharding
-//	0x08 Contracts              0x16 Sidechains
-//	0x09 CrossChain             0x17 StateChannel
-//	0x0A Data                   0x18 Storage
-//	0x0B FaultTolerance         0x19 Tokens
-//	0x0C Governance             0x1A Transactions
-//	0x0D GreenTech              0x1B Utilities
-//	0x0E Ledger                 0x1C VirtualMachine
-//	                            0x1D Wallet
+//		0x01 AI                     0x0F Liquidity
+//		0x02 AMM                    0x10 Loanpool
+//		0x03 Authority              0x11 Network
+//		0x04 Charity                0x12 Replication
+//		0x05 Coin                   0x13 Rollups
+//		0x06 Compliance             0x14 Security
+//		0x07 Consensus              0x15 Sharding
+//		0x08 Contracts              0x16 Sidechains
+//		0x09 CrossChain             0x17 StateChannel
+//		0x0A Data                   0x18 Storage
+//		0x0B FaultTolerance         0x19 Tokens
+//		0x0C Governance             0x1A Transactions
+//		0x0D GreenTech              0x1B Utilities
+//		0x0E Ledger                 0x1C VirtualMachine
+//		                            0x1D Wallet
+//	                                 0x1E Employment
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,14 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// Employment (0x1E)
+	{"InitEmployment", 0x1E0001},
+	{"CreateJob", 0x1E0002},
+	{"SignJob", 0x1E0003},
+	{"RecordWork", 0x1E0004},
+	{"PaySalary", 0x1E0005},
+	{"GetJob", 0x1E0006},
 }
 
 // init wires the catalogue into the live dispatcher.


### PR DESCRIPTION
## Summary
- implement `employment.go` core module with ledger-based job contracts
- register employment CLI commands and expose via index
- assign opcodes and gas pricing for employment functions
- document new module in README, CLI guide, and whitepaper

## Testing
- `go build ./core`
- `go test ./core`
- `go build ./cmd/cli` *(fails: loanpool.go etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688c433a7d2483208019541021b8b053