### PR TITLE
Stage 6: Harden resource allocation and supply chain logic

### DIFF
--- a/synnergy-network/core/carbon_credit_system.go
+++ b/synnergy-network/core/carbon_credit_system.go
@@ -6,19 +6,26 @@ import (
 	"fmt"
 	"sync"
 	"time"
-
-	Tokens "synnergy-network/core/Tokens"
 )
+
+// VerificationRecord captures third-party verification details for a project.
+// It is defined locally to avoid cyclic imports between core and token packages.
+type VerificationRecord struct {
+	ID        string    `json:"id"`
+	Verifier  Address   `json:"verifier"`
+	Timestamp time.Time `json:"timestamp"`
+	Status    string    `json:"status"`
+}
 
 // CarbonProject represents a verified carbon offset project recorded on chain.
 type CarbonProject struct {
-	ID            uint64                      `json:"id"`
-	Name          string                      `json:"name"`
-	Owner         Address                     `json:"owner"`
-	Total         uint64                      `json:"total"`
-	Remaining     uint64                      `json:"remaining"`
-	Verified      bool                        `json:"verified"`
-	Verifications []Tokens.VerificationRecord `json:"verifications"`
+	ID            uint64               `json:"id"`
+	Name          string               `json:"name"`
+	Owner         Address              `json:"owner"`
+	Total         uint64               `json:"total"`
+	Remaining     uint64               `json:"remaining"`
+	Verified      bool                 `json:"verified"`
+	Verifications []VerificationRecord `json:"verifications"`
 }
 
 // CarbonEngine manages carbon credit issuance and retirement. Projects are
@@ -26,7 +33,7 @@ type CarbonProject struct {
 // the built‑in SYN-CO2 token.
 type CarbonEngine struct {
 	ledger  StateRW
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	nextID  uint64
 	tokenID TokenID
 }
@@ -127,12 +134,21 @@ func (e *CarbonEngine) RetireCredits(holder Address, amount uint64) error {
 }
 
 // AddVerification records a verification entry for the specified project.
-func (e *CarbonEngine) AddVerification(id uint64, ver Tokens.VerificationRecord) error {
+func (e *CarbonEngine) AddVerification(id uint64, ver VerificationRecord) error {
+	if ver.ID == "" {
+		return errors.New("verification id required")
+	}
+	ver.Timestamp = time.Now().UTC()
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	proj, err := e.getProject(id)
 	if err != nil {
 		return err
+	}
+	for _, existing := range proj.Verifications {
+		if existing.ID == ver.ID {
+			return fmt.Errorf("verification %s exists", ver.ID)
+		}
 	}
 	proj.Verifications = append(proj.Verifications, ver)
 	if ver.Status == "verified" {
@@ -143,20 +159,22 @@ func (e *CarbonEngine) AddVerification(id uint64, ver Tokens.VerificationRecord)
 }
 
 // ListVerifications returns verification records for a project.
-func (e *CarbonEngine) ListVerifications(id uint64) ([]Tokens.VerificationRecord, error) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+func (e *CarbonEngine) ListVerifications(id uint64) ([]VerificationRecord, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	proj, err := e.getProject(id)
 	if err != nil {
 		return nil, err
 	}
-	return proj.Verifications, nil
+	out := make([]VerificationRecord, len(proj.Verifications))
+	copy(out, proj.Verifications)
+	return out, nil
 }
 
 // ProjectInfo returns a project by id.
 func (e *CarbonEngine) ProjectInfo(id uint64) (*CarbonProject, bool) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	proj, err := e.getProject(id)
 	if err != nil {
 		return nil, false
@@ -166,6 +184,8 @@ func (e *CarbonEngine) ProjectInfo(id uint64) (*CarbonProject, bool) {
 
 // ListProjects enumerates all projects in the ledger.
 func (e *CarbonEngine) ListProjects() ([]CarbonProject, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	iter := e.ledger.PrefixIterator([]byte("ccs:proj:"))
 	var list []CarbonProject
 	for iter.Next() {
@@ -175,7 +195,7 @@ func (e *CarbonEngine) ListProjects() ([]CarbonProject, error) {
 		}
 		list = append(list, p)
 	}
-	return list, nil
+	return list, iter.Error()
 }
 
 // End of carbon_credit_system.go

--- a/synnergy-network/core/supply_chain.go
+++ b/synnergy-network/core/supply_chain.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -16,11 +18,19 @@ type SupplyItem struct {
 	Updated     time.Time `json:"updated"`
 }
 
+var supplyMu sync.RWMutex
+
 // RegisterItem stores a new SupplyItem on the ledger and broadcasts the event.
 func RegisterItem(item SupplyItem) error {
-	item.Updated = time.Now().UTC()
+	supplyMu.Lock()
+	defer supplyMu.Unlock()
 	key := fmt.Sprintf("supply:item:%s", item.ID)
-
+	if _, err := CurrentStore().Get([]byte(key)); err == nil {
+		return fmt.Errorf("item %s already exists", item.ID)
+	} else if !errors.Is(err, ErrNotFound) {
+		return err
+	}
+	item.Updated = time.Now().UTC()
 	raw, err := json.Marshal(item)
 	if err != nil {
 		return err
@@ -33,7 +43,9 @@ func RegisterItem(item SupplyItem) error {
 
 // UpdateLocation changes the location of an existing item.
 func UpdateLocation(id, location string) error {
-	item, err := GetItem(id)
+	supplyMu.Lock()
+	defer supplyMu.Unlock()
+	item, err := fetchItem(id)
 	if err != nil {
 		return err
 	}
@@ -44,7 +56,9 @@ func UpdateLocation(id, location string) error {
 
 // MarkStatus updates the status of an item (e.g. shipped, delivered).
 func MarkStatus(id, status string) error {
-	item, err := GetItem(id)
+	supplyMu.Lock()
+	defer supplyMu.Unlock()
+	item, err := fetchItem(id)
 	if err != nil {
 		return err
 	}
@@ -55,15 +69,9 @@ func MarkStatus(id, status string) error {
 
 // GetItem retrieves a SupplyItem by ID.
 func GetItem(id string) (*SupplyItem, error) {
-	raw, err := CurrentStore().Get([]byte(fmt.Sprintf("supply:item:%s", id)))
-	if err != nil {
-		return nil, err
-	}
-	var item SupplyItem
-	if err := json.Unmarshal(raw, &item); err != nil {
-		return nil, err
-	}
-	return &item, nil
+	supplyMu.RLock()
+	defer supplyMu.RUnlock()
+	return fetchItem(id)
 }
 
 func saveItem(it SupplyItem) error {
@@ -76,4 +84,32 @@ func saveItem(it SupplyItem) error {
 		return err
 	}
 	return Broadcast("supply_update", raw)
+}
+
+func fetchItem(id string) (*SupplyItem, error) {
+	raw, err := CurrentStore().Get([]byte(fmt.Sprintf("supply:item:%s", id)))
+	if err != nil {
+		return nil, err
+	}
+	var item SupplyItem
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+// ListItems returns all supply chain items on the ledger.
+func ListItems() ([]SupplyItem, error) {
+	supplyMu.RLock()
+	defer supplyMu.RUnlock()
+	it := CurrentStore().PrefixIterator([]byte("supply:item:"))
+	var items []SupplyItem
+	for it.Next() {
+		var itx SupplyItem
+		if err := json.Unmarshal(it.Value(), &itx); err != nil {
+			continue
+		}
+		items = append(items, itx)
+	}
+	return items, it.Error()
 }


### PR DESCRIPTION
## Summary
- Add thread-safe resource allocator with explicit error handling and deadlock-free limit transfers
- Guard supply chain registry with locks and duplicate checks to ensure consistent item updates
- Lock carbon credit listings and surface iterator errors when scanning projects
- Decouple carbon credit verification records to break token import cycles
- Validate carbon project verification entries and expose read-only accessors
- Support supply chain inventory enumeration and limit removal in resource allocator

## Testing
- `go test ./...` *(fails: import cycle not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_688d6f9539e4832089704914b9ece1bd