### PR TITLE
Improve README inside synnergy-network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,107 @@
-k
+# Synnergy Network Repository
+
+Synnergy is an experimental blockchain written in Go. This repository contains the command line applications, core packages, GUI front‑ends and example smart contracts used to simulate a full network. The code is primarily intended for research and learning. For the vision and background see [`synnergy-network/WHITEPAPER.md`](synnergy-network/WHITEPAPER.md).
+
+## Repository Layout
+
+```
+./setup_synn.sh         # minimal bootstrap script for the CLI
+./Synnergy.env.sh       # full environment setup with optional tooling
+./Dockerfile            # container build for running Synnergy
+./scripts/              # helper scripts for devnets and testnets
+./synnergy-network/     # Go sources, GUIs and smart contracts
+```
+
+Inside `synnergy-network` you will find:
+
+| Path | Description |
+|------|-------------|
+| `cmd/` | CLI source code organised into many command groups. See [`synnergy-network/README.md`](synnergy-network/README.md) for a detailed list. |
+| `core/` | Core blockchain modules implementing consensus, ledger management, networking and the virtual machine. Each file is summarised in [`core/module_guide.md`](synnergy-network/core/module_guide.md). |
+| `GUI/` | Web interfaces such as the wallet and explorers. Subprojects include `wallet`, `explorer`, `ai-marketplace`, `storage-marketplace`, `nft_marketplace` and more. |
+| `walletserver/` | Go HTTP backend powering the wallet GUI. |
+| `tests/` | Unit tests for the core packages. |
+| `smart_contract_guide.md` | Guide to writing and deploying smart contracts on Synnergy. |
+| `internal/` | Shared utilities for the CLI and services. |
+
+## Building
+
+The CLI requires Go 1.20 or newer. After cloning the repository run:
+
+```bash
+./setup_synn.sh        # installs Go and builds synnergy
+```
+
+For a complete environment with additional tools run `./Synnergy.env.sh` instead which also loads variables from `.env` if present. Both scripts build the CLI binary in `synnergy-network`.
+
+To build manually:
+
+```bash
+cd synnergy-network
+go mod tidy
+GOFLAGS="-trimpath" go build -o synnergy ./cmd/synnergy
+```
+
+## Running a Local Node
+
+Initialise a ledger and start the services:
+
+```bash
+cd synnergy-network
+./synnergy ledger init --path ./ledger.db
+./synnergy network start &
+```
+
+You can then open another terminal to create wallets or deploy contracts. The [`cmd/synnergy`](synnergy-network/cmd/synnergy) directory contains additional guides.
+
+Two helper scripts simplify network startup:
+
+- `scripts/devnet_start.sh` spins up multiple local nodes for development.
+- `scripts/testnet_start.sh` launches a configurable testnet using a YAML file.
+
+The Dockerfile can build a containerised node which runs the networking, consensus, replication and VM services automatically via `docker-entrypoint.sh`.
+
+## CLI Overview
+
+The CLI exposes dozens of commands grouped by module: AI management, token operations, governance tools, cross‑chain utilities and many more. Each file under `cmd/cli` registers a command group. Refer to [`synnergy-network/README.md`](synnergy-network/README.md) and `cmd/cli/cli_guide.md` for the full catalogue and examples.
+
+## Core Modules
+
+The Go packages in `core/` implement the blockchain runtime. Important modules include consensus, ledger storage, networking layers, data replication, sharding and the virtual machine. Development helpers in `core/helpers.go` allow the CLI to run without a full node. A summary of every file lives in [`core/module_guide.md`](synnergy-network/core/module_guide.md).
+
+## GUI Projects
+
+Web front‑ends are provided under `GUI/`. Each directory contains a standalone project with its own README. Highlights include:
+
+- `wallet` – manage accounts and sign transactions using the wallet server.
+- `explorer` – query balances and transactions via a simple interface.
+- `ai-marketplace` – browse and purchase AI models.
+- `smart-contract-marketplace` – deploy and trade contracts.
+- `storage-marketplace` – pay for decentralized storage services.
+- `nft_marketplace` – create and trade NFTs.
+- `dao-explorer` – interact with on‑chain DAOs.
+- `token-creation-tool` – generate and manage new tokens.
+- `dex-screener` – view decentralized exchange listings.
+- `authority-node-index` and `cross-chain-management` – administrative dashboards.
+
+## Smart Contracts
+
+Example contracts demonstrating Synnergy's opcode catalogue are located throughout `smart_contract_guide.md` and under various GUI directories. They illustrate token faucets, storage markets, DAO governance and more. Contracts are compiled to WebAssembly and deployed via the CLI. See [`synnergy-network/smart_contract_guide.md`](synnergy-network/smart_contract_guide.md) for a step‑by‑step tutorial.
+
+## Tests
+
+Unit tests reside in `synnergy-network/tests`. Execute them with:
+
+```bash
+go test ./...
+```
+
+Some tests expect running services or mock implementations. `go vet` and `go build` can be run in the same way to lint and compile the modules.
+
+## Contributing
+
+Development follows the staged workflow described in [`AGENTS.md`](AGENTS.md). Work through the stages sequentially and modify no more than three files per pull request. Run `go fmt`, `go vet`, `go build` and `go test` on the packages you touch. Mark progress in `AGENTS.md` so others know which files are complete.
+
+## License
+
+Synnergy is provided for research and educational purposes. Third‑party dependencies in `third_party/` retain their original licenses. See those directories for details.

--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -22,9 +22,16 @@ The repository is organised as follows:
 | `cmd/` | Command line sources, configuration files and helper scripts. CLI modules live under `cmd/cli`. |
 | `core/binary_tree_operations.go` | Ledger-backed binary search tree implementation with CLI and VM opcodes. |
 | `tests/` | Go unit tests covering each module. Run with `go test ./...`. |
+| `GUI/` | Web front-ends including `wallet`, `explorer`, `ai-marketplace` and more. |
+| `walletserver/` | Go HTTP backend powering the wallet GUI. |
+| `internal/` | Shared utilities used across CLI and services. |
+| `cmd/scripts/` | Shell helpers for common development tasks. See [`cmd/scripts/script_guide.md`](cmd/scripts/script_guide.md). |
+| `scripts/` | Top-level scripts to start local devnets or testnets. |
+| `smart_contract_guide.md` | Documentation and examples for writing contracts. |
 | `third_party/` | Vendored dependencies such as a libp2p fork used during early development. |
 | `setup_synn.sh` | Convenience script that installs Go and builds the CLI. |
 | `Synnergy.env.sh` | Optional environment bootstrap script that downloads tools and loads variables from `.env`. |
+| `WHITEPAPER.md` | Project vision and design goals. |
 
 ## Building
 
@@ -228,6 +235,42 @@ Two top level scripts provide larger network setups:
 configuration. Both build the CLI automatically and clean up all processes on
 `Ctrl+C`.
 
+## Scripts
+
+Reusable shell helpers in `cmd/scripts` automate common tasks such as funding
+accounts (`faucet_fund.sh`), deploying contracts (`contracts_deploy.sh`),
+starting network services and more. The complete reference is available in
+[`cmd/scripts/script_guide.md`](cmd/scripts/script_guide.md).
+
+Top level scripts are provided for multi-node setups:
+
+- `scripts/devnet_start.sh` – start a local developer network.
+- `scripts/testnet_start.sh` – launch an ephemeral testnet from YAML.
+
+## GUI Projects
+
+Browser-based interfaces reside under `GUI/`:
+
+- `wallet` – manage accounts using the `walletserver` backend.
+- `explorer` – query balances and transactions.
+- `ai-marketplace` – browse and purchase AI models.
+- `smart-contract-marketplace` – deploy and trade contracts.
+- `storage-marketplace` – pay for decentralized storage.
+- `nft_marketplace` – create and trade NFTs.
+- `dao-explorer` – interact with DAO governance.
+- `token-creation-tool` – generate new tokens.
+- `dex-screener` – view decentralized exchange listings.
+- `authority-node-index` – monitor authority nodes.
+- `cross-chain-management` – manage bridges and transfers.
+
+The `walletserver/` directory contains the Go HTTP backend for the wallet GUI.
+
+## Smart Contracts
+
+Example contracts live throughout the repository and are documented in
+[`smart_contract_guide.md`](smart_contract_guide.md). They demonstrate opcode
+usage for token faucets, storage markets, DAO governance and more. Contracts are
+compiled to WebAssembly and deployed via the `synnergy` CLI.
 
 ## Docker
 


### PR DESCRIPTION
## Summary
- expand `synnergy-network/README.md` with repo structure details
- document helper scripts, GUI projects, and contract examples

## Testing
- no code changes; no tests run

------
https://chatgpt.com/codex/tasks/task_e_688d64a433c48320bfbda7a7098123cd