### PR TITLE
Add warehouse inventory module

### DIFF
--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -72,6 +72,7 @@ all modules from the core library. Highlights include:
 - `sidechain` – launch and interact with sidechains
 - `state_channel` – open and settle payment channels
 - `storage` – interact with on‑chain storage providers
+- `warehouse` – manage on‑chain inventory records
 - `tokens` – ERC‑20 style token commands
 - `transactions` – build and sign transactions
 - `utility_functions` – assorted helpers

--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -13,6 +13,7 @@ The Synnergy ecosystem brings together several services:
 - **Data Layer** – Integrated IPFS-style storage allows assets and off-chain data to be referenced on-chain.
 - **AI Compliance** – A built-in AI service scans transactions for fraud patterns, KYC signals, and anomalies.
 - **DEX and AMM** – Native modules manage liquidity pools and cross-chain swaps.
+- **Warehouse Management** – On-chain inventory tracking for supply chains.
 - **Governance** – Token holders can create proposals and vote on protocol upgrades.
 - **Developer Tooling** – CLI modules, RPC services, and SDKs make integration straightforward.
 All services are optional and run as independent modules that plug into the core.
@@ -95,6 +96,7 @@ All high-level functions in the protocol are mapped to unique 24-bit opcodes of 
 0x0D  GreenTech              0x1B  Utilities
 0x0E  Ledger                 0x1C  VirtualMachine
                                  0x1D  Wallet
+                                 0x1E  Warehouse
 ```
 The complete list of opcodes along with their handlers can be inspected in `core/opcode_dispatcher.go`. Tools like `synnergy opcodes` dump the catalogue in `<FunctionName>=<Hex>` format to aid audits.
 

--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -30,6 +30,7 @@ The following command groups expose the same functionality available in the core
 - **sidechain** – Launch side chains or interact with remote side‑chain nodes.
 - **state_channel** – Open, close and settle payment channels.
 - **storage** – Configure the backing key/value store and inspect content.
+- **warehouse** – Manage on-chain inventory records.
 - **tokens** – Register new token types and move balances between accounts.
 - **transactions** – Build raw transactions, sign them and broadcast to the network.
 - **utility_functions** – Miscellaneous helpers shared by other command groups.
@@ -340,6 +341,15 @@ needed in custom tooling.
 | `deal:close` | Close a storage deal and release funds. |
 | `deal:get` | Get details for a storage deal. |
 | `deal:list` | List storage deals. |
+
+### warehouse
+
+| Sub-command | Description |
+|-------------|-------------|
+| `add` | Add a new inventory item. |
+| `remove` | Delete an existing item. |
+| `move` | Transfer item ownership. |
+| `list` | List all warehouse items. |
 
 ### tokens
 

--- a/synnergy-network/cmd/cli/index.go
+++ b/synnergy-network/cmd/cli/index.go
@@ -30,6 +30,7 @@ func RegisterRoutes(root *cobra.Command) {
 		ChannelRoute,
 		StorageRoute,
 		UtilityRoute,
+		WarehouseCmd,
 	)
 
 	// modules that expose constructors

--- a/synnergy-network/cmd/cli/warehouse.go
+++ b/synnergy-network/cmd/cli/warehouse.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/joho/godotenv"
+	"github.com/spf13/cobra"
+
+	"synnergy-network/core"
+)
+
+var (
+	whOnce   bool
+	wh       *core.Warehouse
+	whLedger *core.Ledger
+)
+
+func whInit(cmd *cobra.Command, _ []string) error {
+	if whOnce {
+		return nil
+	}
+	_ = godotenv.Load()
+	path := os.Getenv("LEDGER_PATH")
+	if path == "" {
+		path = "./ledger.db"
+	}
+	var err error
+	whLedger, err = core.OpenLedger(path)
+	if err != nil {
+		return fmt.Errorf("open ledger: %w", err)
+	}
+	wh = core.NewWarehouse(whLedger)
+	whOnce = true
+	return nil
+}
+
+//---------------------------------------------------------------------
+// Controllers
+//---------------------------------------------------------------------
+
+type warehouseController struct{}
+
+func (warehouseController) Add(id, name string, qty uint64) error {
+	ctx := &core.Context{Caller: core.Address{}}
+	return wh.AddItem(ctx, id, name, qty)
+}
+func (warehouseController) Remove(id string) error {
+	ctx := &core.Context{Caller: core.Address{}}
+	return wh.RemoveItem(ctx, id)
+}
+func (warehouseController) Move(id, owner string) error {
+	addr, err := core.ParseAddress(owner)
+	if err != nil {
+		return err
+	}
+	ctx := &core.Context{Caller: core.Address{}}
+	return wh.MoveItem(ctx, id, addr)
+}
+func (warehouseController) List() error {
+	items, err := wh.ListItems()
+	if err != nil {
+		return err
+	}
+	b, _ := json.MarshalIndent(items, "", "  ")
+	fmt.Println(string(b))
+	return nil
+}
+
+//---------------------------------------------------------------------
+// CLI commands
+//---------------------------------------------------------------------
+
+var warehouseCmd = &cobra.Command{
+	Use:               "warehouse",
+	Short:             "Manage on-chain warehouse inventory",
+	PersistentPreRunE: whInit,
+}
+
+var warehouseAddCmd = &cobra.Command{
+	Use:   "add <id> <name> <qty>",
+	Short: "Add a new item",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		qty, err := strconv.ParseUint(args[2], 10, 64)
+		if err != nil {
+			return err
+		}
+		return warehouseController{}.Add(args[0], args[1], qty)
+	},
+}
+
+var warehouseRemoveCmd = &cobra.Command{
+	Use:   "remove <id>",
+	Short: "Remove an item",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return warehouseController{}.Remove(args[0])
+	},
+}
+
+var warehouseMoveCmd = &cobra.Command{
+	Use:   "move <id> <owner>",
+	Short: "Change item owner",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return warehouseController{}.Move(args[0], args[1])
+	},
+}
+
+var warehouseListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all items",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return warehouseController{}.List()
+	},
+}
+
+func init() {
+	warehouseCmd.AddCommand(warehouseAddCmd)
+	warehouseCmd.AddCommand(warehouseRemoveCmd)
+	warehouseCmd.AddCommand(warehouseMoveCmd)
+	warehouseCmd.AddCommand(warehouseListCmd)
+}
+
+// WarehouseCmd is the entry point for root.RegisterRoutes
+var WarehouseCmd = warehouseCmd

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -1177,12 +1177,18 @@ var gasNames = map[string]uint64{
 	// ----------------------------------------------------------------------
 	// Wallet / Key-Management
 	// ----------------------------------------------------------------------
-	"NewRandomWallet":     10_000,
-	"WalletFromMnemonic":  5_000,
-	"NewHDWalletFromSeed": 6_000,
-	"PrivateKey":          400,
-	"NewAddress":          500,
-	"SignTx":              3_000,
+	"NewRandomWallet":      10_000,
+	"WalletFromMnemonic":   5_000,
+	"NewHDWalletFromSeed":  6_000,
+	"PrivateKey":           400,
+	"NewAddress":           500,
+	"SignTx":               3_000,
+	"Warehouse_New":        10_000,
+	"Warehouse_AddItem":    2_000,
+	"Warehouse_RemoveItem": 2_000,
+	"Warehouse_MoveItem":   2_000,
+	"Warehouse_ListItems":  1_000,
+	"Warehouse_GetItem":    1_000,
 }
 
 func init() {

--- a/synnergy-network/core/opcode_dispatcher.go
+++ b/synnergy-network/core/opcode_dispatcher.go
@@ -96,21 +96,22 @@ func wrap(name string) OpcodeFunc {
 //
 // Category map:
 //
-//	0x01 AI                     0x0F Liquidity
-//	0x02 AMM                    0x10 Loanpool
-//	0x03 Authority              0x11 Network
-//	0x04 Charity                0x12 Replication
-//	0x05 Coin                   0x13 Rollups
-//	0x06 Compliance             0x14 Security
-//	0x07 Consensus              0x15 Sharding
-//	0x08 Contracts              0x16 Sidechains
-//	0x09 CrossChain             0x17 StateChannel
-//	0x0A Data                   0x18 Storage
-//	0x0B FaultTolerance         0x19 Tokens
-//	0x0C Governance             0x1A Transactions
-//	0x0D GreenTech              0x1B Utilities
-//	0x0E Ledger                 0x1C VirtualMachine
-//	                            0x1D Wallet
+//		0x01 AI                     0x0F Liquidity
+//		0x02 AMM                    0x10 Loanpool
+//		0x03 Authority              0x11 Network
+//		0x04 Charity                0x12 Replication
+//		0x05 Coin                   0x13 Rollups
+//		0x06 Compliance             0x14 Security
+//		0x07 Consensus              0x15 Sharding
+//		0x08 Contracts              0x16 Sidechains
+//		0x09 CrossChain             0x17 StateChannel
+//		0x0A Data                   0x18 Storage
+//		0x0B FaultTolerance         0x19 Tokens
+//		0x0C Governance             0x1A Transactions
+//		0x0D GreenTech              0x1B Utilities
+//		0x0E Ledger                 0x1C VirtualMachine
+//		                            0x1D Wallet
+//	                                 0x1E Warehouse
 //
 // Each binary code is shown as a 24-bit big-endian string.
 var catalogue = []struct {
@@ -581,6 +582,13 @@ var catalogue = []struct {
 	{"PrivateKey", 0x1D0004},
 	{"NewAddress", 0x1D0005},
 	{"SignTx", 0x1D0006},
+	// Warehouse (0x1E)
+	{"Warehouse_New", 0x1E0001},
+	{"Warehouse_AddItem", 0x1E0002},
+	{"Warehouse_RemoveItem", 0x1E0003},
+	{"Warehouse_MoveItem", 0x1E0004},
+	{"Warehouse_ListItems", 0x1E0005},
+	{"Warehouse_GetItem", 0x1E0006},
 }
 
 // init wires the catalogue into the live dispatcher.

--- a/synnergy-network/core/warehouse.go
+++ b/synnergy-network/core/warehouse.go
@@ -1,0 +1,149 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+)
+
+// WarehouseItem represents an item stored on-chain for supply chain tracking.
+type WarehouseItem struct {
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	Owner    Address `json:"owner"`
+	Quantity uint64  `json:"qty"`
+}
+
+// Warehouse provides simple inventory management backed by the ledger state.
+type Warehouse struct {
+	led *Ledger
+	mu  sync.Mutex
+}
+
+// NewWarehouse returns a new warehouse instance using the provided ledger.
+func NewWarehouse(l *Ledger) *Warehouse { return &Warehouse{led: l} }
+
+func warehouseKey(id string) []byte { return []byte("warehouse:item:" + id) }
+
+// AddItem registers a new item owned by the caller.
+func (w *Warehouse) AddItem(ctx *Context, id, name string, qty uint64) error {
+	if w.led == nil {
+		return errors.New("ledger not initialised")
+	}
+	if qty == 0 {
+		return errors.New("quantity must be positive")
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if ok, _ := w.led.HasState(warehouseKey(id)); ok {
+		return errors.New("item already exists")
+	}
+	item := WarehouseItem{ID: id, Name: name, Owner: ctx.Caller, Quantity: qty}
+	b, _ := json.Marshal(item)
+	return w.led.SetState(warehouseKey(id), b)
+}
+
+// RemoveItem deletes an item. Only the owner may remove it.
+func (w *Warehouse) RemoveItem(ctx *Context, id string) error {
+	if w.led == nil {
+		return errors.New("ledger not initialised")
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	raw, err := w.led.GetState(warehouseKey(id))
+	if err != nil {
+		return err
+	}
+	var it WarehouseItem
+	if err := json.Unmarshal(raw, &it); err != nil {
+		return err
+	}
+	if it.Owner != ctx.Caller {
+		return errors.New("not item owner")
+	}
+	return w.led.DeleteState(warehouseKey(id))
+}
+
+// MoveItem transfers ownership to a new address.
+func (w *Warehouse) MoveItem(ctx *Context, id string, newOwner Address) error {
+	if w.led == nil {
+		return errors.New("ledger not initialised")
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	raw, err := w.led.GetState(warehouseKey(id))
+	if err != nil {
+		return err
+	}
+	var it WarehouseItem
+	if err := json.Unmarshal(raw, &it); err != nil {
+		return err
+	}
+	if it.Owner != ctx.Caller {
+		return errors.New("not item owner")
+	}
+	it.Owner = newOwner
+	b, _ := json.Marshal(it)
+	return w.led.SetState(warehouseKey(id), b)
+}
+
+// GetItem fetches a single item by ID.
+func (w *Warehouse) GetItem(id string) (WarehouseItem, error) {
+	if w.led == nil {
+		return WarehouseItem{}, errors.New("ledger not initialised")
+	}
+	raw, err := w.led.GetState(warehouseKey(id))
+	if err != nil {
+		return WarehouseItem{}, err
+	}
+	var it WarehouseItem
+	if err := json.Unmarshal(raw, &it); err != nil {
+		return WarehouseItem{}, err
+	}
+	return it, nil
+}
+
+// ListItems returns all warehouse items.
+func (w *Warehouse) ListItems() ([]WarehouseItem, error) {
+	if w.led == nil {
+		return nil, errors.New("ledger not initialised")
+	}
+	iter := w.led.PrefixIterator([]byte("warehouse:item:"))
+	var items []WarehouseItem
+	for iter.Next() {
+		var it WarehouseItem
+		if err := json.Unmarshal(iter.Value(), &it); err != nil {
+			return nil, err
+		}
+		items = append(items, it)
+	}
+	return items, iter.Error()
+}
+
+// -------------------------------------------------------------------
+// Opcode wrappers used by the VM dispatcher
+// -------------------------------------------------------------------
+
+var defaultWarehouse *Warehouse
+
+func ensureWarehouse() *Warehouse {
+	if defaultWarehouse == nil {
+		defaultWarehouse = NewWarehouse(CurrentLedger())
+	}
+	return defaultWarehouse
+}
+
+func Warehouse_New(_ *Context) error { defaultWarehouse = NewWarehouse(CurrentLedger()); return nil }
+func Warehouse_AddItem(ctx *Context, id, name string, qty uint64) error {
+	return ensureWarehouse().AddItem(ctx, id, name, qty)
+}
+func Warehouse_RemoveItem(ctx *Context, id string) error {
+	return ensureWarehouse().RemoveItem(ctx, id)
+}
+func Warehouse_MoveItem(ctx *Context, id string, newOwner Address) error {
+	return ensureWarehouse().MoveItem(ctx, id, newOwner)
+}
+func Warehouse_ListItems(_ *Context) ([]WarehouseItem, error) { return ensureWarehouse().ListItems() }
+func Warehouse_GetItem(_ *Context, id string) (WarehouseItem, error) {
+	return ensureWarehouse().GetItem(id)
+}


### PR DESCRIPTION
## Summary
- create `warehouse.go` in core for on-chain inventory
- register opcodes and gas costs
- wire Warehouse commands into CLI
- document new module in README, CLI guide and whitepaper

## Testing
- `go vet ./...` *(fails: loanpool.go etc.)*
- `go build ./core/... ./cmd/cli/...` *(fails: cmd/cli build errors)*
- `go test ./core/... ./cmd/cli/...` *(fails: cmd/cli build errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c43e705dc8320916f575cd1c1b537