### PR TITLE
Add SYN12 token standard

### DIFF
--- a/synnergy-network/core/Tokens/syn12.go
+++ b/synnergy-network/core/Tokens/syn12.go
@@ -1,0 +1,31 @@
+package Tokens
+
+import "time"
+
+// SYN12Metadata holds CBD Treasury Bill metadata.
+type SYN12Metadata struct {
+	TokenID      string
+	TBillCode    string
+	Issuer       string
+	MaturityDate time.Time
+	DiscountRate float64
+}
+
+// SYN12 implements the TokenInterfaces contract for CBDTBs.
+type SYN12 struct {
+	meta SYN12Metadata
+}
+
+// Meta returns the SYN12 token metadata.
+func (s *SYN12) Meta() any { return s.meta }
+
+// NewSYN12 constructs a new SYN12 token description.
+func NewSYN12(id, code, issuer string, maturity time.Time, rate float64) *SYN12 {
+	return &SYN12{meta: SYN12Metadata{
+		TokenID:      id,
+		TBillCode:    code,
+		Issuer:       issuer,
+		MaturityDate: maturity,
+		DiscountRate: rate,
+	}}
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -595,6 +595,7 @@ var gasTable map[Opcode]uint64
    // Token Standards (constants – zero-cost markers)
    // ----------------------------------------------------------------------
    StdSYN10:   0,
+   StdSYN12:   0,
    StdSYN20:   0,
    StdSYN70:   0,
    StdSYN130:  0,
@@ -1546,6 +1547,7 @@ var gasNames = map[string]uint64{
 	// Token Standards (constants – zero-cost markers)
 	// ----------------------------------------------------------------------
 	"StdSYN10":   1,
+	"StdSYN12":   12,
 	"StdSYN20":   2,
 	"StdSYN70":   7,
 	"StdSYN130":  13,

--- a/synnergy-network/core/tokens.go
+++ b/synnergy-network/core/tokens.go
@@ -86,6 +86,7 @@ const (
 	StdSYN4700 byte = 0x86
 	StdSYN4900 byte = 0x87
 	StdSYN5000 byte = 0x88
+	StdSYN12   byte = 0x8A
 	StdSYN10   byte = 0x0A
 )
 


### PR DESCRIPTION
## Summary
- add `syn12.go` describing CBD treasury bill token meta
- define `StdSYN12` constant for the new token
- map `StdSYN12` into the gas table

## Testing
- `go vet ./core/Tokens ./core`
- `go build ./core/Tokens` *(fails for `./core` due to existing errors)*
- `go test ./tests/...` *(fails: could not compile `core` package)*

------
https://chatgpt.com/codex/tasks/task_e_688d1345bfd483208c2aee633614d080