### PR TITLE
Add healthcare module and CLI integration

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -72,6 +72,7 @@ all modules from the core library. Highlights include:
 - `sidechain` – launch and interact with sidechains
 - `state_channel` – open and settle payment channels
 - `storage` – interact with on‑chain storage providers
+- `healthcare` – manage on‑chain healthcare records
 - `tokens` – ERC‑20 style token commands
 - `transactions` – build and sign transactions
 - `utility_functions` – assorted helpers

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -14,6 +14,7 @@ The Synnergy ecosystem brings together several services:
 - **AI Compliance** – A built-in AI service scans transactions for fraud patterns, KYC signals, and anomalies.
 - **DEX and AMM** – Native modules manage liquidity pools and cross-chain swaps.
 - **Governance** – Token holders can create proposals and vote on protocol upgrades.
+- **Healthcare Data** – Patients control medical records stored via on-chain permissions.
 - **Developer Tooling** – CLI modules, RPC services, and SDKs make integration straightforward.
 All services are optional and run as independent modules that plug into the core.
 
@@ -68,6 +69,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `sidechain` – Launch or interact with auxiliary chains.
 - `state_channel` – Open and settle payment channels.
 - `storage` – Manage off-chain storage deals.
+- `healthcare` – Manage healthcare records and permissions.
 - `tokens` – Issue and manage token contracts.
 - `transactions` – Build and broadcast transactions manually.
 - `utility_functions` – Miscellaneous support utilities.
@@ -95,6 +97,7 @@ All high-level functions in the protocol are mapped to unique 24-bit opcodes of 
 0x0D  GreenTech              0x1B  Utilities
 0x0E  Ledger                 0x1C  VirtualMachine
                                  0x1D  Wallet
+                                 0x1E  Healthcare
 ```
 The complete list of opcodes along with their handlers can be inspected in `core/opcode_dispatcher.go`. Tools like `synnergy opcodes` dump the catalogue in `<FunctionName>=<Hex>` format to aid audits.
 

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -30,6 +30,7 @@ The following command groups expose the same functionality available in the core
 - **sidechain** – Launch side chains or interact with remote side‑chain nodes.
 - **state_channel** – Open, close and settle payment channels.
 - **storage** – Configure the backing key/value store and inspect content.
+- **healthcare** – Manage healthcare records and permissions.
 - **tokens** – Register new token types and move balances between accounts.
 - **transactions** – Build raw transactions, sign them and broadcast to the network.
 - **utility_functions** – Miscellaneous helpers shared by other command groups.
@@ -340,6 +341,16 @@ needed in custom tooling.
 | `deal:close` | Close a storage deal and release funds. |
 | `deal:get` | Get details for a storage deal. |
 | `deal:list` | List storage deals. |
+
+### healthcare
+
+| Sub-command | Description |
+|-------------|-------------|
+| `register <addr>` | Register a patient address. |
+| `grant <patient> <provider>` | Allow a provider to submit records. |
+| `revoke <patient> <provider>` | Revoke provider access. |
+| `add <patient> <provider> <cid>` | Add a record CID for a patient. |
+| `list <patient>` | List stored record IDs for a patient. |
 
 ### tokens
 

--- a/synnergy-network/cmd/cli/healthcare.go
+++ b/synnergy-network/cmd/cli/healthcare.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"github.com/spf13/cobra"
+	"synnergy-network/core"
+)
+
+// ----------------------------------------------------------------------------
+// Middleware
+// ----------------------------------------------------------------------------
+
+func hcParseAddr(s string) (core.Address, error) {
+	b, err := hex.DecodeString(s)
+	if err != nil || len(b) != 20 {
+		return core.Address{}, fmt.Errorf("bad address")
+	}
+	var a core.Address
+	copy(a[:], b)
+	return a, nil
+}
+
+func hcInitLedger(cmd *cobra.Command, _ []string) error {
+	path, _ := cmd.Flags().GetString("ledger")
+	if path == "" {
+		path = "./ledger.db"
+	}
+	return core.InitLedger(path)
+}
+
+// ----------------------------------------------------------------------------
+// Controllers
+// ----------------------------------------------------------------------------
+
+func hcRegister(cmd *cobra.Command, args []string) error {
+	addr, err := hcParseAddr(args[0])
+	if err != nil {
+		return err
+	}
+	return core.RegisterPatient(addr)
+}
+
+func hcGrant(cmd *cobra.Command, args []string) error {
+	p, err := hcParseAddr(args[0])
+	if err != nil {
+		return err
+	}
+	d, err := hcParseAddr(args[1])
+	if err != nil {
+		return err
+	}
+	return core.GrantAccess(p, d)
+}
+
+func hcRevoke(cmd *cobra.Command, args []string) error {
+	p, err := hcParseAddr(args[0])
+	if err != nil {
+		return err
+	}
+	d, err := hcParseAddr(args[1])
+	if err != nil {
+		return err
+	}
+	return core.RevokeAccess(p, d)
+}
+
+func hcAddRecord(cmd *cobra.Command, args []string) error {
+	p, err := hcParseAddr(args[0])
+	if err != nil {
+		return err
+	}
+	d, err := hcParseAddr(args[1])
+	if err != nil {
+		return err
+	}
+	cid := args[2]
+	id, err := core.AddHealthRecord(p, d, cid)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), id)
+	return nil
+}
+
+func hcList(cmd *cobra.Command, args []string) error {
+	p, err := hcParseAddr(args[0])
+	if err != nil {
+		return err
+	}
+	recs, err := core.ListHealthRecords(p)
+	if err != nil {
+		return err
+	}
+	for _, r := range recs {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%d\n", r.ID, hex.EncodeToString(r.Provider[:]), r.CID, r.CreatedAt)
+	}
+	return nil
+}
+
+// ----------------------------------------------------------------------------
+// Cobra tree
+// ----------------------------------------------------------------------------
+
+var hcCmd = &cobra.Command{Use: "healthcare", Short: "Manage healthcare records", PersistentPreRunE: hcInitLedger}
+
+var hcRegisterCmd = &cobra.Command{Use: "register <addr>", Short: "Register patient", Args: cobra.ExactArgs(1), RunE: hcRegister}
+var hcGrantCmd = &cobra.Command{Use: "grant <patient> <provider>", Short: "Grant access", Args: cobra.ExactArgs(2), RunE: hcGrant}
+var hcRevokeCmd = &cobra.Command{Use: "revoke <patient> <provider>", Short: "Revoke access", Args: cobra.ExactArgs(2), RunE: hcRevoke}
+var hcAddCmd = &cobra.Command{Use: "add <patient> <provider> <cid>", Short: "Add record", Args: cobra.ExactArgs(3), RunE: hcAddRecord}
+var hcListCmd = &cobra.Command{Use: "list <patient>", Short: "List records", Args: cobra.ExactArgs(1), RunE: hcList}
+
+func init() {
+	hcCmd.Flags().String("ledger", "", "ledger path")
+	hcCmd.AddCommand(hcRegisterCmd, hcGrantCmd, hcRevokeCmd, hcAddCmd, hcListCmd)
+}
+
+var HealthcareCmd = hcCmd

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -29,6 +29,7 @@ func RegisterRoutes(root *cobra.Command) {
 		DataCmd,
 		ChannelRoute,
 		StorageRoute,
+		HealthcareCmd,
 		UtilityRoute,
 	)
 

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1183,6 +1183,16 @@ var gasNames = map[string]uint64{
 	"PrivateKey":          400,
 	"NewAddress":          500,
 	"SignTx":              3_000,
+
+	// ----------------------------------------------------------------------
+	// Healthcare Records
+	// ----------------------------------------------------------------------
+	"InitHealthcare":    8_000,
+	"RegisterPatient":   3_000,
+	"AddHealthRecord":   4_000,
+	"GrantAccess":       1_500,
+	"RevokeAccess":      1_000,
+	"ListHealthRecords": 2_000,
 }
 
 func init() {

--- a/synnergy-network/core/healthcare.go
+++ b/synnergy-network/core/healthcare.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// HealthRecord stores a pointer to an off-chain medical record.
+type HealthRecord struct {
+	ID        string  `json:"id"`
+	Patient   Address `json:"patient"`
+	Provider  Address `json:"provider"`
+	CID       string  `json:"cid"`
+	CreatedAt int64   `json:"created_at"`
+}
+
+// HealthcareEngine coordinates patient registration and record access.
+type HealthcareEngine struct {
+	led StateRW
+}
+
+var (
+	hcOnce sync.Once
+	hc     *HealthcareEngine
+)
+
+// InitHealthcare wires the global healthcare engine with the provided ledger.
+func InitHealthcare(led StateRW) {
+	hcOnce.Do(func() { hc = &HealthcareEngine{led: led} })
+}
+
+// helper key builders
+func keyPatient(a Address) []byte { return []byte("health:patient:" + hex.EncodeToString(a[:])) }
+func keyAccess(p, v Address) []byte {
+	return []byte("health:access:" + hex.EncodeToString(p[:]) + ":" + hex.EncodeToString(v[:]))
+}
+func keyRecord(p Address, id string) []byte {
+	return []byte("health:record:" + hex.EncodeToString(p[:]) + ":" + id)
+}
+func prefixRecord(p Address) []byte { return []byte("health:record:" + hex.EncodeToString(p[:]) + ":") }
+
+// RegisterPatient stores a zero-value record for the patient address.
+func RegisterPatient(addr Address) error {
+	if hc == nil {
+		return errors.New("healthcare not initialised")
+	}
+	key := keyPatient(addr)
+	if ok, _ := hc.led.HasState(key); ok {
+		return errors.New("patient exists")
+	}
+	return hc.led.SetState(key, []byte{1})
+}
+
+// GrantAccess allows provider to upload records for the patient.
+func GrantAccess(patient, provider Address) error {
+	if hc == nil {
+		return errors.New("healthcare not initialised")
+	}
+	if ok, _ := hc.led.HasState(keyPatient(patient)); !ok {
+		return errors.New("patient unknown")
+	}
+	return hc.led.SetState(keyAccess(patient, provider), []byte{1})
+}
+
+// RevokeAccess removes a provider from the patient's allow list.
+func RevokeAccess(patient, provider Address) error {
+	if hc == nil {
+		return errors.New("healthcare not initialised")
+	}
+	return hc.led.DeleteState(keyAccess(patient, provider))
+}
+
+// AddHealthRecord stores a CID referencing encrypted medical data.
+// Provider must be authorised and pays 1 coin to the patient.
+func AddHealthRecord(patient, provider Address, cid string) (string, error) {
+	if hc == nil {
+		return "", errors.New("healthcare not initialised")
+	}
+	if ok, _ := hc.led.HasState(keyPatient(patient)); !ok {
+		return "", errors.New("patient unknown")
+	}
+	if patient != provider {
+		if ok, _ := hc.led.HasState(keyAccess(patient, provider)); !ok {
+			return "", errors.New("unauthorised provider")
+		}
+	}
+	id := uuid.New().String()
+	rec := HealthRecord{ID: id, Patient: patient, Provider: provider, CID: cid, CreatedAt: time.Now().Unix()}
+	blob, _ := json.Marshal(rec)
+	if err := hc.led.SetState(keyRecord(patient, id), blob); err != nil {
+		return "", err
+	}
+	_ = hc.led.Transfer(provider, patient, 1)
+	return id, nil
+}
+
+// ListHealthRecords returns all records stored for the patient.
+func ListHealthRecords(patient Address) ([]HealthRecord, error) {
+	if hc == nil {
+		return nil, errors.New("healthcare not initialised")
+	}
+	it := hc.led.PrefixIterator(prefixRecord(patient))
+	var out []HealthRecord
+	for it.Next() {
+		var rec HealthRecord
+		if err := json.Unmarshal(it.Value(), &rec); err == nil {
+			out = append(out, rec)
+		}
+	}
+	return out, it.Error()
+}

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -96,21 +96,22 @@ func wrap(name string) OpcodeFunc {
 //
 // Category map:
 //
-//	0x01 AI                     0x0F Liquidity
-//	0x02 AMM                    0x10 Loanpool
-//	0x03 Authority              0x11 Network
-//	0x04 Charity                0x12 Replication
-//	0x05 Coin                   0x13 Rollups
-//	0x06 Compliance             0x14 Security
-//	0x07 Consensus              0x15 Sharding
-//	0x08 Contracts              0x16 Sidechains
-//	0x09 CrossChain             0x17 StateChannel
-//	0x0A Data                   0x18 Storage
-//	0x0B FaultTolerance         0x19 Tokens
-//	0x0C Governance             0x1A Transactions
-//	0x0D GreenTech              0x1B Utilities
-//	0x0E Ledger                 0x1C VirtualMachine
-//	                            0x1D Wallet
+//		0x01 AI                     0x0F Liquidity
+//		0x02 AMM                    0x10 Loanpool
+//		0x03 Authority              0x11 Network
+//		0x04 Charity                0x12 Replication
+//		0x05 Coin                   0x13 Rollups
+//		0x06 Compliance             0x14 Security
+//		0x07 Consensus              0x15 Sharding
+//		0x08 Contracts              0x16 Sidechains
+//		0x09 CrossChain             0x17 StateChannel
+//		0x0A Data                   0x18 Storage
+//		0x0B FaultTolerance         0x19 Tokens
+//		0x0C Governance             0x1A Transactions
+//		0x0D GreenTech              0x1B Utilities
+//		0x0E Ledger                 0x1C VirtualMachine
+//		                            0x1D Wallet
+//	                                 0x1E Healthcare
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,14 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+
+	// Healthcare (0x1E)
+	{"InitHealthcare", 0x1E0001},
+	{"RegisterPatient", 0x1E0002},
+	{"AddHealthRecord", 0x1E0003},
+	{"GrantAccess", 0x1E0004},
+	{"RevokeAccess", 0x1E0005},
+	{"ListHealthRecords", 0x1E0006},
 }
 
 // init wires the catalogue into the live dispatcher.


### PR DESCRIPTION
## Summary
- implement new `HealthcareEngine` in core for managing patient records
- wire new opcodes and gas costs for healthcare functions
- add `healthcare` CLI commands with register, grant, revoke, add, list
- register healthcare routes in CLI index
- document healthcare module in README, CLI guide and WHITEPAPER

## Testing
- `go vet ./cmd/cli/...` *(fails: cmd/cli loanpool.go type mismatch)*
- `go build ./cmd/cli/healthcare.go`
- `go build ./core`
- `go test ./core`


------
https://chatgpt.com/codex/tasks/task_e_688c441bc9b083209312ca2bee4250d3