### PR TITLE
feat(core): add fork recovery and ledger rebuild

### DIFF
--- a/synnergy-network/cmd/cli/chain_fork_manager.go
+++ b/synnergy-network/cmd/cli/chain_fork_manager.go
@@ -25,7 +25,7 @@ func forkInit(cmd *cobra.Command, _ []string) error {
 		}
 		forkLedger, forkErr = core.OpenLedger(path)
 		if forkErr == nil {
-			core.InitForkManager(forkLedger)
+			forkErr = core.InitForkManager(forkLedger)
 		}
 	})
 	return forkErr
@@ -41,6 +41,10 @@ func forkList(_ *cobra.Command, _ []string) error {
 
 func forkResolve(_ *cobra.Command, _ []string) error {
 	return core.ResolveForks()
+}
+
+func forkRecover(_ *cobra.Command, _ []string) error {
+	return core.RecoverLongestFork()
 }
 
 var forkCmd = &cobra.Command{
@@ -61,8 +65,14 @@ var forkResolveCmd = &cobra.Command{
 	RunE:  forkResolve,
 }
 
+var forkRecoverCmd = &cobra.Command{
+	Use:   "recover",
+	Short: "Rebuild the chain to the longest known fork",
+	RunE:  forkRecover,
+}
+
 func init() {
-	forkCmd.AddCommand(forkListCmd, forkResolveCmd)
+	forkCmd.AddCommand(forkListCmd, forkResolveCmd, forkRecoverCmd)
 }
 
 var ForkCmd = forkCmd

--- a/synnergy-network/core/bft_simulation.go
+++ b/synnergy-network/core/bft_simulation.go
@@ -1,0 +1,55 @@
+package core
+
+// bft_simulation.go - quick Monte Carlo estimation of consensus safety under
+// Byzantine faults. The simulation is intentionally lightweight so it can run
+// during CLI diagnostics or integration tests without external dependencies.
+
+import (
+	"math/rand"
+	"time"
+)
+
+// SimulateBFT runs a naive Monte Carlo simulation to estimate the probability
+// of reaching agreement in the presence of f Byzantine nodes out of n total.
+// A round is counted as successful if at least 2f+1 honest votes align. When
+// n >= 3f+1 the function returns 1 immediately to reflect the theoretical
+// guarantee of Byzantine fault tolerance.
+// SimulateBFTWith allows custom failure probability for honest nodes. The
+// `failProb` parameter models the chance that an honest vote is missing due to
+// network delay or crash. When `n >= 3f+1` the function returns 1 immediately to
+// reflect the theoretical guarantee of Byzantine fault tolerance.
+func SimulateBFTWith(n, f, rounds int, failProb float64) float64 {
+	if n <= 0 || f < 0 || f >= n || rounds <= 0 {
+		return 0
+	}
+	if failProb < 0 || failProb >= 1 {
+		return 0
+	}
+	if n >= 3*f+1 {
+		return 1
+	}
+	src := rand.New(rand.NewSource(time.Now().UnixNano()))
+	success := 0
+	honest := n - f
+	for i := 0; i < rounds; i++ {
+		votes := 0
+		for j := 0; j < honest; j++ {
+			// each honest node may be delayed or fail with given probability
+			if src.Float64() >= failProb {
+				votes++
+			}
+		}
+		if votes >= 2*f+1 {
+			success++
+		}
+	}
+	return float64(success) / float64(rounds)
+}
+
+// SimulateBFT runs SimulateBFTWith using a default 1% failure probability for
+// honest nodes.
+func SimulateBFT(n, f, rounds int) float64 {
+	return SimulateBFTWith(n, f, rounds, 0.01)
+}
+
+// END bft_simulation.go

--- a/synnergy-network/core/bft_simulation_test.go
+++ b/synnergy-network/core/bft_simulation_test.go
@@ -1,0 +1,14 @@
+package core
+
+import "testing"
+
+// TestSimulateBFTWith verifies deterministic scenarios of the Monte Carlo
+// estimator.
+func TestSimulateBFTWith(t *testing.T) {
+	if SimulateBFT(4, 1, 10) != 1 {
+		t.Fatalf("expected full tolerance when n>=3f+1")
+	}
+	if p := SimulateBFTWith(3, 1, 100, 0); p != 0 {
+		t.Fatalf("expected zero probability when quorum unattainable, got %v", p)
+	}
+}

--- a/synnergy-network/core/chain_fork_manager.go
+++ b/synnergy-network/core/chain_fork_manager.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"sync"
 
@@ -24,8 +25,14 @@ type ChainForkManager struct {
 var forkMgr *ChainForkManager
 
 // InitForkManager initialises the global fork manager with a ledger instance.
-func InitForkManager(l *Ledger) {
+// It returns an error if the ledger is nil to avoid panics during block
+// processing.
+func InitForkManager(l *Ledger) error {
+	if l == nil {
+		return fmt.Errorf("nil ledger")
+	}
 	forkMgr = &ChainForkManager{ledger: l, forks: make(map[string][]*Block)}
+	return nil
 }
 
 // AddForkBlock adds a new block to the ledger or stores it as a fork.
@@ -93,5 +100,63 @@ func ResolveForks() error {
 	delete(forkMgr.forks, tipHex)
 	logrus.WithField("new_height", forkMgr.ledger.Blocks[len(forkMgr.ledger.Blocks)-1].Header.Height).
 		Info("fork resolved into main chain")
+	return nil
+}
+
+// RecoverLongestFork searches known forks and, if a branch results in a longer
+// chain than the current canonical tip, rewinds the ledger to the fork point and
+// rebuilds using the longer branch. This provides automatic recovery from chain
+// splits.
+func RecoverLongestFork() error {
+	if forkMgr == nil {
+		return fmt.Errorf("fork manager not initialised")
+	}
+	forkMgr.mu.Lock()
+	defer forkMgr.mu.Unlock()
+
+	mainLen := len(forkMgr.ledger.Blocks)
+	bestParent := ""
+	var bestFork []*Block
+	bestLen := mainLen
+
+	for parentHex, blocks := range forkMgr.forks {
+		parentBytes, err := hex.DecodeString(parentHex)
+		if err != nil {
+			logrus.WithField("parent", parentHex).WithError(err).Warn("invalid fork parent hash")
+			continue
+		}
+		var ph Hash
+		copy(ph[:], parentBytes)
+		parent, ok := forkMgr.ledger.blockIndex[ph]
+		if !ok {
+			logrus.WithField("parent", parentHex).Warn("fork parent not found in ledger")
+			continue
+		}
+		candLen := int(parent.Header.Height) + len(blocks) + 1
+		if candLen > bestLen {
+			bestLen = candLen
+			bestParent = parentHex
+			bestFork = blocks
+		}
+	}
+
+	if bestParent == "" {
+		return nil // no longer fork detected
+	}
+
+	parentBytes, _ := hex.DecodeString(bestParent)
+	var parentHash Hash
+	copy(parentHash[:], parentBytes)
+	parentBlock := forkMgr.ledger.blockIndex[parentHash]
+	parentHeight := int(parentBlock.Header.Height)
+
+	newChain := append([]*Block{}, forkMgr.ledger.Blocks[:parentHeight+1]...)
+	newChain = append(newChain, bestFork...)
+	if err := forkMgr.ledger.RebuildChain(newChain); err != nil {
+		return err
+	}
+	delete(forkMgr.forks, bestParent)
+	logrus.WithField("new_height", forkMgr.ledger.Blocks[len(forkMgr.ledger.Blocks)-1].Header.Height).
+		Info("chain reorganized to longest fork")
 	return nil
 }


### PR DESCRIPTION
## Summary
- add ledger `RebuildChain` to reset state and rewrite WAL for fork recovery
- implement `RecoverLongestFork` to reorganize the ledger to the longest branch
- improve fork manager initialization and logging
- add lightweight BFT simulation to validate fault tolerance assumptions
- extend BFT simulation with customizable failure probability and CLI fork recovery command

## Testing
- `go test ./core -run TestLedgerRebuild -count=1` *(fails: import cycle between core and core/Tokens)*
- `go test ./core -run TestSimulateBFTWith -count=1` *(fails: import cycle between core and core/Tokens)*


------
https://chatgpt.com/codex/tasks/task_e_688d6fe41fc88320ac0dcae6848ee541