### PR TITLE
Ensure cross-chain operations require active connections

### DIFF
--- a/synnergy-network/core/cross_chain.go
+++ b/synnergy-network/core/cross_chain.go
@@ -52,6 +52,11 @@ func RegisterBridge(b Bridge) error {
 		return ErrUnauthorized
 	}
 
+	if !HasActiveConnection(b.SourceChain, b.TargetChain) {
+		logger.Warnf("No active connection between %s and %s", b.SourceChain, b.TargetChain)
+		return fmt.Errorf("no active connection between %s and %s: %w", b.SourceChain, b.TargetChain, ErrNoActiveConnection)
+	}
+
 	// assign ID
 	b.ID = uuid.New().String()
 	b.CreatedAt = time.Now().UTC()
@@ -94,7 +99,7 @@ type KVStore interface {
 	Set(key, value []byte) error
 	Get(key []byte) ([]byte, error)
 	Delete(key []byte) error
-	Iterator(start, end []byte) Iterator // ← Add this line
+	Iterator(start, end []byte) Iterator
 }
 
 type Iterator interface {


### PR DESCRIPTION
## Summary
- standardize missing-connection handling with `ErrNoActiveConnection` and a helper to list active links
- enforce active connection checks when registering bridges or cross-chain contract mappings

## Testing
- `go test ./...` (fails: import cycle in cmd/cli)
- `go test ./core/Nodes` (fails: syntax errors in core/Nodes/index.go)


------
https://chatgpt.com/codex/tasks/task_e_688d6fbc7cc48320b4434132b6c6a5e7