### PR TITLE
Initialize fee distributor with ledger

### DIFF
--- a/synnergy-network/core/consensus.go
+++ b/synnergy-network/core/consensus.go
@@ -366,8 +366,9 @@ func (sc *SynnergyConsensus) SealMainBlockPOW(headers []SubBlockHeader) error {
 		nonce++
 	}
 
-	blk := &Block{Header: bh, Body: BlockBody{SubHeaders: headers}}
-	if err := sc.ledger.AppendBlock(blk); err != nil {
+	txs := sc.ledger.ListPool(0)
+	blk := &Block{Header: bh, Body: BlockBody{SubHeaders: headers}, Transactions: txs}
+	if err := sc.ledger.AddBlock(blk); err != nil {
 		return err
 	}
 	sc.logger.Printf("block #%d sealed (nonce %d)", bh.Height, nonce)

--- a/synnergy-network/core/dao_access_control.go
+++ b/synnergy-network/core/dao_access_control.go
@@ -31,12 +31,12 @@ type DAOAccessControl struct {
 }
 
 var (
-	// ErrMemberExists is returned when attempting to add an address that already exists.
-	ErrMemberExists = errors.New("member already exists")
-	// ErrMemberNotFound is returned when a lookup fails.
-	ErrMemberNotFound = errors.New("member not found")
-	// ErrNotTokenHolder indicates the address does not hold the governance token.
-	ErrNotTokenHolder = errors.New("not DAO token holder")
+	// ErrACMemberExists is returned when attempting to add an address that already exists.
+	ErrACMemberExists = errors.New("member already exists")
+	// ErrACMemberNotFound is returned when a lookup fails.
+	ErrACMemberNotFound = errors.New("member not found")
+	// ErrACNotTokenHolder indicates the address does not hold the governance token.
+	ErrACNotTokenHolder = errors.New("not DAO token holder")
 )
 
 // NewDAOAccessControl returns a new access controller using the provided ledger.
@@ -54,10 +54,10 @@ func (d *DAOAccessControl) AddMember(addr Address, role DAORole) error {
 		return errors.New("ledger not set")
 	}
 	if !d.led.IsIDTokenHolder(addr) {
-		return ErrNotTokenHolder
+		return ErrACNotTokenHolder
 	}
 	if ok, _ := d.led.HasState(daoKey(addr)); ok {
-		return ErrMemberExists
+		return ErrACMemberExists
 	}
 	m := DAOMember{Addr: addr, Role: role, AddedAt: time.Now().UTC()}
 	raw, _ := json.Marshal(m)
@@ -72,18 +72,18 @@ func (d *DAOAccessControl) RemoveMember(addr Address) error {
 		return errors.New("ledger not set")
 	}
 	if ok, _ := d.led.HasState(daoKey(addr)); !ok {
-		return ErrMemberNotFound
+		return ErrACMemberNotFound
 	}
 	return d.led.DeleteState(daoKey(addr))
 }
 
-// RoleOf returns the role of an address or ErrMemberNotFound.
+// RoleOf returns the role of an address or ErrACMemberNotFound.
 func (d *DAOAccessControl) RoleOf(addr Address) (DAORole, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	raw, err := d.led.GetState(daoKey(addr))
 	if err != nil || len(raw) == 0 {
-		return 0, ErrMemberNotFound
+		return 0, ErrACMemberNotFound
 	}
 	var m DAOMember
 	if err := json.Unmarshal(raw, &m); err != nil {

--- a/synnergy-network/core/helpers.go
+++ b/synnergy-network/core/helpers.go
@@ -21,6 +21,9 @@ func InitLedger(path string) error {
 	var err error
 	ledgerOnce.Do(func() {
 		globalLedger, err = OpenLedger(path)
+		if err == nil {
+			InitTxDistributor(globalLedger)
+		}
 	})
 	return err
 }
@@ -91,6 +94,7 @@ func InitFirewall() {
 
 // CurrentFirewall returns the global firewall if initialised.
 func CurrentFirewall() *Firewall { return globalFirewall }
+
 // ------------------------------------------------------------------
 // DynamicGasCalculator parses bytecode and sums real gas costs
 // ------------------------------------------------------------------

--- a/synnergy-network/core/identity_verification.go
+++ b/synnergy-network/core/identity_verification.go
@@ -20,13 +20,13 @@ type IdentityService struct {
 }
 
 var (
-	idOnce sync.Once
-	idSvc  *IdentityService
+	idSvcOnce sync.Once
+	idSvc     *IdentityService
 )
 
 // InitIdentityService initializes the singleton using the provided ledger.
 func InitIdentityService(led stateBackend) {
-	idOnce.Do(func() {
+	idSvcOnce.Do(func() {
 		idSvc = &IdentityService{ledger: led, ns: []byte("identity:")}
 	})
 }

--- a/synnergy-network/core/idwallet_registration.go
+++ b/synnergy-network/core/idwallet_registration.go
@@ -23,14 +23,14 @@ type IDRegistration struct {
 }
 
 var (
-	idOnce sync.Once
-	idReg  *IDRegistry
+	idRegOnce sync.Once
+	idReg     *IDRegistry
 )
 
 // InitIDRegistry wires the ledger and logger. It must be called
 // before invoking RegisterIDWallet or IsIDWalletRegistered.
 func InitIDRegistry(lg *logrus.Logger, led *Ledger) {
-	idOnce.Do(func() {
+	idRegOnce.Do(func() {
 		idReg = &IDRegistry{led: led, logger: lg}
 	})
 }

--- a/synnergy-network/core/ledger.go
+++ b/synnergy-network/core/ledger.go
@@ -59,6 +59,8 @@ func NewLedger(cfg LedgerConfig) (*Ledger, error) {
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("WAL scan: %w", err)
 	}
+	// initialise global fee distributor for this ledger
+	InitTxDistributor(l)
 	return l, nil
 }
 
@@ -102,6 +104,7 @@ func OpenLedger(path string) (*Ledger, error) {
 		loaded.TokenBalances = l.TokenBalances
 		loaded.NodeLocations = l.NodeLocations
 	}
+	InitTxDistributor(loaded)
 	return loaded, nil
 }
 

--- a/synnergy-network/core/plasma.go
+++ b/synnergy-network/core/plasma.go
@@ -8,8 +8,8 @@ import (
 	"time"
 )
 
-// PlasmaDeposit represents a deposit into the Plasma chain.
-type PlasmaDeposit struct {
+// SimplePlasmaDeposit represents a deposit into the Plasma chain.
+type SimplePlasmaDeposit struct {
 	Nonce     uint64  `json:"nonce"`
 	From      Address `json:"from"`
 	Amount    uint64  `json:"amount"`
@@ -17,7 +17,7 @@ type PlasmaDeposit struct {
 }
 
 // PlasmaExit records a finalised withdrawal from the Plasma chain.
-type PlasmaExit struct {
+type SimplePlasmaExit struct {
 	Nonce     uint64  `json:"nonce"`
 	To        Address `json:"to"`
 	Proof     []byte  `json:"proof"`
@@ -58,14 +58,14 @@ func (pc *PlasmaCoordinator) Deposit(from Address, amount uint64) (uint64, error
 	defer pc.mu.Unlock()
 	pc.nonce++
 	n := pc.nonce
-	dep := PlasmaDeposit{Nonce: n, From: from, Amount: amount, Timestamp: time.Now().Unix()}
+	dep := SimplePlasmaDeposit{Nonce: n, From: from, Amount: amount, Timestamp: time.Now().Unix()}
 	raw, _ := json.Marshal(dep)
 	_ = pc.Ledger.SetState(pc.depKey(n), raw)
 	return n, nil
 }
 
 // Withdraw finalises an exit by deleting the deposit record.
-func (pc *PlasmaCoordinator) Withdraw(exit PlasmaExit) error {
+func (pc *PlasmaCoordinator) Withdraw(exit SimplePlasmaExit) error {
 	if pc == nil {
 		return errors.New("plasma not initialised")
 	}


### PR DESCRIPTION
## Summary
- set up global transaction fee distributor when initializing the ledger
- add fee distributor setup for new and opened ledgers
- apply fees per transaction before reward distribution
- rename several structs and vars to avoid package conflicts

## Testing
- `go vet ./core` *(fails: ResourceAllocator redeclared)*
- `go build ./core` *(fails: duplicate declarations and map keys)*

------
https://chatgpt.com/codex/tasks/task_e_688cfa3c68dc83208919583ef1ff864a