### PR TITLE
Fix consensus description

### DIFF
--- a/synnergy-network/WHITEPAPER.md
+++ b/synnergy-network/WHITEPAPER.md
@@ -46,10 +46,10 @@ All services are optional and run as independent modules that plug into the core
 At a high level the network consists of:
 1. **Peer-to-Peer Network** – Validators communicate using libp2p with gossip-based transaction propagation.
 2.   Dedicated bootstrap nodes can be run using the CLI to help new peers discover the network.
-2. **Consensus Engine** – A hybrid approach combines Proof of History (PoH) and Proof of Stake (PoS) with pluggable modules for alternative algorithms.
+2. **Consensus Engine** – A hybrid approach combines Proof of History (PoH), Proof of Stake (PoS) and Proof of Work (PoW) with pluggable modules for alternative algorithms.
 2. **Connection Pools** – Reusable outbound connections reduce handshake overhead and speed up cross-module communication.
 2. **NAT Traversal** – Nodes automatically open ports via UPnP or NAT-PMP so peers can reach them behind firewalls.
-3. **Consensus Engine** – A hybrid approach combines Proof of History (PoH) and Proof of Stake (PoS) with pluggable modules for alternative algorithms.
+3. **Consensus Engine** – A hybrid approach combines Proof of History (PoH), Proof of Stake (PoS) and Proof of Work (PoW) with pluggable modules for alternative algorithms.
 4. **Ledger** – Blocks contain sub-blocks that optimize for data availability. Smart contracts and token transfers are recorded here.
 5. **Virtual Machine** – The dispatcher assigns a 24-bit opcode to every protocol function. Gas is charged before execution using a deterministic cost table.
 6. **Storage Nodes** – Off-chain storage is coordinated through specialized nodes for cheap archiving and retrieval.


### PR DESCRIPTION
## Summary
- clarify that Synnergy's hybrid consensus combines PoH, PoS and PoW in the whitepaper

## Testing
- `go vet ./core/...` *(fails: ErrMemberExists redeclared)*
- `go build ./core/...` *(fails: redeclared symbols)*
- `go test ./core` *(fails: redeclared symbols)*

------
https://chatgpt.com/codex/tasks/task_e_688cf993bf948320bde5a5d5ff2387d3