### PR TITLE
Add placeholder smart contract stubs

### DIFF
--- a/synnergy-network/cmd/smart_contracts/ai_model_registry.sol
+++ b/synnergy-network/cmd/smart_contracts/ai_model_registry.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for ai_model_registry contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/ai_optimizer.sol
+++ b/synnergy-network/cmd/smart_contracts/ai_optimizer.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for ai_optimizer contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/ai_predictor.sol
+++ b/synnergy-network/cmd/smart_contracts/ai_predictor.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for ai_predictor contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/amm_pool_manager.sol
+++ b/synnergy-network/cmd/smart_contracts/amm_pool_manager.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for amm_pool_manager contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/authority_applier.sol
+++ b/synnergy-network/cmd/smart_contracts/authority_applier.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for authority_applier contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/bank_node_bridge.sol
+++ b/synnergy-network/cmd/smart_contracts/bank_node_bridge.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for bank_node_bridge contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/carbon_credit.sol
+++ b/synnergy-network/cmd/smart_contracts/carbon_credit.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for carbon_credit contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/compliance_auditor.sol
+++ b/synnergy-network/cmd/smart_contracts/compliance_auditor.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for compliance_auditor contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/consensus_tester.sol
+++ b/synnergy-network/cmd/smart_contracts/consensus_tester.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for consensus_tester contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/cross_chain_bridge.sol
+++ b/synnergy-network/cmd/smart_contracts/cross_chain_bridge.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for cross_chain_bridge contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/cross_chain_protocol.sol
+++ b/synnergy-network/cmd/smart_contracts/cross_chain_protocol.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for cross_chain_protocol contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/data_feed_oracle.sol
+++ b/synnergy-network/cmd/smart_contracts/data_feed_oracle.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for data_feed_oracle contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/data_marketplace.sol
+++ b/synnergy-network/cmd/smart_contracts/data_marketplace.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for data_marketplace contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/fault_tolerance_checker.sol
+++ b/synnergy-network/cmd/smart_contracts/fault_tolerance_checker.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for fault_tolerance_checker contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/gov_quorum.sol
+++ b/synnergy-network/cmd/smart_contracts/gov_quorum.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for gov_quorum contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/green_certifier.sol
+++ b/synnergy-network/cmd/smart_contracts/green_certifier.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for green_certifier contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/health_monitor.sol
+++ b/synnergy-network/cmd/smart_contracts/health_monitor.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for health_monitor contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/identity_token.sol
+++ b/synnergy-network/cmd/smart_contracts/identity_token.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for identity_token contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/ledger_snapshotter.sol
+++ b/synnergy-network/cmd/smart_contracts/ledger_snapshotter.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for ledger_snapshotter contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/loan_application.sol
+++ b/synnergy-network/cmd/smart_contracts/loan_application.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for loan_application contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/message_queue.sol
+++ b/synnergy-network/cmd/smart_contracts/message_queue.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for message_queue contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/mobile_miner.sol
+++ b/synnergy-network/cmd/smart_contracts/mobile_miner.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for mobile_miner contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/network_bootstrap.sol
+++ b/synnergy-network/cmd/smart_contracts/network_bootstrap.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for network_bootstrap contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/node_firewall.sol
+++ b/synnergy-network/cmd/smart_contracts/node_firewall.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for node_firewall contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/oracle_updater.sol
+++ b/synnergy-network/cmd/smart_contracts/oracle_updater.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for oracle_updater contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/pension_plan.sol
+++ b/synnergy-network/cmd/smart_contracts/pension_plan.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for pension_plan contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/replication_service.sol
+++ b/synnergy-network/cmd/smart_contracts/replication_service.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for replication_service contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/ai_model_registry.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/ai_model_registry.rs
@@ -1,0 +1,1 @@
+// Placeholder for ai_model_registry contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/ai_optimizer.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/ai_optimizer.rs
@@ -1,0 +1,1 @@
+// Placeholder for ai_optimizer contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/ai_predictor.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/ai_predictor.rs
@@ -1,0 +1,1 @@
+// Placeholder for ai_predictor contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/amm_pool_manager.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/amm_pool_manager.rs
@@ -1,0 +1,1 @@
+// Placeholder for amm_pool_manager contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/authority_applier.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/authority_applier.rs
@@ -1,0 +1,1 @@
+// Placeholder for authority_applier contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/bank_node_bridge.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/bank_node_bridge.rs
@@ -1,0 +1,1 @@
+// Placeholder for bank_node_bridge contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/carbon_credit.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/carbon_credit.rs
@@ -1,0 +1,1 @@
+// Placeholder for carbon_credit contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/compliance_auditor.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/compliance_auditor.rs
@@ -1,0 +1,1 @@
+// Placeholder for compliance_auditor contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/consensus_tester.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/consensus_tester.rs
@@ -1,0 +1,1 @@
+// Placeholder for consensus_tester contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/cross_chain_bridge.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/cross_chain_bridge.rs
@@ -1,0 +1,1 @@
+// Placeholder for cross_chain_bridge contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/cross_chain_protocol.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/cross_chain_protocol.rs
@@ -1,0 +1,1 @@
+// Placeholder for cross_chain_protocol contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/data_feed_oracle.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/data_feed_oracle.rs
@@ -1,0 +1,1 @@
+// Placeholder for data_feed_oracle contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/data_marketplace.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/data_marketplace.rs
@@ -1,0 +1,1 @@
+// Placeholder for data_marketplace contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/fault_tolerance_checker.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/fault_tolerance_checker.rs
@@ -1,0 +1,1 @@
+// Placeholder for fault_tolerance_checker contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/gov_quorum.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/gov_quorum.rs
@@ -1,0 +1,1 @@
+// Placeholder for gov_quorum contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/green_certifier.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/green_certifier.rs
@@ -1,0 +1,1 @@
+// Placeholder for green_certifier contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/health_monitor.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/health_monitor.rs
@@ -1,0 +1,1 @@
+// Placeholder for health_monitor contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/identity_token.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/identity_token.rs
@@ -1,0 +1,1 @@
+// Placeholder for identity_token contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/ledger_snapshotter.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/ledger_snapshotter.rs
@@ -1,0 +1,1 @@
+// Placeholder for ledger_snapshotter contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/loan_application.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/loan_application.rs
@@ -1,0 +1,1 @@
+// Placeholder for loan_application contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/message_queue.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/message_queue.rs
@@ -1,0 +1,1 @@
+// Placeholder for message_queue contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/mobile_miner.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/mobile_miner.rs
@@ -1,0 +1,1 @@
+// Placeholder for mobile_miner contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/network_bootstrap.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/network_bootstrap.rs
@@ -1,0 +1,1 @@
+// Placeholder for network_bootstrap contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/node_firewall.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/node_firewall.rs
@@ -1,0 +1,1 @@
+// Placeholder for node_firewall contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/oracle_updater.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/oracle_updater.rs
@@ -1,0 +1,1 @@
+// Placeholder for oracle_updater contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/pension_plan.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/pension_plan.rs
@@ -1,0 +1,1 @@
+// Placeholder for pension_plan contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/replication_service.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/replication_service.rs
@@ -1,0 +1,1 @@
+// Placeholder for replication_service contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/security_auditor.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/security_auditor.rs
@@ -1,0 +1,1 @@
+// Placeholder for security_auditor contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/sharding_coordinator.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/sharding_coordinator.rs
@@ -1,0 +1,1 @@
+// Placeholder for sharding_coordinator contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/rust/time_locked_wallet.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/time_locked_wallet.rs
@@ -1,0 +1,1 @@
+// Placeholder for time_locked_wallet contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/security_auditor.sol
+++ b/synnergy-network/cmd/smart_contracts/security_auditor.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for security_auditor contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/sharding_coordinator.sol
+++ b/synnergy-network/cmd/smart_contracts/sharding_coordinator.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for sharding_coordinator contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.

--- a/synnergy-network/cmd/smart_contracts/time_locked_wallet.sol
+++ b/synnergy-network/cmd/smart_contracts/time_locked_wallet.sol
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+// Placeholder for time_locked_wallet contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.


### PR DESCRIPTION
## Summary
- add extensive placeholder Solidity contracts for future development
- add matching Rust stubs under `smart_contracts/rust`

## Testing
- `go vet ./...` *(fails: import cycle)*
- `go build ./...` *(fails: import cycle)*
- `go test ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d655791548320af2629be73bf9fb0