### PR TITLE
Stage 6: Harden resource allocation and supply chain logic

### DIFF
--- a/synnergy-network/core/resource_allocation_management.go
+++ b/synnergy-network/core/resource_allocation_management.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 )
@@ -35,13 +36,15 @@ func (rm *ResourceAllocator) SetLimit(addr Address, limit uint64) error {
 	return rm.ledger.SetState(resourceKey(addr), buf[:])
 }
 
-// GetLimit returns the gas limit for an address. If none exists a default is returned.
-func (rm *ResourceAllocator) GetLimit(addr Address) (uint64, error) {
-	rm.mu.RLock()
-	defer rm.mu.RUnlock()
+// fetchLimit retrieves the gas limit for an address without acquiring locks.
+// A missing entry returns the default limit; other errors are propagated.
+func (rm *ResourceAllocator) fetchLimit(addr Address) (uint64, error) {
 	val, err := rm.ledger.GetState(resourceKey(addr))
 	if err != nil {
-		return defaultGasLimit, nil
+		if errors.Is(err, ErrNotFound) {
+			return defaultGasLimit, nil
+		}
+		return 0, err
 	}
 	if len(val) != 8 {
 		return 0, fmt.Errorf("corrupt gas limit for %s", hex.EncodeToString(addr[:]))
@@ -49,15 +52,20 @@ func (rm *ResourceAllocator) GetLimit(addr Address) (uint64, error) {
 	return binary.BigEndian.Uint64(val), nil
 }
 
+// GetLimit returns the gas limit for an address. If none exists a default is returned.
+func (rm *ResourceAllocator) GetLimit(addr Address) (uint64, error) {
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+	return rm.fetchLimit(addr)
+}
+
 // Consume deducts gas from the limit of an address.
 func (rm *ResourceAllocator) Consume(addr Address, amt uint64) error {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
-	key := resourceKey(addr)
-	val, err := rm.ledger.GetState(key)
-	limit := defaultGasLimit
-	if err == nil && len(val) == 8 {
-		limit = binary.BigEndian.Uint64(val)
+	limit, err := rm.fetchLimit(addr)
+	if err != nil {
+		return err
 	}
 	if limit < amt {
 		return fmt.Errorf("insufficient limit for %s", hex.EncodeToString(addr[:]))
@@ -65,21 +73,24 @@ func (rm *ResourceAllocator) Consume(addr Address, amt uint64) error {
 	limit -= amt
 	var buf [8]byte
 	binary.BigEndian.PutUint64(buf[:], limit)
-	return rm.ledger.SetState(key, buf[:])
+	return rm.ledger.SetState(resourceKey(addr), buf[:])
 }
 
 // TransferLimit moves a portion of one address limit to another address.
 func (rm *ResourceAllocator) TransferLimit(from, to Address, amt uint64) error {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
-	fromLimit, err := rm.GetLimit(from)
+	fromLimit, err := rm.fetchLimit(from)
 	if err != nil {
 		return err
 	}
 	if fromLimit < amt {
 		return fmt.Errorf("insufficient limit for %s", hex.EncodeToString(from[:]))
 	}
-	toLimit, _ := rm.GetLimit(to)
+	toLimit, err := rm.fetchLimit(to)
+	if err != nil {
+		return err
+	}
 	fromLimit -= amt
 	toLimit += amt
 	var buf [8]byte


### PR DESCRIPTION
## Summary
- Add thread-safe resource allocator with explicit error handling and deadlock-free limit transfers
- Guard supply chain registry with locks and duplicate checks to ensure consistent item updates
- Lock carbon credit listings and surface iterator errors when scanning projects
- Decouple carbon credit verification records to break token import cycles

## Testing
- `go test ./...` *(fails: import cycle not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_688d6f9539e4832089704914b9ece1bd