### PR TITLE
Add supply chain module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -76,6 +76,7 @@ all modules from the core library. Highlights include:
 - `transactions` – build and sign transactions
 - `utility_functions` – assorted helpers
 - `virtual_machine` – run the on‑chain VM service
+- `supply` – manage supply chain assets on chain
 - `wallet` – mnemonic generation and signing
 
 More details for each command can be found in `cmd/cli/cli_guide.md`.

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -70,6 +70,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `storage` – Manage off-chain storage deals.
 - `tokens` – Issue and manage token contracts.
 - `transactions` – Build and broadcast transactions manually.
+- `supply` – Track supply chain assets and logistics.
 - `utility_functions` – Miscellaneous support utilities.
 - `virtual_machine` – Execute VM-level operations for debugging.
 - `wallet` – Create wallets and sign transfers.
@@ -95,6 +96,7 @@ All high-level functions in the protocol are mapped to unique 24-bit opcodes of 
 0x0D  GreenTech              0x1B  Utilities
 0x0E  Ledger                 0x1C  VirtualMachine
                                  0x1D  Wallet
+                                 0x1E  SupplyChain
 ```
 The complete list of opcodes along with their handlers can be inspected in `core/opcode_dispatcher.go`. Tools like `synnergy opcodes` dump the catalogue in `<FunctionName>=<Hex>` format to aid audits.
 

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -34,6 +34,7 @@ The following command groups expose the same functionality available in the core
 - **transactions** – Build raw transactions, sign them and broadcast to the network.
 - **utility_functions** – Miscellaneous helpers shared by other command groups.
 - **virtual_machine** – Execute scripts in the built‑in VM for testing.
+- **supply** – Manage supply chain records.
 - **wallet** – Generate mnemonics, derive addresses and sign transactions.
 
 
@@ -371,6 +372,15 @@ needed in custom tooling.
 | `hash` | Compute a cryptographic hash. |
 | `short-hash` | Shorten a 32-byte hash to first4..last4 format. |
 | `bytes2addr` | Convert big-endian bytes to an address. |
+
+### supply
+
+| Sub-command | Description |
+|-------------|-------------|
+| `register <id> <desc> <owner> <location>` | Register a new item on chain. |
+| `update-location <id> <location>` | Update item location. |
+| `status <id> <status>` | Update item status. |
+| `get <id>` | Fetch item metadata. |
 
 ### virtual_machine
 

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -30,6 +30,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ChannelRoute,
 		StorageRoute,
 		UtilityRoute,
+		SupplyCmd,
 	)
 
 	// modules that expose constructors

--- a/synnergy-network/cmd/cli/supply_chain.go
+++ b/synnergy-network/cmd/cli/supply_chain.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"github.com/spf13/cobra"
+	core "synnergy-network/core"
+)
+
+// Middleware ensures the KV store is initialised.
+func supplyMiddleware(cmd *cobra.Command, args []string) error {
+	if core.CurrentStore() == nil {
+		return errors.New("supply chain store not initialised")
+	}
+	return nil
+}
+
+// Controller wraps core supply chain helpers.
+type SupplyController struct{}
+
+func (c *SupplyController) Register(id, desc, ownerHex, loc string) error {
+	ownerBytes, err := hex.DecodeString(ownerHex)
+	if err != nil || len(ownerBytes) != 20 {
+		return fmt.Errorf("invalid owner address")
+	}
+	var addr core.Address
+	copy(addr[:], ownerBytes)
+	item := core.SupplyItem{ID: id, Description: desc, Owner: addr, Location: loc}
+	return core.RegisterItem(item)
+}
+
+func (c *SupplyController) UpdateLocation(id, loc string) error {
+	return core.UpdateLocation(id, loc)
+}
+
+func (c *SupplyController) MarkStatus(id, status string) error {
+	return core.MarkStatus(id, status)
+}
+
+func (c *SupplyController) Get(id string) (*core.SupplyItem, error) {
+	return core.GetItem(id)
+}
+
+// CLI commands
+var (
+	supplyCmd = &cobra.Command{
+		Use:               "supply",
+		Short:             "Manage on-chain supply chain records",
+		PersistentPreRunE: supplyMiddleware,
+	}
+
+	supplyRegisterCmd = &cobra.Command{
+		Use:   "register <id> <desc> <owner> <location>",
+		Short: "Register a new supply item",
+		Args:  cobra.ExactArgs(4),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctrl := &SupplyController{}
+			return ctrl.Register(args[0], args[1], args[2], args[3])
+		},
+	}
+
+	supplyUpdateCmd = &cobra.Command{
+		Use:   "update-location <id> <location>",
+		Short: "Update item location",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctrl := &SupplyController{}
+			return ctrl.UpdateLocation(args[0], args[1])
+		},
+	}
+
+	supplyStatusCmd = &cobra.Command{
+		Use:   "status <id> <status>",
+		Short: "Update item status",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctrl := &SupplyController{}
+			return ctrl.MarkStatus(args[0], args[1])
+		},
+	}
+
+	supplyGetCmd = &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get item details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctrl := &SupplyController{}
+			item, err := ctrl.Get(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%+v\n", *item)
+			return nil
+		},
+	}
+)
+
+func init() {
+	supplyCmd.AddCommand(supplyRegisterCmd)
+	supplyCmd.AddCommand(supplyUpdateCmd)
+	supplyCmd.AddCommand(supplyStatusCmd)
+	supplyCmd.AddCommand(supplyGetCmd)
+}
+
+var SupplyCmd = supplyCmd

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1183,6 +1183,10 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+	"GetItem":             1_000,
+	"RegisterItem":        10_000,
+	"UpdateLocation":      5_000,
+	"MarkStatus":          5_000,
 }
 
 func init() {

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -96,21 +96,22 @@ func wrap(name string) OpcodeFunc {
 //
 // Category map:
 //
-//	0x01 AI                     0x0F Liquidity
-//	0x02 AMM                    0x10 Loanpool
-//	0x03 Authority              0x11 Network
-//	0x04 Charity                0x12 Replication
-//	0x05 Coin                   0x13 Rollups
-//	0x06 Compliance             0x14 Security
-//	0x07 Consensus              0x15 Sharding
-//	0x08 Contracts              0x16 Sidechains
-//	0x09 CrossChain             0x17 StateChannel
-//	0x0A Data                   0x18 Storage
-//	0x0B FaultTolerance         0x19 Tokens
-//	0x0C Governance             0x1A Transactions
-//	0x0D GreenTech              0x1B Utilities
-//	0x0E Ledger                 0x1C VirtualMachine
-//	                            0x1D Wallet
+//		0x01 AI                     0x0F Liquidity
+//		0x02 AMM                    0x10 Loanpool
+//		0x03 Authority              0x11 Network
+//		0x04 Charity                0x12 Replication
+//		0x05 Coin                   0x13 Rollups
+//		0x06 Compliance             0x14 Security
+//		0x07 Consensus              0x15 Sharding
+//		0x08 Contracts              0x16 Sidechains
+//		0x09 CrossChain             0x17 StateChannel
+//		0x0A Data                   0x18 Storage
+//		0x0B FaultTolerance         0x19 Tokens
+//		0x0C Governance             0x1A Transactions
+//		0x0D GreenTech              0x1B Utilities
+//		0x0E Ledger                 0x1C VirtualMachine
+//		                            0x1D Wallet
+//	                                 0x1E SupplyChain
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,10 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+	{"RegisterItem", 0x1E0001},
+	{"UpdateLocation", 0x1E0002},
+	{"MarkStatus", 0x1E0003},
+	{"GetItem", 0x1E0004},
 }
 
 // init wires the catalogue into the live dispatcher.

--- a/synnergy-network/core/supply_chain.go
+++ b/synnergy-network/core/supply_chain.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// SupplyItem represents a tracked asset in the supply chain.
+type SupplyItem struct {
+	ID          string    `json:"id"`
+	Description string    `json:"desc"`
+	Owner       Address   `json:"owner"`
+	Location    string    `json:"loc"`
+	Status      string    `json:"status"`
+	Updated     time.Time `json:"updated"`
+}
+
+// RegisterItem stores a new SupplyItem on the ledger and broadcasts the event.
+func RegisterItem(item SupplyItem) error {
+	item.Updated = time.Now().UTC()
+	key := fmt.Sprintf("supply:item:%s", item.ID)
+
+	raw, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+	if err := CurrentStore().Set([]byte(key), raw); err != nil {
+		return err
+	}
+	return Broadcast("supply_new", raw)
+}
+
+// UpdateLocation changes the location of an existing item.
+func UpdateLocation(id, location string) error {
+	item, err := GetItem(id)
+	if err != nil {
+		return err
+	}
+	item.Location = location
+	item.Updated = time.Now().UTC()
+	return saveItem(*item)
+}
+
+// MarkStatus updates the status of an item (e.g. shipped, delivered).
+func MarkStatus(id, status string) error {
+	item, err := GetItem(id)
+	if err != nil {
+		return err
+	}
+	item.Status = status
+	item.Updated = time.Now().UTC()
+	return saveItem(*item)
+}
+
+// GetItem retrieves a SupplyItem by ID.
+func GetItem(id string) (*SupplyItem, error) {
+	raw, err := CurrentStore().Get([]byte(fmt.Sprintf("supply:item:%s", id)))
+	if err != nil {
+		return nil, err
+	}
+	var item SupplyItem
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+func saveItem(it SupplyItem) error {
+	raw, err := json.Marshal(it)
+	if err != nil {
+		return err
+	}
+	key := fmt.Sprintf("supply:item:%s", it.ID)
+	if err := CurrentStore().Set([]byte(key), raw); err != nil {
+		return err
+	}
+	return Broadcast("supply_update", raw)
+}


### PR DESCRIPTION
## Summary
- implement supply chain tracking in core
- expose supply chain CLI commands
- wire new command into index
- price opcodes in gas table and register dispatcher entries
- document supply chain module in README, CLI guide and whitepaper

## Testing
- `go vet ./core ./cmd/cli` *(fails: cannot use logrus.StandardLogger)*
- `go build ./...` *(fails: various compile issues in existing packages)*
- `go test ./core ./cmd/cli` *(fails: compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c440ad14083209b0a9bc712fa6c00