### PR TITLE
Add tangible assets module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -72,6 +72,7 @@ all modules from the core library. Highlights include:
 - `sidechain` – launch and interact with sidechains
 - `state_channel` – open and settle payment channels
 - `storage` – interact with on‑chain storage providers
+- `tangible` – register and transfer tangible asset records
 - `tokens` – ERC‑20 style token commands
 - `transactions` – build and sign transactions
 - `utility_functions` – assorted helpers

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -68,6 +68,7 @@ Synnergy comes with a powerful CLI built using the Cobra framework. Commands are
 - `sidechain` – Launch or interact with auxiliary chains.
 - `state_channel` – Open and settle payment channels.
 - `storage` – Manage off-chain storage deals.
+- `tangible` – Track tangible asset ownership on-chain.
 - `tokens` – Issue and manage token contracts.
 - `transactions` – Build and broadcast transactions manually.
 - `utility_functions` – Miscellaneous support utilities.

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -354,6 +354,15 @@ needed in custom tooling.
 | `approve <tok>` | Approve a spender allowance. |
 | `allowance <tok> <owner> <spender>` | Show current allowance. |
 
+### tangible
+
+| Sub-command | Description |
+|-------------|-------------|
+| `register <id> <owner> <meta> <value>` | Register a new tangible asset. |
+| `transfer <id> <owner>` | Transfer ownership of an asset. |
+| `info <id>` | Display asset metadata. |
+| `list` | List all tangible assets. |
+
 ### transactions
 
 | Sub-command | Description |

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -30,6 +30,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ChannelRoute,
 		StorageRoute,
 		UtilityRoute,
+		TangibleCmd,
 	)
 
 	// modules that expose constructors

--- a/synnergy-network/cmd/cli/tangible_assets.go
+++ b/synnergy-network/cmd/cli/tangible_assets.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+var (
+	taOnce sync.Once
+	taMgr  *core.TangibleAssets
+	taLog  = logrus.StandardLogger()
+)
+
+func taMiddleware(cmd *cobra.Command, _ []string) error {
+	var err error
+	taOnce.Do(func() {
+		_ = godotenv.Load()
+		lvl := os.Getenv("LOG_LEVEL")
+		if lvl == "" {
+			lvl = "info"
+		}
+		lv, e := logrus.ParseLevel(lvl)
+		if e == nil {
+			taLog.SetLevel(lv)
+		}
+		path := os.Getenv("LEDGER_PATH")
+		if path == "" {
+			err = fmt.Errorf("LEDGER_PATH not set")
+			return
+		}
+		led, e := core.OpenLedger(path)
+		if e != nil {
+			err = e
+			return
+		}
+		taMgr = core.NewTangibleAssets(led)
+	})
+	return err
+}
+
+func taHandleRegister(cmd *cobra.Command, args []string) error {
+	if len(args) < 4 {
+		return fmt.Errorf("usage: register <id> <owner> <meta> <value>")
+	}
+	id := args[0]
+	ownerHex := args[1]
+	meta := args[2]
+	val, err := strconv.ParseUint(args[3], 10, 64)
+	if err != nil {
+		return err
+	}
+	ownerBytes, err := hex.DecodeString(trimHex(ownerHex))
+	if err != nil || len(ownerBytes) != 20 {
+		return fmt.Errorf("invalid owner address")
+	}
+	var owner core.Address
+	copy(owner[:], ownerBytes)
+	return taMgr.Register(id, owner, meta, val)
+}
+
+func taHandleTransfer(cmd *cobra.Command, args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("usage: transfer <id> <newOwner>")
+	}
+	id := args[0]
+	ownerBytes, err := hex.DecodeString(trimHex(args[1]))
+	if err != nil || len(ownerBytes) != 20 {
+		return fmt.Errorf("invalid owner address")
+	}
+	var owner core.Address
+	copy(owner[:], ownerBytes)
+	return taMgr.Transfer(id, owner)
+}
+
+func taHandleInfo(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: info <id>")
+	}
+	rec, ok, err := taMgr.Get(args[0])
+	if err != nil {
+		return err
+	}
+	if !ok {
+		fmt.Println("not found")
+		return nil
+	}
+	b, _ := json.MarshalIndent(rec, "", "  ")
+	fmt.Println(string(b))
+	return nil
+}
+
+func taHandleList(cmd *cobra.Command, _ []string) error {
+	assets, err := taMgr.List()
+	if err != nil {
+		return err
+	}
+	for _, a := range assets {
+		fmt.Printf("%s %x %s %d\n", a.ID, a.Owner, a.Meta, a.Value)
+	}
+	return nil
+}
+
+var tangibleCmd = &cobra.Command{
+	Use:               "tangible",
+	Short:             "Manage tangible asset records",
+	PersistentPreRunE: taMiddleware,
+}
+
+var taRegisterCmd = &cobra.Command{Use: "register <id> <owner> <meta> <value>", RunE: taHandleRegister}
+var taTransferCmd = &cobra.Command{Use: "transfer <id> <owner>", RunE: taHandleTransfer}
+var taInfoCmd = &cobra.Command{Use: "info <id>", RunE: taHandleInfo}
+var taListCmd = &cobra.Command{Use: "list", RunE: taHandleList}
+
+func init() {
+	tangibleCmd.AddCommand(taRegisterCmd, taTransferCmd, taInfoCmd, taListCmd)
+}
+
+var TangibleCmd = tangibleCmd
+
+func RegisterTangible(root *cobra.Command) { root.AddCommand(TangibleCmd) }
+
+func trimHex(s string) string {
+	if len(s) >= 2 && s[0:2] == "0x" {
+		return s[2:]
+	}
+	return s
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -944,6 +944,11 @@ var gasNames = map[string]uint64{
 	"ListListings":  1_000,
 	"GetDeal":       1_000,
 	"ListDeals":     1_000,
+	// Tangible assets
+	"Assets_Register": 5_000,
+	"Assets_Transfer": 4_000,
+	"Assets_Get":      1_000,
+	"Assets_List":     1_000,
 	// Pin & Retrieve already priced
 
 	// ----------------------------------------------------------------------

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -111,6 +111,7 @@ func wrap(name string) OpcodeFunc {
 //	0x0D GreenTech              0x1B Utilities
 //	0x0E Ledger                 0x1C VirtualMachine
 //	                            0x1D Wallet
+//	0x1E Assets
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,10 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+	{"Assets_Register", 0x1E0001},
+	{"Assets_Transfer", 0x1E0002},
+	{"Assets_Get", 0x1E0003},
+	{"Assets_List", 0x1E0004},
 }
 
 // init wires the catalogue into the live dispatcher.

--- a/synnergy-network/core/tangible_assets.go
+++ b/synnergy-network/core/tangible_assets.go
@@ -1,0 +1,92 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// TangibleAsset represents a tokenised physical asset tracked on chain.
+type TangibleAsset struct {
+	ID      string    `json:"id"`
+	Owner   Address   `json:"owner"`
+	Meta    string    `json:"meta"`
+	Value   uint64    `json:"value"`
+	Created time.Time `json:"created"`
+}
+
+// TangibleAssets provides ledger backed operations for tangible assets.
+type TangibleAssets struct {
+	Ledger StateRW
+}
+
+// NewTangibleAssets returns a manager instance using the provided ledger.
+func NewTangibleAssets(led StateRW) *TangibleAssets {
+	return &TangibleAssets{Ledger: led}
+}
+
+func assetKey(id string) []byte { return []byte("tangible:" + id) }
+
+// Register stores a new asset record. The id must be unique.
+func (m *TangibleAssets) Register(id string, owner Address, meta string, value uint64) error {
+	if exists, _ := m.Ledger.HasState(assetKey(id)); exists {
+		return fmt.Errorf("asset %s already exists", id)
+	}
+	rec := TangibleAsset{ID: id, Owner: owner, Meta: meta, Value: value, Created: time.Now().UTC()}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	return m.Ledger.SetState(assetKey(id), data)
+}
+
+// Transfer updates the ownership of an existing asset.
+func (m *TangibleAssets) Transfer(id string, newOwner Address) error {
+	data, err := m.Ledger.GetState(assetKey(id))
+	if err != nil || data == nil {
+		return fmt.Errorf("asset %s not found", id)
+	}
+	var rec TangibleAsset
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return err
+	}
+	rec.Owner = newOwner
+	updated, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	return m.Ledger.SetState(assetKey(id), updated)
+}
+
+// Get retrieves a single asset by id.
+func (m *TangibleAssets) Get(id string) (TangibleAsset, bool, error) {
+	data, err := m.Ledger.GetState(assetKey(id))
+	if err != nil || data == nil {
+		return TangibleAsset{}, false, err
+	}
+	var rec TangibleAsset
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return TangibleAsset{}, false, err
+	}
+	return rec, true, nil
+}
+
+// List returns all registered tangible assets.
+func (m *TangibleAssets) List() ([]TangibleAsset, error) {
+	it := m.Ledger.PrefixIterator([]byte("tangible:"))
+	var out []TangibleAsset
+	for it.Next() {
+		var rec TangibleAsset
+		if err := json.Unmarshal(it.Value(), &rec); err == nil {
+			out = append(out, rec)
+		}
+	}
+	if err := it.Error(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// registerTangibleOpcodes wires the VM dispatcher. Actual execution relies on
+// Context.Call which is stubbed during early development.
+// Opcodes are defined in opcode_dispatcher.go through the generated catalogue.


### PR DESCRIPTION
## Summary
- implement `TangibleAssets` core module for on-chain asset tracking
- expose new CLI commands under `tangible`
- register asset opcodes and gas costs
- document new commands in README, CLI guide and whitepaper
- wire tangible command into CLI index

## Testing
- `go vet ./core`
- `go build ./core`
- `go test ./core`
- `go vet ./cmd/cli` *(fails: loanpool.go uses incompatible types)*
- `go build ./cmd/cli` *(fails with compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c43c62be48320a7eafc6ddd273e98