### PR TITLE
Expand staging roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,246 +1,817 @@
-# Synnergy Enterprise Development Playbook
+# Synnergy Core, GUI & CLI Production Plan
 
-Synnergy Network is an experimental blockchain written in Go. This repository hosts the command line utilities, core modules and example smart contracts used to simulate a full network.  This document serves as the primary guide for contributors.  It explains how to set up the environment, the workflow for staged development and the current status of every package.  It also records future work needed to transform the prototype into a production‑ready platform.
+This file enumerates all current files under `synnergy-network/core`, `synnergy-network/GUI` and `synnergy-network/cmd` and outlines a 25-stage enterprise-grade process to bring the project to production readiness. In total, there are 701 files (core: 281; GUI: 132; CLI: 288).
 
-## Repository Overview
+## File Inventory
 
-```
-./setup_synn.sh          # Minimal bootstrap script for building the CLI
-./Synnergy.env.sh        # Full environment setup and dependency installer
-synnergy-network/        # Go modules, commands and smart contracts
-  cmd/                   # CLI source code and convenience scripts
-  core/                  # Core blockchain modules
-  tests/                 # Unit tests for the core packages
-  WHITEPAPER.md          # Project vision and design goals
-  README.md              # Build and usage instructions
-```
+### Core (281 files)
+1. synnergy-network/core/Nodes/Nodes_Type_manual.md
+2. synnergy-network/core/Nodes/authority_nodes/Authority_node_typr_manual.md
+3. synnergy-network/core/Nodes/authority_nodes/index.go
+4. synnergy-network/core/Nodes/bank_nodes/index.go
+5. synnergy-network/core/Nodes/consensus_specific.go
+6. synnergy-network/core/Nodes/elected_authority_node.go
+7. synnergy-network/core/Nodes/experimental_node.go
+8. synnergy-network/core/Nodes/forensic_node.go
+9. synnergy-network/core/Nodes/geospatial.go
+10. synnergy-network/core/Nodes/historical_node.go
+11. synnergy-network/core/Nodes/holographic_node.go
+12. synnergy-network/core/Nodes/index.go
+13. synnergy-network/core/Nodes/light_node.go
+14. synnergy-network/core/Nodes/military_nodes/index.go
+15. synnergy-network/core/Nodes/molecular_node.go
+16. synnergy-network/core/Nodes/optimization_nodes/index.go
+17. synnergy-network/core/Nodes/optimization_nodes/optimization.go
+18. synnergy-network/core/Nodes/super_node.go
+19. synnergy-network/core/Nodes/syn845_node.go
+20. synnergy-network/core/Nodes/watchtower/index.go
+21. synnergy-network/core/Nodes/witness/archival_witness_node.go
+22. synnergy-network/core/SYN1967.go
+23. synnergy-network/core/SYN2369.go
+24. synnergy-network/core/Tokens/SYN1000.go
+25. synnergy-network/core/Tokens/SYN3000.go
+26. synnergy-network/core/Tokens/Tokens_manual.md
+27. synnergy-network/core/Tokens/index.go
+28. synnergy-network/core/Tokens/syn10.go
+29. synnergy-network/core/Tokens/syn1000_index.go
+30. synnergy-network/core/Tokens/syn1100.go
+31. synnergy-network/core/Tokens/syn12.go
+32. synnergy-network/core/Tokens/syn200.go
+33. synnergy-network/core/Tokens/syn2200.go
+34. synnergy-network/core/Tokens/syn2600.go
+35. synnergy-network/core/Tokens/syn2800.go
+36. synnergy-network/core/Tokens/syn2900.go
+37. synnergy-network/core/Tokens/syn3400.go
+38. synnergy-network/core/Tokens/syn70.go
+39. synnergy-network/core/Tokens/syn845.go
+40. synnergy-network/core/access_control.go
+41. synnergy-network/core/account_and_balance_operations.go
+42. synnergy-network/core/ai.go
+43. synnergy-network/core/ai_enhanced_contract.go
+44. synnergy-network/core/ai_enhanced_node.go
+45. synnergy-network/core/ai_inference_analysis.go
+46. synnergy-network/core/ai_model_management.go
+47. synnergy-network/core/ai_trainining.go
+48. synnergy-network/core/amm.go
+49. synnergy-network/core/anomaly_detection.go
+50. synnergy-network/core/api_node.go
+51. synnergy-network/core/audit_management.go
+52. synnergy-network/core/audit_node.go
+53. synnergy-network/core/authority_apply.go
+54. synnergy-network/core/authority_nodes.go
+55. synnergy-network/core/autonomous_agent_node.go
+56. synnergy-network/core/bank_institutional_node.go
+57. synnergy-network/core/binary_tree_operations.go
+58. synnergy-network/core/biometric_security_node.go
+59. synnergy-network/core/biometrics_auth.go
+60. synnergy-network/core/blockchain_compression.go
+61. synnergy-network/core/blockchain_synchronization.go
+62. synnergy-network/core/bootstrap_node.go
+63. synnergy-network/core/carbon_credit_system.go
+64. synnergy-network/core/central_banking_node.go
+65. synnergy-network/core/chain_fork_manager.go
+66. synnergy-network/core/charity_pool.go
+67. synnergy-network/core/coin.go
+68. synnergy-network/core/common_structs.go
+69. synnergy-network/core/compliance.go
+70. synnergy-network/core/compliance_management.go
+71. synnergy-network/core/connection_pool.go
+72. synnergy-network/core/consensus.go
+73. synnergy-network/core/consensus_adaptive_management.go
+74. synnergy-network/core/consensus_difficulty.go
+75. synnergy-network/core/consensus_specific_node.go
+76. synnergy-network/core/consensus_validator_management.go
+77. synnergy-network/core/content_node.go
+78. synnergy-network/core/content_node_impl.go
+79. synnergy-network/core/contract_management.go
+80. synnergy-network/core/contracts.go
+81. synnergy-network/core/contracts_opcodes.go
+82. synnergy-network/core/cross_chain.go
+83. synnergy-network/core/cross_chain_agnostic_protocols.go
+84. synnergy-network/core/cross_chain_bridge.go
+85. synnergy-network/core/cross_chain_connection.go
+86. synnergy-network/core/cross_chain_contracts.go
+87. synnergy-network/core/cross_chain_transactions.go
+88. synnergy-network/core/cross_consensus_scaling_networks.go
+89. synnergy-network/core/custodial_node.go
+90. synnergy-network/core/dao.go
+91. synnergy-network/core/dao_access_control.go
+92. synnergy-network/core/dao_quadratic_voting.go
+93. synnergy-network/core/dao_staking.go
+94. synnergy-network/core/dao_token.go
+95. synnergy-network/core/data.go
+96. synnergy-network/core/data_distribution.go
+97. synnergy-network/core/data_operations.go
+98. synnergy-network/core/data_resource_management.go
+99. synnergy-network/core/defi.go
+100. synnergy-network/core/devnet.go
+101. synnergy-network/core/disaster_recovery_node.go
+102. synnergy-network/core/distributed_network_coordination.go
+103. synnergy-network/core/distribution.go
+104. synnergy-network/core/dynamic_consensus_hopping.go
+105. synnergy-network/core/ecommerce.go
+106. synnergy-network/core/education_token.go
+107. synnergy-network/core/elected_authority_node.go
+108. synnergy-network/core/employment.go
+109. synnergy-network/core/energy_efficiency.go
+110. synnergy-network/core/energy_efficient_node.go
+111. synnergy-network/core/energy_tokens.go
+112. synnergy-network/core/environmental_monitoring_node.go
+113. synnergy-network/core/escrow.go
+114. synnergy-network/core/event_management.go
+115. synnergy-network/core/execution_management.go
+116. synnergy-network/core/experimental_node.go
+117. synnergy-network/core/external_sensor.go
+118. synnergy-network/core/failover_recovery.go
+119. synnergy-network/core/faucet.go
+120. synnergy-network/core/fault_tolerance.go
+121. synnergy-network/core/finalization_management.go
+122. synnergy-network/core/firewall.go
+123. synnergy-network/core/forum.go
+124. synnergy-network/core/full_node.go
+125. synnergy-network/core/gaming.go
+126. synnergy-network/core/gas_table.go
+127. synnergy-network/core/gateway_node.go
+128. synnergy-network/core/geolocation_network.go
+129. synnergy-network/core/geospatial_node.go
+130. synnergy-network/core/governance.go
+131. synnergy-network/core/governance_execution.go
+132. synnergy-network/core/governance_management.go
+133. synnergy-network/core/governance_reputation_voting.go
+134. synnergy-network/core/governance_timelock.go
+135. synnergy-network/core/governance_token_voting.go
+136. synnergy-network/core/government_authority_node.go
+137. synnergy-network/core/green_technology.go
+138. synnergy-network/core/healthcare.go
+139. synnergy-network/core/helpers.go
+140. synnergy-network/core/high_availability.go
+141. synnergy-network/core/historical_node.go
+142. synnergy-network/core/holographic.go
+143. synnergy-network/core/identity_verification.go
+144. synnergy-network/core/idwallet_registration.go
+145. synnergy-network/core/immutability_enforcement.go
+146. synnergy-network/core/indexing_node.go
+147. synnergy-network/core/initialization_replication.go
+148. synnergy-network/core/intangible_assets.go
+149. synnergy-network/core/integration_nodes/integration_node.go
+150. synnergy-network/core/integration_registry.go
+151. synnergy-network/core/ip_management.go
+152. synnergy-network/core/ipfs.go
+153. synnergy-network/core/kademlia.go
+154. synnergy-network/core/ledger.go
+155. synnergy-network/core/ledger_test.go
+156. synnergy-network/core/lightning_node.go
+157. synnergy-network/core/liquidity_pools.go
+158. synnergy-network/core/liquidity_views.go
+159. synnergy-network/core/loanpool.go
+160. synnergy-network/core/loanpool_apply.go
+161. synnergy-network/core/loanpool_approval_process.go
+162. synnergy-network/core/loanpool_grant_disbursement.go
+163. synnergy-network/core/loanpool_management.go
+164. synnergy-network/core/loanpool_proposal.go
+165. synnergy-network/core/marketplace.go
+166. synnergy-network/core/master_node.go
+167. synnergy-network/core/merkle_tree_operations.go
+168. synnergy-network/core/messages.go
+169. synnergy-network/core/mining_node.go
+170. synnergy-network/core/mobile_mining_node.go
+171. synnergy-network/core/mobile_node.go
+172. synnergy-network/core/module_guide.md
+173. synnergy-network/core/molecular_node.go
+174. synnergy-network/core/monomaniac_recovery.go
+175. synnergy-network/core/music_royalty_token.go
+176. synnergy-network/core/nat_traversal.go
+177. synnergy-network/core/network.go
+178. synnergy-network/core/node.go
+179. synnergy-network/core/offchain_wallet.go
+180. synnergy-network/core/opcode_and_gas_guide.md
+181. synnergy-network/core/opcode_dispatcher.go
+182. synnergy-network/core/oracle_management.go
+183. synnergy-network/core/orphan/orphan_node.go
+184. synnergy-network/core/partitioning_and_compression.go
+185. synnergy-network/core/peer_management.go
+186. synnergy-network/core/plasma.go
+187. synnergy-network/core/plasma_management.go
+188. synnergy-network/core/plasma_operations.go
+189. synnergy-network/core/polls_management.go
+190. synnergy-network/core/private_transactions.go
+191. synnergy-network/core/quantum_resistant_node.go
+192. synnergy-network/core/quorum_tracker.go
+193. synnergy-network/core/real_estate.go
+194. synnergy-network/core/regulatory_management.go
+195. synnergy-network/core/regulatory_node.go
+196. synnergy-network/core/rental_management.go
+197. synnergy-network/core/replication.go
+198. synnergy-network/core/resource_allocation_management.go
+199. synnergy-network/core/resource_management.go
+200. synnergy-network/core/resource_marketplace.go
+201. synnergy-network/core/rollup_management.go
+202. synnergy-network/core/rollups.go
+203. synnergy-network/core/rpc_webrtc.go
+204. synnergy-network/core/security.go
+205. synnergy-network/core/sharding.go
+206. synnergy-network/core/sidechain_ops.go
+207. synnergy-network/core/sidechains.go
+208. synnergy-network/core/smart_legal_contracts.go
+209. synnergy-network/core/stake_penalty.go
+210. synnergy-network/core/staking_node.go
+211. synnergy-network/core/state_channel.go
+212. synnergy-network/core/state_channel_management.go
+213. synnergy-network/core/storage.go
+214. synnergy-network/core/super_node.go
+215. synnergy-network/core/supply_chain.go
+216. synnergy-network/core/swarm.go
+217. synnergy-network/core/syn10.go
+218. synnergy-network/core/syn1155.go
+219. synnergy-network/core/syn11_token.go
+220. synnergy-network/core/syn1300.go
+221. synnergy-network/core/syn131_token.go
+222. synnergy-network/core/syn1401.go
+223. synnergy-network/core/syn1500.go
+224. synnergy-network/core/syn1700_token.go
+225. synnergy-network/core/syn1800.go
+226. synnergy-network/core/syn20.go
+227. synnergy-network/core/syn2100.go
+228. synnergy-network/core/syn223_token.go
+229. synnergy-network/core/syn2400.go
+230. synnergy-network/core/syn2500_token.go
+231. synnergy-network/core/syn2700.go
+232. synnergy-network/core/syn2900.go
+233. synnergy-network/core/syn3000_token.go
+234. synnergy-network/core/syn300_token.go
+235. synnergy-network/core/syn3100.go
+236. synnergy-network/core/syn3200.go
+237. synnergy-network/core/syn3300_token.go
+238. synnergy-network/core/syn3500_token.go
+239. synnergy-network/core/syn3600.go
+240. synnergy-network/core/syn3700_token.go
+241. synnergy-network/core/syn3800.go
+242. synnergy-network/core/syn3900.go
+243. synnergy-network/core/syn4200_token.go
+244. synnergy-network/core/syn4700.go
+245. synnergy-network/core/syn500.go
+246. synnergy-network/core/syn5000.go
+247. synnergy-network/core/syn5000_index.go
+248. synnergy-network/core/syn700.go
+249. synnergy-network/core/syn721_token.go
+250. synnergy-network/core/syn800_token.go
+251. synnergy-network/core/system_health_logging.go
+252. synnergy-network/core/tangible_assets.go
+253. synnergy-network/core/time_locked_node.go
+254. synnergy-network/core/token_management.go
+255. synnergy-network/core/token_management_syn1000.go
+256. synnergy-network/core/token_syn130.go
+257. synnergy-network/core/token_syn4900.go
+258. synnergy-network/core/token_syn600.go
+259. synnergy-network/core/tokens.go
+260. synnergy-network/core/tokens_syn1000.go
+261. synnergy-network/core/tokens_syn1000_helpers.go
+262. synnergy-network/core/tokens_syn1000_opcodes.go
+263. synnergy-network/core/tokens_syn1200.go
+264. synnergy-network/core/tokens_syn900.go
+265. synnergy-network/core/tokens_syn900_index.go
+266. synnergy-network/core/transaction_distribution.go
+267. synnergy-network/core/transactionreversal.go
+268. synnergy-network/core/transactions.go
+269. synnergy-network/core/user_feedback_system.go
+270. synnergy-network/core/utility_functions.go
+271. synnergy-network/core/validator_node.go
+272. synnergy-network/core/virtual_machine.go
+273. synnergy-network/core/vm_sandbox_management.go
+274. synnergy-network/core/wallet.go
+275. synnergy-network/core/wallet_management.go
+276. synnergy-network/core/warehouse.go
+277. synnergy-network/core/warfare_node.go
+278. synnergy-network/core/watchtower_node.go
+279. synnergy-network/core/workflow_integrations.go
+280. synnergy-network/core/zero_trust_data_channels.go
+281. synnergy-network/core/zkp_node.go
 
-Use `module_guide.md` under `synnergy-network/core` for a summary of each module.
+### GUI (132 files)
+1. synnergy-network/GUI/ai-marketplace/README.md
+2. synnergy-network/GUI/ai-marketplace/app.js
+3. synnergy-network/GUI/ai-marketplace/index.html
+4. synnergy-network/GUI/ai-marketplace/server.js
+5. synnergy-network/GUI/authority-node-index/README.md
+6. synnergy-network/GUI/authority-node-index/app.js
+7. synnergy-network/GUI/authority-node-index/index.html
+8. synnergy-network/GUI/cross-chain-management/README.md
+9. synnergy-network/GUI/cross-chain-management/app.js
+10. synnergy-network/GUI/cross-chain-management/assets/logo.svg
+11. synnergy-network/GUI/cross-chain-management/components/BridgeForm.js
+12. synnergy-network/GUI/cross-chain-management/components/BridgeList.js
+13. synnergy-network/GUI/cross-chain-management/components/BurnReleaseForm.js
+14. synnergy-network/GUI/cross-chain-management/components/LockMintForm.js
+15. synnergy-network/GUI/cross-chain-management/components/RelayerForm.js
+16. synnergy-network/GUI/cross-chain-management/index.html
+17. synnergy-network/GUI/cross-chain-management/services/api.js
+18. synnergy-network/GUI/cross-chain-management/styles.css
+19. synnergy-network/GUI/dao-explorer/README.md
+20. synnergy-network/GUI/dao-explorer/app.js
+21. synnergy-network/GUI/dao-explorer/assets/logo.svg
+22. synnergy-network/GUI/dao-explorer/assets/logo.txt
+23. synnergy-network/GUI/dao-explorer/backend/.env
+24. synnergy-network/GUI/dao-explorer/backend/config/config.js
+25. synnergy-network/GUI/dao-explorer/backend/controllers/proposalController.js
+26. synnergy-network/GUI/dao-explorer/backend/middleware/errorHandler.js
+27. synnergy-network/GUI/dao-explorer/backend/package.json
+28. synnergy-network/GUI/dao-explorer/backend/routes/proposalRoutes.js
+29. synnergy-network/GUI/dao-explorer/backend/server.js
+30. synnergy-network/GUI/dao-explorer/backend/services/contractService.js
+31. synnergy-network/GUI/dao-explorer/backend/services/proposalService.js
+32. synnergy-network/GUI/dao-explorer/components/NewProposalForm.js
+33. synnergy-network/GUI/dao-explorer/components/ProposalDetail.js
+34. synnergy-network/GUI/dao-explorer/components/ProposalList.js
+35. synnergy-network/GUI/dao-explorer/components/VoteForm.js
+36. synnergy-network/GUI/dao-explorer/styles/main.css
+37. synnergy-network/GUI/dao-explorer/views/index.html
+38. synnergy-network/GUI/dex-screener/README.md
+39. synnergy-network/GUI/dex-screener/app.js
+40. synnergy-network/GUI/dex-screener/assets/README.md
+41. synnergy-network/GUI/dex-screener/components/poolTable.js
+42. synnergy-network/GUI/dex-screener/index.html
+43. synnergy-network/GUI/dex-screener/styles/main.css
+44. synnergy-network/GUI/explorer/README.md
+45. synnergy-network/GUI/explorer/app.js
+46. synnergy-network/GUI/explorer/assets/logo.svg
+47. synnergy-network/GUI/explorer/components/balance.js
+48. synnergy-network/GUI/explorer/components/blocks.js
+49. synnergy-network/GUI/explorer/components/tx.js
+50. synnergy-network/GUI/explorer/index.html
+51. synnergy-network/GUI/explorer/styles.css
+52. synnergy-network/GUI/nft_marketplace/README.md
+53. synnergy-network/GUI/nft_marketplace/app.js
+54. synnergy-network/GUI/nft_marketplace/assets/logo.png
+55. synnergy-network/GUI/nft_marketplace/backend/.env
+56. synnergy-network/GUI/nft_marketplace/backend/config/index.js
+57. synnergy-network/GUI/nft_marketplace/backend/controllers/nftController.js
+58. synnergy-network/GUI/nft_marketplace/backend/middleware/logger.js
+59. synnergy-network/GUI/nft_marketplace/backend/package.json
+60. synnergy-network/GUI/nft_marketplace/backend/routes/nftRoutes.js
+61. synnergy-network/GUI/nft_marketplace/backend/server.js
+62. synnergy-network/GUI/nft_marketplace/backend/services/marketplaceService.js
+63. synnergy-network/GUI/nft_marketplace/index.html
+64. synnergy-network/GUI/nft_marketplace/style.css
+65. synnergy-network/GUI/smart-contract-marketplace/.env
+66. synnergy-network/GUI/smart-contract-marketplace/README.md
+67. synnergy-network/GUI/smart-contract-marketplace/app.js
+68. synnergy-network/GUI/smart-contract-marketplace/assets/logo.png
+69. synnergy-network/GUI/smart-contract-marketplace/components/footer.html
+70. synnergy-network/GUI/smart-contract-marketplace/components/navbar.html
+71. synnergy-network/GUI/smart-contract-marketplace/config/default.js
+72. synnergy-network/GUI/smart-contract-marketplace/index.html
+73. synnergy-network/GUI/smart-contract-marketplace/package.json
+74. synnergy-network/GUI/smart-contract-marketplace/script.js
+75. synnergy-network/GUI/smart-contract-marketplace/server/controllers/contractController.js
+76. synnergy-network/GUI/smart-contract-marketplace/server/data/contracts.json
+77. synnergy-network/GUI/smart-contract-marketplace/server/middleware/logger.js
+78. synnergy-network/GUI/smart-contract-marketplace/server/routes/contracts.js
+79. synnergy-network/GUI/smart-contract-marketplace/server/server.js
+80. synnergy-network/GUI/smart-contract-marketplace/server/services/contractService.js
+81. synnergy-network/GUI/smart-contract-marketplace/styles.css
+82. synnergy-network/GUI/smart-contract-marketplace/views/deploy.html
+83. synnergy-network/GUI/smart-contract-marketplace/views/detail.html
+84. synnergy-network/GUI/smart-contract-marketplace/views/listings.html
+85. synnergy-network/GUI/storage-marketplace/README.md
+86. synnergy-network/GUI/storage-marketplace/app.js
+87. synnergy-network/GUI/storage-marketplace/assets/README.txt
+88. synnergy-network/GUI/storage-marketplace/assets/logo.txt
+89. synnergy-network/GUI/storage-marketplace/backend/.env
+90. synnergy-network/GUI/storage-marketplace/backend/config/index.js
+91. synnergy-network/GUI/storage-marketplace/backend/controllers/dealsController.js
+92. synnergy-network/GUI/storage-marketplace/backend/controllers/listingsController.js
+93. synnergy-network/GUI/storage-marketplace/backend/controllers/storageController.js
+94. synnergy-network/GUI/storage-marketplace/backend/middleware/errorHandler.js
+95. synnergy-network/GUI/storage-marketplace/backend/package.json
+96. synnergy-network/GUI/storage-marketplace/backend/routes/deals.js
+97. synnergy-network/GUI/storage-marketplace/backend/routes/listings.js
+98. synnergy-network/GUI/storage-marketplace/backend/routes/storage.js
+99. synnergy-network/GUI/storage-marketplace/backend/server.js
+100. synnergy-network/GUI/storage-marketplace/backend/services/data.json
+101. synnergy-network/GUI/storage-marketplace/backend/services/storageService.js
+102. synnergy-network/GUI/storage-marketplace/components/deals.js
+103. synnergy-network/GUI/storage-marketplace/components/listings.js
+104. synnergy-network/GUI/storage-marketplace/components/storage.js
+105. synnergy-network/GUI/storage-marketplace/index.html
+106. synnergy-network/GUI/storage-marketplace/styles/style.css
+107. synnergy-network/GUI/token-creation-tool/README.md
+108. synnergy-network/GUI/token-creation-tool/app.js
+109. synnergy-network/GUI/token-creation-tool/assets/banner.svg
+110. synnergy-network/GUI/token-creation-tool/assets/logo.svg
+111. synnergy-network/GUI/token-creation-tool/components/TokenForm.js
+112. synnergy-network/GUI/token-creation-tool/components/TokenList.js
+113. synnergy-network/GUI/token-creation-tool/index.html
+114. synnergy-network/GUI/token-creation-tool/server/.env
+115. synnergy-network/GUI/token-creation-tool/server/config/default.json
+116. synnergy-network/GUI/token-creation-tool/server/controllers/tokenController.js
+117. synnergy-network/GUI/token-creation-tool/server/middleware/errorHandler.js
+118. synnergy-network/GUI/token-creation-tool/server/middleware/logger.js
+119. synnergy-network/GUI/token-creation-tool/server/package.json
+120. synnergy-network/GUI/token-creation-tool/server/routes/tokenRoutes.js
+121. synnergy-network/GUI/token-creation-tool/server/server.js
+122. synnergy-network/GUI/token-creation-tool/server/services/tokenService.js
+123. synnergy-network/GUI/token-creation-tool/server/tokens.json
+124. synnergy-network/GUI/token-creation-tool/styles/style.css
+125. synnergy-network/GUI/token-creation-tool/views/create.html
+126. synnergy-network/GUI/wallet/README.md
+127. synnergy-network/GUI/wallet/app.js
+128. synnergy-network/GUI/wallet/assets/.gitkeep
+129. synnergy-network/GUI/wallet/components/wallet.js
+130. synnergy-network/GUI/wallet/index.html
+131. synnergy-network/GUI/wallet/styles/style.css
+132. synnergy-network/GUI/wallet/views/index.html
 
-## Environment Setup
+### CLI (288 files)
+1. synnergy-network/cmd/.DS_Store
+2. synnergy-network/cmd/cli/access_control.go
+3. synnergy-network/cmd/cli/account_and_balance_operations.go
+4. synnergy-network/cmd/cli/agriculture.go
+5. synnergy-network/cmd/cli/ai.go
+6. synnergy-network/cmd/cli/ai_contract.go
+7. synnergy-network/cmd/cli/ai_enhanced_node.go
+8. synnergy-network/cmd/cli/ai_inference.go
+9. synnergy-network/cmd/cli/ai_model_management.go
+10. synnergy-network/cmd/cli/ai_trainining.go
+11. synnergy-network/cmd/cli/amm.go
+12. synnergy-network/cmd/cli/anomaly_detection.go
+13. synnergy-network/cmd/cli/api_node.go
+14. synnergy-network/cmd/cli/archival_witness_node.go
+15. synnergy-network/cmd/cli/audit_management.go
+16. synnergy-network/cmd/cli/audit_node.go
+17. synnergy-network/cmd/cli/authority_apply.go
+18. synnergy-network/cmd/cli/authority_node.go
+19. synnergy-network/cmd/cli/autonomous_agent_node.go
+20. synnergy-network/cmd/cli/bank_institutional_node.go
+21. synnergy-network/cmd/cli/binary_tree_operations.go
+22. synnergy-network/cmd/cli/biometric_security_node.go
+23. synnergy-network/cmd/cli/biometrics.go
+24. synnergy-network/cmd/cli/blockchain_compression.go
+25. synnergy-network/cmd/cli/blockchain_synchronization.go
+26. synnergy-network/cmd/cli/bootstrap_node.go
+27. synnergy-network/cmd/cli/carbon_credit_system.go
+28. synnergy-network/cmd/cli/central_banking_node.go
+29. synnergy-network/cmd/cli/chain_fork_manager.go
+30. synnergy-network/cmd/cli/charity_mgmt.go
+31. synnergy-network/cmd/cli/charity_pool.go
+32. synnergy-network/cmd/cli/charity_token.go
+33. synnergy-network/cmd/cli/cli_guide.md
+34. synnergy-network/cmd/cli/coin.go
+35. synnergy-network/cmd/cli/compliance.go
+36. synnergy-network/cmd/cli/compliance_management.go
+37. synnergy-network/cmd/cli/connection_pool.go
+38. synnergy-network/cmd/cli/consensus.go
+39. synnergy-network/cmd/cli/consensus_adaptive_management.go
+40. synnergy-network/cmd/cli/consensus_specific_node.go
+41. synnergy-network/cmd/cli/content_node.go
+42. synnergy-network/cmd/cli/contract_management.go
+43. synnergy-network/cmd/cli/contracts.go
+44. synnergy-network/cmd/cli/cross_chain.go
+45. synnergy-network/cmd/cli/cross_chain_agnostic_protocols.go
+46. synnergy-network/cmd/cli/cross_chain_bridge.go
+47. synnergy-network/cmd/cli/cross_chain_connection.go
+48. synnergy-network/cmd/cli/cross_chain_contracts.go
+49. synnergy-network/cmd/cli/cross_chain_transactions.go
+50. synnergy-network/cmd/cli/cross_consensus_scaling_networks.go
+51. synnergy-network/cmd/cli/custodial_node.go
+52. synnergy-network/cmd/cli/dao.go
+53. synnergy-network/cmd/cli/dao_access_control.go
+54. synnergy-network/cmd/cli/dao_staking.go
+55. synnergy-network/cmd/cli/dao_token.go
+56. synnergy-network/cmd/cli/data.go
+57. synnergy-network/cmd/cli/data_distribution.go
+58. synnergy-network/cmd/cli/data_operations.go
+59. synnergy-network/cmd/cli/data_resource_management.go
+60. synnergy-network/cmd/cli/defi.go
+61. synnergy-network/cmd/cli/devnet.go
+62. synnergy-network/cmd/cli/disaster_recovery_node.go
+63. synnergy-network/cmd/cli/distributed_network_coordination.go
+64. synnergy-network/cmd/cli/distribution.go
+65. synnergy-network/cmd/cli/dynamic_consensus_hopping.go
+66. synnergy-network/cmd/cli/ecommerce.go
+67. synnergy-network/cmd/cli/elected_authority_node.go
+68. synnergy-network/cmd/cli/employment.go
+69. synnergy-network/cmd/cli/employment_token.go
+70. synnergy-network/cmd/cli/energy_efficiency.go
+71. synnergy-network/cmd/cli/energy_efficient_node.go
+72. synnergy-network/cmd/cli/energy_tokens.go
+73. synnergy-network/cmd/cli/environmental_monitoring_node.go
+74. synnergy-network/cmd/cli/escrow.go
+75. synnergy-network/cmd/cli/event_management.go
+76. synnergy-network/cmd/cli/event_ticket.go
+77. synnergy-network/cmd/cli/execution_management.go
+78. synnergy-network/cmd/cli/experimental_node.go
+79. synnergy-network/cmd/cli/failover_recovery.go
+80. synnergy-network/cmd/cli/faucet.go
+81. synnergy-network/cmd/cli/fault_tolerance.go
+82. synnergy-network/cmd/cli/finalization_management.go
+83. synnergy-network/cmd/cli/firewall.go
+84. synnergy-network/cmd/cli/forensic_node.go
+85. synnergy-network/cmd/cli/forex_token.go
+86. synnergy-network/cmd/cli/full_node.go
+87. synnergy-network/cmd/cli/gaming.go
+88. synnergy-network/cmd/cli/gateway_node.go
+89. synnergy-network/cmd/cli/geolocation_network.go
+90. synnergy-network/cmd/cli/geospatial_node.go
+91. synnergy-network/cmd/cli/governance.go
+92. synnergy-network/cmd/cli/governance_management.go
+93. synnergy-network/cmd/cli/governance_reputation_voting.go
+94. synnergy-network/cmd/cli/grant_disbursement.go
+95. synnergy-network/cmd/cli/grant_tokens.go
+96. synnergy-network/cmd/cli/green_technology.go
+97. synnergy-network/cmd/cli/healthcare.go
+98. synnergy-network/cmd/cli/high_availability.go
+99. synnergy-network/cmd/cli/historical_node.go
+100. synnergy-network/cmd/cli/holographic_node.go
+101. synnergy-network/cmd/cli/identity_token.go
+102. synnergy-network/cmd/cli/identity_verification.go
+103. synnergy-network/cmd/cli/idwallet.go
+104. synnergy-network/cmd/cli/immutability_enforcement.go
+105. synnergy-network/cmd/cli/index.go
+106. synnergy-network/cmd/cli/indexing_node.go
+107. synnergy-network/cmd/cli/initrep.go
+108. synnergy-network/cmd/cli/insurance_token.go
+109. synnergy-network/cmd/cli/integration_node.go
+110. synnergy-network/cmd/cli/ipfs.go
+111. synnergy-network/cmd/cli/iptoken.go
+112. synnergy-network/cmd/cli/kademlia.go
+113. synnergy-network/cmd/cli/ledger.go
+114. synnergy-network/cmd/cli/legal_token.go
+115. synnergy-network/cmd/cli/life_insurance.go
+116. synnergy-network/cmd/cli/lightning_node.go
+117. synnergy-network/cmd/cli/liquidity_pools.go
+118. synnergy-network/cmd/cli/loanpool.go
+119. synnergy-network/cmd/cli/loanpool_apply.go
+120. synnergy-network/cmd/cli/loanpool_management.go
+121. synnergy-network/cmd/cli/marketplace.go
+122. synnergy-network/cmd/cli/master_node.go
+123. synnergy-network/cmd/cli/messages.go
+124. synnergy-network/cmd/cli/military_node.go
+125. synnergy-network/cmd/cli/mining_node.go
+126. synnergy-network/cmd/cli/mobile_mining_node.go
+127. synnergy-network/cmd/cli/mobile_node.go
+128. synnergy-network/cmd/cli/molecular_node.go
+129. synnergy-network/cmd/cli/monomaniac_recovery.go
+130. synnergy-network/cmd/cli/nat.go
+131. synnergy-network/cmd/cli/network.go
+132. synnergy-network/cmd/cli/offchain_wallet.go
+133. synnergy-network/cmd/cli/optimization.go
+134. synnergy-network/cmd/cli/oracle_management.go
+135. synnergy-network/cmd/cli/orphan_node.go
+136. synnergy-network/cmd/cli/partitioning_and_compression.go
+137. synnergy-network/cmd/cli/peer_management.go
+138. synnergy-network/cmd/cli/pension_tokens.go
+139. synnergy-network/cmd/cli/plasma.go
+140. synnergy-network/cmd/cli/plasma_management.go
+141. synnergy-network/cmd/cli/plasma_operations.go
+142. synnergy-network/cmd/cli/polls_management.go
+143. synnergy-network/cmd/cli/private_transactions.go
+144. synnergy-network/cmd/cli/quadratic_voting.go
+145. synnergy-network/cmd/cli/quantum_resistant_node.go
+146. synnergy-network/cmd/cli/quorum_tracker.go
+147. synnergy-network/cmd/cli/real_estate.go
+148. synnergy-network/cmd/cli/regulatory_management.go
+149. synnergy-network/cmd/cli/regulatory_node.go
+150. synnergy-network/cmd/cli/rental_token.go
+151. synnergy-network/cmd/cli/replication.go
+152. synnergy-network/cmd/cli/reputation_tokens.go
+153. synnergy-network/cmd/cli/resource_allocation.go
+154. synnergy-network/cmd/cli/resource_management.go
+155. synnergy-network/cmd/cli/resource_marketplace.go
+156. synnergy-network/cmd/cli/rollups.go
+157. synnergy-network/cmd/cli/security.go
+158. synnergy-network/cmd/cli/sensor.go
+159. synnergy-network/cmd/cli/sharding.go
+160. synnergy-network/cmd/cli/sidechain.go
+161. synnergy-network/cmd/cli/smart_legal_contracts.go
+162. synnergy-network/cmd/cli/stake_penalty.go
+163. synnergy-network/cmd/cli/staking_node.go
+164. synnergy-network/cmd/cli/state_channel.go
+165. synnergy-network/cmd/cli/state_channel_management.go
+166. synnergy-network/cmd/cli/storage.go
+167. synnergy-network/cmd/cli/super_node.go
+168. synnergy-network/cmd/cli/supply_chain.go
+169. synnergy-network/cmd/cli/swarm.go
+170. synnergy-network/cmd/cli/syn10.go
+171. synnergy-network/cmd/cli/syn1000.go
+172. synnergy-network/cmd/cli/syn11.go
+173. synnergy-network/cmd/cli/syn1100.go
+174. synnergy-network/cmd/cli/syn1155.go
+175. synnergy-network/cmd/cli/syn1200.go
+176. synnergy-network/cmd/cli/syn130.go
+177. synnergy-network/cmd/cli/syn1300_token.go
+178. synnergy-network/cmd/cli/syn131.go
+179. synnergy-network/cmd/cli/syn1401.go
+180. synnergy-network/cmd/cli/syn1600.go
+181. synnergy-network/cmd/cli/syn1800.go
+182. synnergy-network/cmd/cli/syn1900.go
+183. synnergy-network/cmd/cli/syn1967.go
+184. synnergy-network/cmd/cli/syn200.go
+185. synnergy-network/cmd/cli/syn2100.go
+186. synnergy-network/cmd/cli/syn2200.go
+187. synnergy-network/cmd/cli/syn223.go
+188. synnergy-network/cmd/cli/syn2400.go
+189. synnergy-network/cmd/cli/syn300.go
+190. synnergy-network/cmd/cli/syn3200.go
+191. synnergy-network/cmd/cli/syn3300.go
+192. synnergy-network/cmd/cli/syn3500.go
+193. synnergy-network/cmd/cli/syn500.go
+194. synnergy-network/cmd/cli/syn5000.go
+195. synnergy-network/cmd/cli/syn600.go
+196. synnergy-network/cmd/cli/syn70.go
+197. synnergy-network/cmd/cli/syn721.go
+198. synnergy-network/cmd/cli/syn800.go
+199. synnergy-network/cmd/cli/syn845.go
+200. synnergy-network/cmd/cli/system_health.go
+201. synnergy-network/cmd/cli/tangible_assets.go
+202. synnergy-network/cmd/cli/time_locked_node.go
+203. synnergy-network/cmd/cli/timelock.go
+204. synnergy-network/cmd/cli/token_management.go
+205. synnergy-network/cmd/cli/token_vote.go
+206. synnergy-network/cmd/cli/tokens.go
+207. synnergy-network/cmd/cli/transaction_distribution.go
+208. synnergy-network/cmd/cli/transactionreversal.go
+209. synnergy-network/cmd/cli/transactions.go
+210. synnergy-network/cmd/cli/user_feedback_system.go
+211. synnergy-network/cmd/cli/utility_functions.go
+212. synnergy-network/cmd/cli/validator_node.go
+213. synnergy-network/cmd/cli/virtual_machine.go
+214. synnergy-network/cmd/cli/vm_sandbox_management.go
+215. synnergy-network/cmd/cli/wallet.go
+216. synnergy-network/cmd/cli/wallet_management.go
+217. synnergy-network/cmd/cli/warehouse.go
+218. synnergy-network/cmd/cli/watchtower_node.go
+219. synnergy-network/cmd/cli/workflow_integrations.go
+220. synnergy-network/cmd/cli/zero_trust_data_channels.go
+221. synnergy-network/cmd/cli/zkp_node.go
+222. synnergy-network/cmd/config/bootstrap.yaml
+223. synnergy-network/cmd/config/config.go
+224. synnergy-network/cmd/config/config_guide.md
+225. synnergy-network/cmd/config/crosschain.yaml
+226. synnergy-network/cmd/config/default.yaml
+227. synnergy-network/cmd/config/explorer.yaml
+228. synnergy-network/cmd/config/genesis.json
+229. synnergy-network/cmd/config/prod.yaml
+230. synnergy-network/cmd/dexserver/README.md
+231. synnergy-network/cmd/dexserver/main.go
+232. synnergy-network/cmd/explorer/main.go
+233. synnergy-network/cmd/explorer/middleware.go
+234. synnergy-network/cmd/explorer/server.go
+235. synnergy-network/cmd/explorer/service.go
+236. synnergy-network/cmd/readme.md
+237. synnergy-network/cmd/scripts/authority_apply.sh
+238. synnergy-network/cmd/scripts/build_cli.sh
+239. synnergy-network/cmd/scripts/coin_mint.sh
+240. synnergy-network/cmd/scripts/consensus_start.sh
+241. synnergy-network/cmd/scripts/contracts_deploy.sh
+242. synnergy-network/cmd/scripts/cross_chain_register.sh
+243. synnergy-network/cmd/scripts/dao_vote.sh
+244. synnergy-network/cmd/scripts/faucet_fund.sh
+245. synnergy-network/cmd/scripts/fault_check.sh
+246. synnergy-network/cmd/scripts/governance_propose.sh
+247. synnergy-network/cmd/scripts/loanpool_apply.sh
+248. synnergy-network/cmd/scripts/marketplace_list.sh
+249. synnergy-network/cmd/scripts/network_peers.sh
+250. synnergy-network/cmd/scripts/network_start.sh
+251. synnergy-network/cmd/scripts/replication_status.sh
+252. synnergy-network/cmd/scripts/rollup_submit_batch.sh
+253. synnergy-network/cmd/scripts/script_guide.md
+254. synnergy-network/cmd/scripts/security_merkle.sh
+255. synnergy-network/cmd/scripts/sharding_leader.sh
+256. synnergy-network/cmd/scripts/sidechain_sync.sh
+257. synnergy-network/cmd/scripts/start_synnergy_network.sh
+258. synnergy-network/cmd/scripts/state_channel_open.sh
+259. synnergy-network/cmd/scripts/storage_marketplace_pin.sh
+260. synnergy-network/cmd/scripts/storage_pin.sh
+261. synnergy-network/cmd/scripts/token_transfer.sh
+262. synnergy-network/cmd/scripts/transactions_submit.sh
+263. synnergy-network/cmd/scripts/vm_start.sh
+264. synnergy-network/cmd/scripts/wallet_create.sh
+265. synnergy-network/cmd/smart_contracts/ai_marketplace.sol
+266. synnergy-network/cmd/smart_contracts/cross_chain_eth.sol
+267. synnergy-network/cmd/smart_contracts/cross_chain_manager.sol
+268. synnergy-network/cmd/smart_contracts/dao_explorer.json
+269. synnergy-network/cmd/smart_contracts/dao_explorer.sol
+270. synnergy-network/cmd/smart_contracts/dex_pool_reader.sol
+271. synnergy-network/cmd/smart_contracts/explorer_utils.sol
+272. synnergy-network/cmd/smart_contracts/faucet.sol
+273. synnergy-network/cmd/smart_contracts/ledger_inspector.sol
+274. synnergy-network/cmd/smart_contracts/liquidity_adder.sol
+275. synnergy-network/cmd/smart_contracts/marketplace.sol
+276. synnergy-network/cmd/smart_contracts/multi_sig_wallet.sol
+277. synnergy-network/cmd/smart_contracts/nft_marketplace.sol
+278. synnergy-network/cmd/smart_contracts/oracle_reader.sol
+279. synnergy-network/cmd/smart_contracts/storage_marketplace.sol
+280. synnergy-network/cmd/smart_contracts/token_creator.sol
+281. synnergy-network/cmd/smart_contracts/token_factory.sol
+282. synnergy-network/cmd/smart_contracts/token_minter.sol
+283. synnergy-network/cmd/synnergy/main.go
+284. synnergy-network/cmd/synnergy/synnergy_set_up.md
+285. synnergy-network/cmd/xchainserver/main.go
+286. synnergy-network/cmd/xchainserver/server/handlers.go
+287. synnergy-network/cmd/xchainserver/server/middleware.go
+288. synnergy-network/cmd/xchainserver/server/routes.go
 
-1. Run `./setup_synn.sh` to install Go and fetch module dependencies.
-2. Optionally execute `./Synnergy.env.sh` to install additional tools and load variables from `.env`.  This script also downloads Go modules and sets up `$GOPATH`.
-3. After either script completes, enter the `synnergy-network` directory and run `go mod tidy` to ensure all dependencies are present.
-4. Always start from a clean git state before beginning work on a new stage.
+## 25-Stage Cleanup and Production Plan
 
-## Standard Workflow
+Each stage contains strategic subtasks for teams to execute in parallel once prerequisites are satisfied.
 
-1. Pick the next unchecked file from the stage lists below.  Work on **no more than three files at a time** to keep pull requests focused.
-2. Verify no other open PR covers the same stage.  If it does, move to the next available stage.
-3. Fix compile or logic errors in the selected files.
-4. Run `go fmt` on all modified Go files.
-5. Run `go vet` and `go build` only on the packages containing your changes, for example `go vet ./cmd/...`.
-6. Execute `go test` for those same packages.  Unit tests live in `synnergy-network/tests` and can be invoked with `go test ./synnergy-network/core/<module>`.
-7. If `go vet`, `go build` or `go test` fail due to missing dependencies, run `go mod tidy` and retry.
-8. When all checks pass, update the checkboxes in this document and commit your changes.
-
-### Using the CLI
-
-Once the CLI builds successfully you can start a local node:
-
-```bash
-cd synnergy-network
-go build -o synnergy ./cmd/synnergy
-./synnergy ledger init --path ./ledger.db
-./synnergy network start
-```
-
-In another terminal you may create a wallet and mint coins for testing:
-
-```bash
-./synnergy wallet create --out wallet.json
-./synnergy coin mint $(jq -r .address wallet.json) 1000
-```
-
-Additional commands such as contract deployment or token transfers are documented in `cmd/cli/cli_guide.md`.
-
-## Staged Implementation Plan
-
-Development is divided into twenty‑five stages to keep the effort manageable.  Complete each stage in order, marking the checkboxes when the associated files compile and their tests pass.
-
-1. **Stage 1** – CLI: `ai.go`, `amm.go`, `authority_node.go`
-2. **Stage 2** – CLI: `charity_pool.go`, `coin.go`, `compliance.go`
-3. **Stage 3** – CLI: `consensus.go`, `contracts.go`, `cross_chain.go`
-4. **Stage 4** – CLI: `data.go`, `fault_tolerance.go`, `governance.go`
-5. **Stage 5** – CLI: `green_technology.go`, `index.go`, `ledger.go`
-6. **Stage 6** – CLI: `liquidity_pools.go`, `loanpool.go`, `network.go` ✅
-7. **Stage 7** – CLI: `replication.go`, `rollups.go`, `security.go` ✅
-8. **Stage 8** – CLI: `sharding.go`, `sidechain.go`, `state_channel.go` ✅
-9. **Stage 9** – CLI: `storage.go`, `tokens.go`, `transactions.go` ✅
-10. **Stage 10** – CLI: `utility_functions.go`, `virtual_machine.go`, `wallet.go` ✅
-11. **Stage 11** – Core: `ai.go`, `amm.go`, `authority_nodes.go`
-12. **Stage 12** – Core: `charity_pool.go`, `coin.go`, `common_structs.go`
-13. **Stage 13** – Core: `compliance.go`, `consensus.go`, `contracts.go`
-14. **Stage 14** – Core: `contracts_opcodes.go`, `cross_chain.go`, `data.go` ✅
-15. **Stage 15** – Core: `fault_tolerance.go`, `gas_table.go`, `governance.go` ✅
-16. **Stage 16** – Core: `green_technology.go`, `ledger.go`, `ledger_test.go` ✅
-17. **Stage 17** – Core: `liquidity_pools.go`, `loanpool.go`, `network.go` ✅
-18. **Stage 18** – Core: `opcode_dispatcher.go`, `replication.go`, `rollups.go` ✅
-19. **Stage 19** – Core: `security.go`, `sharding.go`, `sidechains.go` ✅
-20. **Stage 20** – Core: `state_channel.go`, `storage.go`, `tokens.go` ✅
-21. **Stage 21** – Core: `transactions.go`, `utility_functions.go`, `virtual_machine.go` ✅
-22. **Stage 22** – Core: `wallet.go` and review prior fixes ✅
-23. **Stage 23** – Run integration tests across CLI packages
-24. **Stage 24** – Launch a local network and verify node startup
-25. **Stage 25** – Final pass through documentation and ensure all tests pass
-
-## CLI Files Checklist
-
-- [x] ai.go
-- [x] amm.go
-- [x] authority_node.go
-- [x] charity_pool.go
-- [x] coin.go
-- [x] compliance.go
-- [x] consensus.go
-- [x] contracts.go
-- [x] cross_chain.go
-- [x] data.go
-- [x] fault_tolerance.go
-- [x] governance.go
-- [x] green_technology.go
-- [x] index.go
-- [x] ledger.go
-- [x] liquidity_pools.go
-- [x] loanpool.go
-- [x] network.go
-- [x] replication.go
-- [x] rollups.go
-- [x] security.go
-- [x] sharding.go
-- [x] sidechain.go
-- [x] state_channel.go
-- [x] storage.go
-- [x] tokens.go
-- [x] transactions.go
-- [x] utility_functions.go
-- [x] virtual_machine.go
-- [x] wallet.go
-
-## Core Module Checklist
-
-All modules reside under `synnergy-network/core`.  The `module_guide.md` file in that directory explains their responsibilities in detail.
-
-- [x] ai.go
-- [x] amm.go
-- [x] authority_nodes.go
-- [x] charity_pool.go
-- [x] coin.go
-- [x] common_structs.go
-- [x] compliance.go
-- [x] consensus.go
-- [x] contracts.go
-- [x] contracts_opcodes.go
-- [x] cross_chain.go
-- [x] data.go
-- [x] fault_tolerance.go
-- [x] gas_table.go
-- [x] governance.go
-- [x] green_technology.go
-- [x] ledger.go
-- [x] ledger_test.go
-- [x] liquidity_pools.go
-- [x] loanpool.go
-- [x] network.go
-- [x] opcode_dispatcher.go
-- [x] replication.go
-- [x] rollups.go
-- [x] security.go
-- [x] sharding.go
-- [x] sidechains.go
-- [x] state_channel.go
-- [x] storage.go
-- [x] tokens.go
-- [x] transactions.go
-- [x] utility_functions.go
-- [x] virtual_machine.go
-- [x] wallet.go
-
-## Guidance and Tips
-
-- Always work through the stages sequentially and keep your pull requests small.
-- Modify no more than three files at once to reduce merge conflicts.
-- Run formatting and tests as described in the workflow section before committing.
-- Refer to `setup_synn.sh` for a quick environment bootstrap and `Synnergy.env.sh` for a more complete tool chain.
-- Stub helpers are provided in `core/helpers.go`:
-  - `core.InitLedger` and `core.CurrentLedger` manage a shared ledger instance.
-  - `core.InitAuthoritySet` and `core.CurrentAuthoritySet` manage validator info.
-  - `core.NewTFStubClient` returns a no‑op AI gRPC client for development.
-  - `core.NewFlatGasCalculator` provides a simple gas model for tests and CLI prototypes.
-
-## Upgrade Roadmap
-
-The current code base is a functional prototype.  The following additions would help move the project toward a production‑ready blockchain:
-
-### Missing Bash Scripts
-
-- `faucet_fund.sh` – automate funding test accounts from a faucet service
-- `dao_vote.sh` – submit DAO proposals and cast votes
-- `marketplace_list.sh` – list items for sale in a decentralized marketplace
-- `storage_marketplace_pin.sh` – interface with the storage marketplace module
-- `loanpool_apply.sh` – submit a loan application transaction
-- `authority_apply.sh` – request validator or authority node status
-
-### Desired Smart Contracts
-
-- **Faucet Contract** – simple token dispenser with rate limiting
-- **DAO Governance Contract** – on‑chain voting and proposal execution
-- **Marketplace Contract** – buy and sell digital goods using SYNN tokens
- - **Storage Marketplace Contract** – pay for decentralized storage ✅
-- **LoanPool Application Contract** – terms negotiation and repayment logic
-- **Authority Node Application Contract** – stake tokens to join the validator set
-
-### Additional Directories and Tools
-
-- `cmd/faucet/` – CLI commands for interacting with the faucet service
-- `cmd/dao/` – DAO management commands
-- `cmd/marketplace/` – marketplace operations
-- `cmd/storage_marketplace/` – storage trading commands
-- `cmd/loanpool_apply/` – loan application utilities
-- `cmd/authority_apply/` – validator application workflow
-- `internal/` packages for shared utilities and cross‑package helpers
-- `GUI/` – web interfaces for wallet management, explorers and marketplaces
--   - `wallet/`, `explorer/`, `smart-contract-marketplace/`, `ai-marketplace/`,
-    `storage-marketplace/` ✅, `dao-explorer/`, `token-creation-tool/`,
-    `dex-screener/`, `authority-node-index/`, `cross-chain-management/`
-- `scripts/devnet_start.sh` for spinning up a multi‑node local network
-- `scripts/benchmark.sh` for load and performance testing
-
-### GUI Tasks
-
-Frontend development lives under `synnergy-network/GUI`. Each subdirectory
-contains a basic HTML page, a JavaScript stub and a README to bootstrap
-interfaces such as the wallet, explorer and various marketplaces. These
-projects are designed for web hosting and will evolve alongside the core
-modules.
-- Explorer GUI expanded with forms to query balances and transactions.
-  Backend server `cmd/explorer` now exposes JSON APIs and uses
-  `LedgerService`. Smart contracts demonstrate opcode usage via
-  `explorer_utils.sol` and `ledger_inspector.sol`.
-
-
-These upgrades will require corresponding tests and documentation.  Contributors are encouraged to propose additional improvements as they work through the stages.
-
-**DAO Explorer** – Tailwind frontend served from Express with controllers,
-services and smart contract bindings. Solidity contract now covers multiple
-governance opcodes and backend can interact with it via ethers.js.
-
-
----
-
-This playbook should be kept up to date as the project evolves.  Check off files as they are completed and add new tasks or modules to the roadmap so that future developers have a clear picture of the current status.
-\n### Recent Updates\n- Wallet GUI server extended with opcode catalogue and address/transaction utilities.
-
-## Progress Log
-
-- Added basic Express server and UI for the AI Marketplace under `GUI/ai-marketplace`.
-- Implemented `AIServiceMarketplace` Solidity contract demonstrating use of opcode `VM_Transfer`.
-- Added `Faucet` smart contract implementing a rate limited token dispenser.
-
-\n### Recent Updates\n- Wallet GUI now includes a Go HTTP backend under `walletserver/` with REST routes and Bootstrap front-end.
-
-\n## Progress\n- Added full NFT Marketplace GUI with backend service and Solidity contract.\n
-
-
-- Upcoming PR will cover the Nodes module, Authority Nodes module and Tokens module directories in full.
+1. **Stage 1 – Inventory Audit**
+   - Confirm file lists and assign owners for core, GUI and CLI modules.
+   - Remove obsolete files and document required dependencies.
+   - Tag remaining components with priority levels for refactor or testing.
+2. **Stage 2 – Build Environment Setup**
+   - Standardize Go, Node and environment versions for all modules.
+   - Configure module-aware builds and containerized development environments.
+   - Enable continuous integration pipelines for multi-module builds.
+3. **Stage 3 – Core Node Infrastructure**
+   - Consolidate base node implementations and unify network interfaces.
+   - Define service boundaries and shared libraries.
+   - Document initialization and shutdown sequences.
+4. **Stage 4 – Node Networking**
+   - Review connection pools, peer discovery and data synchronization logic.
+   - Harden transport protocols and handshake security.
+   - Simulate high-latency and partition scenarios.
+5. **Stage 5 – Authority Systems**
+   - Refine authority node operations, staking and slashing logic.
+   - Formalize key management and rotation procedures.
+   - Provide migration paths for community governance.
+6. **Stage 6 – Resource and Supply Chain**
+   - Optimize resource allocation, carbon credit and supply chain code.
+   - Integrate asset tracking with on-chain events.
+   - Validate accounting and settlement flows.
+7. **Stage 7 – Governance and DAO**
+   - Enhance DAO modules with voting, proposals and treasury management.
+   - Implement role-based access control for DAO actions.
+   - Provide migration scripts for governance upgrades.
+8. **Stage 8 – Token Standards**
+   - Consolidate token implementations to align with SYN specifications.
+   - Implement thorough validation for minting, burning and transfers.
+   - Generate reference documentation for token APIs.
+9. **Stage 9 – Cross-Chain Communication**
+   - Harmonize bridges and cross-chain contract compatibility.
+   - Implement proof verification for external chains.
+   - Provide failover and rollback mechanisms.
+10. **Stage 10 – Smart Contract Framework**
+    - Establish a standard VM execution layer and contract testing routines.
+    - Create developer tooling for compilation, deployment and debugging.
+    - Offer sample contracts and templates.
+11. **Stage 11 – Sharding and Rollups**
+    - Finalize sharding strategies, rollup circuits and state channel code.
+    - Define cross-shard communication protocols.
+    - Benchmark scaling approaches under stress.
+12. **Stage 12 – Consensus and Fault Tolerance**
+    - Review algorithms for dynamic consensus hopping and failover.
+    - Validate Byzantine fault assumptions through simulation.
+    - Provide recovery procedures for chain forks.
+13. **Stage 13 – Storage and Ledger**
+    - Harden ledger persistence, replication and compression mechanisms.
+    - Implement pruning and archiving strategies.
+    - Ensure deterministic state transitions across nodes.
+14. **Stage 14 – AI Integration**
+    - Define ML pipelines, model management and inference APIs.
+    - Secure training data and parameter storage.
+    - Monitor model drift and performance.
+15. **Stage 15 – Security and Encryption**
+    - Implement zero-trust channels, biometric security and quantum resistance.
+    - Conduct threat modeling for all interfaces.
+    - Enforce secure coding guidelines and static analysis.
+16. **Stage 16 – Utility Libraries**
+    - Deduplicate helper functions, standardize error handling and configs.
+    - Package reusable modules for distribution.
+    - Document API contracts and versioning.
+17. **Stage 17 – Testing Framework**
+    - Expand unit and integration tests with fuzzing and sandbox tooling.
+    - Automate regression suites across core, GUI and CLI.
+    - Track coverage metrics and enforce thresholds.
+18. **Stage 18 – Performance Optimization**
+    - Benchmark node operations and optimize for throughput and memory.
+    - Profile GUI/CLI interactions for responsiveness.
+    - Introduce caching and batching where applicable.
+19. **Stage 19 – Monitoring and Observability**
+    - Integrate system health logging, metrics and alerting pipelines.
+    - Provide dashboards for nodes, GUI and CLI usage.
+    - Establish SLOs and incident response runbooks.
+20. **Stage 20 – DevOps and Deployment**
+    - Containerize services and implement CI/CD with infrastructure-as-code.
+    - Provide staging and production environment parity.
+    - Automate rollbacks and canary releases.
+21. **Stage 21 – Documentation**
+    - Produce comprehensive developer docs, API references and examples.
+    - Generate end-user manuals for GUI and CLI tools.
+    - Maintain architecture decision records.
+22. **Stage 22 – Compliance and Auditing**
+    - Validate regulatory compliance and audit logging practices.
+    - Conduct internal and external code reviews.
+    - Archive evidence for certification processes.
+23. **Stage 23 – User Feedback and UX**
+    - Gather community feedback on GUI and CLI workflows.
+    - Conduct usability testing and accessibility reviews.
+    - Refine interface design and onboarding flows.
+24. **Stage 24 – Final Security Audit**
+    - Run external penetration tests and finalize cryptographic modules.
+    - Validate dependency supply chain integrity.
+    - Resolve high and medium severity findings.
+25. **Stage 25 – Production Launch**
+    - Deploy stable release across all nodes and client interfaces.
+    - Execute final go/no-go checklist with stakeholder sign-off.
+    - Transition ongoing maintenance to operations with clear SLAs.


### PR DESCRIPTION
## Summary
- catalog core (281), GUI (132) and CLI (288) files in `AGENTS.md`
- outline a 25-stage enterprise roadmap with detailed subtasks for production readiness

## Testing
- `go test ./...` *(fails: import cycle not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_688d6438e9d4832085ee2b7c124b1419