### PR TITLE
Implement DAO proposals with quadratic voting

### DIFF
--- a/synnergy-network/cmd/cli/dao_proposal.go
+++ b/synnergy-network/cmd/cli/dao_proposal.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	core "synnergy-network/core"
+)
+
+func dpParseAddr(h string) (core.Address, error) {
+	var a core.Address
+	b, err := hex.DecodeString(h)
+	if err != nil || len(b) != len(a) {
+		return a, fmt.Errorf("invalid address")
+	}
+	copy(a[:], b)
+	return a, nil
+}
+
+var daoProposalCmd = &cobra.Command{
+	Use:   "proposal",
+	Short: "Manage DAO proposals",
+}
+
+var daoProposalCreateCmd = &cobra.Command{
+	Use:   "create <dao-id> <creator> <description>",
+	Short: "Create a proposal",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dur, _ := cmd.Flags().GetDuration("duration")
+		creator, err := dpParseAddr(args[1])
+		if err != nil {
+			return err
+		}
+		p, err := core.CreateDAOProposal(args[0], creator, args[2], dur)
+		if err != nil {
+			return err
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(p)
+	},
+}
+
+var daoProposalVoteCmd = &cobra.Command{
+	Use:   "vote <proposal-id> <voter>",
+	Short: "Vote on a proposal",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tokens, _ := cmd.Flags().GetUint64("tokens")
+		approve, _ := cmd.Flags().GetBool("approve")
+		voter, err := dpParseAddr(args[1])
+		if err != nil {
+			return err
+		}
+		return core.VoteDAOProposal(args[0], voter, tokens, approve)
+	},
+}
+
+var daoProposalTallyCmd = &cobra.Command{
+	Use:   "tally <proposal-id>",
+	Short: "Show vote totals",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		forW, againstW, err := core.TallyDAOProposal(args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "for=%d against=%d\n", forW, againstW)
+		return nil
+	},
+}
+
+func init() {
+	daoProposalCreateCmd.Flags().Duration("duration", time.Hour, "voting period")
+	daoProposalVoteCmd.Flags().Uint64("tokens", 0, "token amount to weight the vote")
+	daoProposalVoteCmd.Flags().Bool("approve", true, "approve or reject")
+	daoProposalVoteCmd.MarkFlagRequired("tokens")
+	daoCmd.AddCommand(daoProposalCmd)
+	daoProposalCmd.AddCommand(daoProposalCreateCmd, daoProposalVoteCmd, daoProposalTallyCmd)
+}

--- a/synnergy-network/core/dao_proposal.go
+++ b/synnergy-network/core/dao_proposal.go
@@ -1,0 +1,113 @@
+package core
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DAOProposal represents an on-chain proposal within a DAO.
+type DAOProposal struct {
+	ID          string    `json:"id"`
+	DAOID       string    `json:"dao_id"`
+	Creator     Address   `json:"creator"`
+	Description string    `json:"description"`
+	Deadline    time.Time `json:"deadline"`
+	Executed    bool      `json:"executed"`
+}
+
+// CreateDAOProposal creates a new proposal for the specified DAO. The creator
+// must be a member of the DAO. The proposal's voting window is determined by
+// the supplied duration.
+func CreateDAOProposal(daoID string, creator Address, desc string, dur time.Duration) (*DAOProposal, error) {
+	if daoID == "" {
+		return nil, fmt.Errorf("dao id required")
+	}
+	d, err := DAOInfo(daoID)
+	if err != nil {
+		return nil, err
+	}
+	if !d.Members[hex.EncodeToString(creator[:])] {
+		return nil, ErrMemberMissing
+	}
+	p := &DAOProposal{
+		ID:          uuid.New().String(),
+		DAOID:       daoID,
+		Creator:     creator,
+		Description: desc,
+		Deadline:    time.Now().UTC().Add(dur),
+	}
+	raw, _ := json.Marshal(p)
+	key := fmt.Sprintf("dao:proposal:%s", p.ID)
+	if err := CurrentStore().Set([]byte(key), raw); err != nil {
+		return nil, err
+	}
+	Broadcast("dao:proposal:new", raw)
+	return p, nil
+}
+
+// VoteDAOProposal casts a quadratic vote on a proposal. The voter must be a
+// member of the DAO that owns the proposal.
+func VoteDAOProposal(id string, voter Address, tokens uint64, approve bool) error {
+	key := fmt.Sprintf("dao:proposal:%s", id)
+	raw, err := CurrentStore().Get([]byte(key))
+	if err != nil || raw == nil {
+		return ErrNotFound
+	}
+	var p DAOProposal
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return err
+	}
+	d, err := DAOInfo(p.DAOID)
+	if err != nil {
+		return err
+	}
+	if !d.Members[hex.EncodeToString(voter[:])] {
+		return ErrMemberMissing
+	}
+	return SubmitQuadraticVote(id, voter, tokens, approve)
+}
+
+// TallyDAOProposal returns the quadratic vote weights for and against a
+// proposal.
+func TallyDAOProposal(id string) (uint64, uint64, error) {
+	return QuadraticResults(id)
+}
+
+// ExecuteDAOProposal finalises a proposal after its deadline. It records the
+// outcome on-chain and emits a broadcast event indicating whether it passed.
+func ExecuteDAOProposal(id string) error {
+	key := fmt.Sprintf("dao:proposal:%s", id)
+	raw, err := CurrentStore().Get([]byte(key))
+	if err != nil || raw == nil {
+		return ErrNotFound
+	}
+	var p DAOProposal
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return err
+	}
+	if p.Executed {
+		return ErrInvalidState
+	}
+	if time.Now().UTC().Before(p.Deadline) {
+		return ErrNotReady
+	}
+	forW, againstW, err := QuadraticResults(id)
+	if err != nil {
+		return err
+	}
+	p.Executed = true
+	updated, _ := json.Marshal(&p)
+	if err := CurrentStore().Set([]byte(key), updated); err != nil {
+		return err
+	}
+	if forW > againstW {
+		Broadcast("dao:proposal:passed", updated)
+	} else {
+		Broadcast("dao:proposal:failed", updated)
+	}
+	return nil
+}

--- a/synnergy-network/core/dao_quadratic_voting.go
+++ b/synnergy-network/core/dao_quadratic_voting.go
@@ -41,6 +41,9 @@ func SubmitQuadraticVote(pID string, voter Address, tokens uint64, approve bool)
 	raw, _ := json.Marshal(rec)
 	qvMu.Lock()
 	defer qvMu.Unlock()
+	if val, _ := CurrentStore().Get([]byte(key)); val != nil {
+		return fmt.Errorf("vote already recorded")
+	}
 	return CurrentStore().Set([]byte(key), raw)
 }
 

--- a/synnergy-network/tests/dao_proposal_test.go
+++ b/synnergy-network/tests/dao_proposal_test.go
@@ -1,0 +1,50 @@
+package core_test
+
+import (
+	"testing"
+	"time"
+
+	core "synnergy-network/core"
+)
+
+func TestDAOProposalQuadraticVoting(t *testing.T) {
+	core.SetStore(core.NewInMemoryStore())
+	dir := t.TempDir()
+	if err := core.InitLedger(dir); err != nil {
+		t.Fatalf("ledger init failed: %v", err)
+	}
+	creator := core.Address{1}
+	dao, err := core.CreateDAO("TestDAO", creator)
+	if err != nil {
+		t.Fatalf("create dao: %v", err)
+	}
+	led := core.CurrentLedger()
+	led.TokenBalances[creator.String()+":"+core.Code] = 100
+	voter := core.Address{2}
+	led.TokenBalances[voter.String()+":"+core.Code] = 25
+	if err := core.JoinDAO(dao.ID, voter); err != nil {
+		t.Fatalf("join dao: %v", err)
+	}
+	p, err := core.CreateDAOProposal(dao.ID, creator, "test", time.Millisecond)
+	if err != nil {
+		t.Fatalf("create proposal: %v", err)
+	}
+	if err := core.VoteDAOProposal(p.ID, voter, 25, true); err != nil {
+		t.Fatalf("vote: %v", err)
+	}
+	// duplicate vote should fail
+	if err := core.VoteDAOProposal(p.ID, voter, 25, true); err == nil {
+		t.Fatalf("expected duplicate vote error")
+	}
+	forW, againstW, err := core.TallyDAOProposal(p.ID)
+	if err != nil {
+		t.Fatalf("tally: %v", err)
+	}
+	if forW <= againstW {
+		t.Fatalf("expected for > against")
+	}
+	time.Sleep(2 * time.Millisecond)
+	if err := core.ExecuteDAOProposal(p.ID); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add on-chain DAO proposal model with create, vote, tally, and execution helpers
- expose proposal management commands in CLI
- enforce single vote per address in quadratic voting module
- extend tests to reject double voting and exercise proposal execution

## Testing
- `go test ./tests -run TestDAOProposalQuadraticVoting -count=1` *(fails: import cycle not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_688d6fa5bfcc8320adc7e760b931a53e