### PR TITLE
feat(core): add ledger pruning and state root

### DIFF
--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -304,6 +304,8 @@ type LedgerConfig struct {
 	WALPath          string
 	SnapshotPath     string
 	SnapshotInterval int
+	ArchivePath      string // optional gzip file to archive pruned blocks
+	PruneInterval    int    // number of recent blocks to retain in memory/WAL
 }
 
 // UTXO represents a spendable output identified by (TxID, Index).
@@ -362,6 +364,8 @@ type Ledger struct {
 	walFile          *os.File
 	snapshotPath     string
 	snapshotInterval int
+	archivePath      string // destination file for archived blocks
+	pruneInterval    int    // retain this many recent blocks
 	tokens           map[TokenID]Token
 	lpBalances       map[Address]map[PoolID]uint64
 	nonces           map[Address]uint64

--- a/synnergy-network/core/ledger.go
+++ b/synnergy-network/core/ledger.go
@@ -3,16 +3,17 @@ package core
 import (
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/sirupsen/logrus"
-	"log"
 	"math/big"
 	"os"
 	"path/filepath"
+	"sort"
 )
 
 // NewLedger initializes a ledger, replaying an existing WAL and optionally loading a genesis block.
@@ -38,6 +39,8 @@ func NewLedger(cfg LedgerConfig) (*Ledger, error) {
 		walFile:          wal,
 		snapshotPath:     cfg.SnapshotPath,
 		snapshotInterval: cfg.SnapshotInterval,
+		archivePath:      cfg.ArchivePath,
+		pruneInterval:    cfg.PruneInterval,
 	}
 	if cfg.GenesisBlock != nil {
 		if err := l.applyBlock(cfg.GenesisBlock, false); err != nil {
@@ -264,6 +267,9 @@ func (l *Ledger) applyBlock(block *Block, persist bool) error {
 				logrus.Errorf("snapshot error: %v", err)
 			}
 		}
+		if err := l.prune(); err != nil {
+			logrus.Errorf("prune error: %v", err)
+		}
 	}
 
 	logrus.Infof("Block %d applied; total blocks %d", block.Header.Height, len(l.Blocks))
@@ -289,9 +295,13 @@ func (l *Ledger) snapshot() error {
 		f.Close()
 		return err
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		return err
+	}
 	// Truncate WAL (start anew)
-	l.walFile.Close()
+	if err := l.walFile.Close(); err != nil {
+		return err
+	}
 	wal, err := os.Create(l.walFile.Name())
 	if err != nil {
 		return err
@@ -299,6 +309,96 @@ func (l *Ledger) snapshot() error {
 	l.walFile = wal
 	logrus.Infof("Snapshot saved to %s; WAL truncated", l.snapshotPath)
 	return nil
+}
+
+// prune archives old blocks and rewrites WAL to keep the ledger size bounded.
+func (l *Ledger) prune() error {
+	if l.pruneInterval <= 0 || len(l.Blocks) <= l.pruneInterval {
+		return nil
+	}
+
+	toArchive := len(l.Blocks) - l.pruneInterval
+	if l.archivePath != "" {
+		f, err := os.OpenFile(l.archivePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			return err
+		}
+		gz := gzip.NewWriter(f)
+		for i := 0; i < toArchive; i++ {
+			data, err := json.Marshal(l.Blocks[i])
+			if err != nil {
+				gz.Close()
+				f.Close()
+				return err
+			}
+			if _, err := gz.Write(data); err != nil {
+				gz.Close()
+				f.Close()
+				return err
+			}
+			if _, err := gz.Write([]byte("\n")); err != nil {
+				gz.Close()
+				f.Close()
+				return err
+			}
+			delete(l.blockIndex, l.Blocks[i].Hash())
+		}
+		if err := gz.Close(); err != nil {
+			f.Close()
+			return err
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+
+	l.Blocks = l.Blocks[toArchive:]
+	return l.rewriteWAL()
+}
+
+// rewriteWAL persists current blocks into WAL from scratch.
+func (l *Ledger) rewriteWAL() error {
+	if err := l.walFile.Close(); err != nil {
+		return err
+	}
+	wal, err := os.Create(l.walFile.Name())
+	if err != nil {
+		return err
+	}
+	l.walFile = wal
+	for _, blk := range l.Blocks {
+		data, err := json.Marshal(blk)
+		if err != nil {
+			return err
+		}
+		if _, err := l.walFile.Write(append(data, '\n')); err != nil {
+			return err
+		}
+	}
+	if err := l.walFile.Sync(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// StateRoot computes a deterministic hash of the ledger's State map.
+func (l *Ledger) StateRoot() Hash {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	keys := make([]string, 0, len(l.State))
+	for k := range l.State {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	h := sha256.New()
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write(l.State[k])
+	}
+	var out Hash
+	copy(out[:], h.Sum(nil))
+	return out
 }
 
 // GetBlock returns block by height.
@@ -441,7 +541,7 @@ func (l *Ledger) MintToken(addr Address, tokenID string, amount uint64) error {
 	l.TokenBalances[key] += amount
 
 	// Log the minting event (optional if you use structured logging)
-	log.Printf("Minted %d of token %s to address %s", amount, tokenID, addr.String())
+	logrus.Infof("Minted %d of token %s to address %s", amount, tokenID, addr.String())
 
 	return nil
 }

--- a/synnergy-network/core/ledger_test.go
+++ b/synnergy-network/core/ledger_test.go
@@ -15,11 +15,13 @@ func tmpLedgerConfig(t *testing.T, genesis *Block) (LedgerConfig, func()) {
 	dir := t.TempDir()
 	wal := filepath.Join(dir, "wal.log")
 	snap := filepath.Join(dir, "snap.json")
+	arch := filepath.Join(dir, "archive.gz")
 	cfg := LedgerConfig{
 		WALPath:          wal,
 		SnapshotPath:     snap,
 		SnapshotInterval: 1000, // large to avoid snapshot during tests
 		GenesisBlock:     genesis,
+		ArchivePath:      arch,
 	}
 	cleanup := func() { os.RemoveAll(dir) }
 	return cfg, cleanup
@@ -132,5 +134,63 @@ func TestAppendSubBlock_HeightCheck(t *testing.T) {
 	sbBad := &SubBlock{Header: SubBlockHeader{Height: 0}}
 	if err := led.AppendSubBlock(sbBad); err == nil {
 		t.Fatalf("expected height mismatch error")
+	}
+}
+
+//-------------------------------------------------------------
+// Test pruning archives old blocks
+//-------------------------------------------------------------
+
+func TestPruneArchivesBlocks(t *testing.T) {
+	genesis := &Block{Header: BlockHeader{Height: 0}}
+	cfg, cleanup := tmpLedgerConfig(t, genesis)
+	defer cleanup()
+	cfg.PruneInterval = 2
+	led, err := NewLedger(cfg)
+	if err != nil {
+		t.Fatalf("ledger init: %v", err)
+	}
+
+	// add blocks 1,2,3 - block 0 should be pruned
+	for i := 1; i <= 3; i++ {
+		blk := &Block{Header: BlockHeader{Height: uint64(i)}}
+		if err := led.AddBlock(blk); err != nil {
+			t.Fatalf("add block %d: %v", i, err)
+		}
+	}
+
+	if got := len(led.Blocks); got != 2 {
+		t.Fatalf("expected 2 blocks after prune, got %d", got)
+	}
+
+	// ensure archive file has data
+	info, err := os.Stat(cfg.ArchivePath)
+	if err != nil {
+		t.Fatalf("archive stat: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("archive file empty")
+	}
+}
+
+//-------------------------------------------------------------
+// Test StateRoot determinism
+//-------------------------------------------------------------
+
+func TestStateRootDeterministic(t *testing.T) {
+	cfg, cleanup := tmpLedgerConfig(t, nil)
+	defer cleanup()
+	ledA, _ := NewLedger(cfg)
+	ledA.State["a"] = []byte("1")
+	ledA.State["b"] = []byte("2")
+
+	cfg2, cleanup2 := tmpLedgerConfig(t, nil)
+	defer cleanup2()
+	ledB, _ := NewLedger(cfg2)
+	ledB.State["b"] = []byte("2")
+	ledB.State["a"] = []byte("1")
+
+	if ledA.StateRoot() != ledB.StateRoot() {
+		t.Fatalf("state roots mismatch")
 	}
 }


### PR DESCRIPTION
## Summary
- add configurable block pruning with gzip archiving
- compute deterministic state root for ledger state
- harden WAL snapshot handling and add tests

## Testing
- `go test ./core -run Test -count=1` *(fails: import cycle not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_688d6fefbf04832081053576fdcdcbad