### PR TITLE
refactor: introduce utility package and config loader

### DIFF
--- a/synnergy-network/cmd/cli/audit_node.go
+++ b/synnergy-network/cmd/cli/audit_node.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
 	"sync"
 	"syscall"
 
@@ -17,28 +16,13 @@ import (
 	"github.com/spf13/viper"
 
 	core "synnergy-network/core"
+	"synnergy-network/pkg/utils"
 )
 
 var (
 	audNode *core.AuditNode
 	audMu   sync.RWMutex
 )
-
-func auditEnvOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
-}
-
-func auditEnvOrInt(k string, def int) int {
-	if v := os.Getenv(k); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			return n
-		}
-	}
-	return def
-}
 
 func auditInit(cmd *cobra.Command, _ []string) error {
 	if audNode != nil {
@@ -56,9 +40,9 @@ func auditInit(cmd *cobra.Command, _ []string) error {
 		BootstrapPeers: viper.GetStringSlice("network.bootstrap_peers"),
 		DiscoveryTag:   viper.GetString("network.discovery_tag"),
 	}
-	wal := auditEnvOr("LEDGER_WAL", "./ledger.wal")
-	snap := auditEnvOr("LEDGER_SNAPSHOT", "./ledger.snap")
-	interval := auditEnvOrInt("LEDGER_SNAPSHOT_INTERVAL", 100)
+	wal := utils.EnvOrDefault("LEDGER_WAL", "./ledger.wal")
+	snap := utils.EnvOrDefault("LEDGER_SNAPSHOT", "./ledger.snap")
+	interval := utils.EnvOrDefaultInt("LEDGER_SNAPSHOT_INTERVAL", 100)
 	ledCfg := core.LedgerConfig{WALPath: wal, SnapshotPath: snap, SnapshotInterval: interval}
 	boot := core.BootstrapConfig{Network: netCfg, Ledger: ledCfg, Replication: nil}
 	cfg := core.AuditNodeConfig{Bootstrap: boot, TrailPath: os.Getenv("AUDIT_FILE")}

--- a/synnergy-network/cmd/cli/network.go
+++ b/synnergy-network/cmd/cli/network.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	config "synnergy-network/cmd/config"
 	"synnergy-network/core"
 )
 

--- a/synnergy-network/cmd/cli/virtual_machine.go
+++ b/synnergy-network/cmd/cli/virtual_machine.go
@@ -10,24 +10,24 @@ package cli
 // -----------------------------------------------------------------------------
 
 import (
-    "context"
-    "encoding/hex"
-    "encoding/json"
-    "errors"
-    "fmt"
-    "net/http"
-    "os"
-    "strconv"
-    "time"
-    "sync"
-    "github.com/gorilla/mux"
-    "github.com/joho/godotenv"
-    "github.com/sirupsen/logrus"
-    "github.com/spf13/cobra"
-    "github.com/wasmerio/wasmer-go/wasmer"
-    "golang.org/x/time/rate"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
 
-    "synnergy-network/core"
+	"github.com/gorilla/mux"
+	"github.com/joho/godotenv"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/wasmerio/wasmer-go/wasmer"
+	"golang.org/x/time/rate"
+
+	"synnergy-network/core"
+	"synnergy-network/pkg/utils"
 )
 
 // -----------------------------------------------------------------------------
@@ -35,18 +35,18 @@ import (
 // -----------------------------------------------------------------------------
 
 var (
-    vmState core.StateRW
-    vmImpl  core.VM
-    vmSrv   *http.Server
+	vmState core.StateRW
+	vmImpl  core.VM
+	vmSrv   *http.Server
 
-    runtimeCtx  context.Context
-    runtimeStop context.CancelFunc
+	runtimeCtx  context.Context
+	runtimeStop context.CancelFunc
 
-    vmMode      string
-    vmStartTime time.Time
+	vmMode      string
+	vmStartTime time.Time
 
-    vmOnce   sync.Once
-    vmLogger = logrus.StandardLogger()
+	vmOnce   sync.Once
+	vmLogger = logrus.StandardLogger()
 )
 
 // -----------------------------------------------------------------------------
@@ -54,57 +54,60 @@ var (
 // -----------------------------------------------------------------------------
 
 func vmInit(cmd *cobra.Command, _ []string) error {
-    var err error
-    vmOnce.Do(func() {
-        _ = godotenv.Load()
+	var err error
+	vmOnce.Do(func() {
+		_ = godotenv.Load()
 
-        // logging
-        lvl := vmEnvOr("LOG_LEVEL", "info")
-        lv, e := logrus.ParseLevel(lvl); if e != nil { err = e; return }
-        vmLogger.SetLevel(lv); vmLogger.SetFormatter(&logrus.JSONFormatter{})
+		// logging
+		lvl := utils.EnvOrDefault("LOG_LEVEL", "info")
+		lv, e := logrus.ParseLevel(lvl)
+		if e != nil {
+			err = e
+			return
+		}
+		vmLogger.SetLevel(lv)
+		vmLogger.SetFormatter(&logrus.JSONFormatter{})
 
-        // env config
-        vmMode   = vmEnvOr("VM_MODE", "super-light")
-        listen   := vmEnvOr("VM_LISTEN", ":9090")
-        gasLimit := vmEnvOrUint64("VM_GAS", 8_000_000)
+		// env config
+		vmMode = utils.EnvOrDefault("VM_MODE", "super-light")
+		listen := utils.EnvOrDefault("VM_LISTEN", ":9090")
+		gasLimit := utils.EnvOrDefaultUint64("VM_GAS", 8_000_000)
 
-        // state backend
-        st, e := core.NewInMemory(); if e != nil { err = e; return }
-        vmState = st
+		// state backend
+		st, e := core.NewInMemory()
+		if e != nil {
+			err = e
+			return
+		}
+		vmState = st
 
-        // choose implementation
-        switch vmMode {
-        case "super-light":
-            vmImpl = core.NewSuperLightVM(st)
-        case "light":
-            vmImpl = core.NewLightVM(st, core.NewGasMeter(gasLimit))
-        case "heavy":
-            vmImpl = core.NewHeavyVM(st, core.NewGasMeter(gasLimit), wasmer.NewEngine())
-        default:
-            err = fmt.Errorf("invalid VM_MODE %s", vmMode); return
-        }
+		// choose implementation
+		switch vmMode {
+		case "super-light":
+			vmImpl = core.NewSuperLightVM(st)
+		case "light":
+			vmImpl = core.NewLightVM(st, core.NewGasMeter(gasLimit))
+		case "heavy":
+			vmImpl = core.NewHeavyVM(st, core.NewGasMeter(gasLimit), wasmer.NewEngine())
+		default:
+			err = fmt.Errorf("invalid VM_MODE %s", vmMode)
+			return
+		}
 
-        // router
-        r := mux.NewRouter(); r.Use(vmRateLimit)
-        r.HandleFunc("/execute", vmExecuteHandler).Methods("POST")
+		// router
+		r := mux.NewRouter()
+		r.Use(vmRateLimit)
+		r.HandleFunc("/execute", vmExecuteHandler).Methods("POST")
 
-        vmSrv = &http.Server{
-            Addr:         listen,
-            Handler:      r,
-            ReadTimeout:  5 * time.Second,
-            WriteTimeout: 15 * time.Second,
-            IdleTimeout:  30 * time.Second,
-        }
-    })
-    return err
-}
-
-func vmEnvOr(k, d string) string { if v := os.Getenv(k); v != "" { return v }; return d }
-func vmEnvOrUint64(k string, def uint64) uint64 {
-    if v := os.Getenv(k); v != "" {
-        if n, err := strconv.ParseUint(v, 10, 64); err == nil { return n }
-    }
-    return def
+		vmSrv = &http.Server{
+			Addr:         listen,
+			Handler:      r,
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 15 * time.Second,
+			IdleTimeout:  30 * time.Second,
+		}
+	})
+	return err
 }
 
 // -----------------------------------------------------------------------------
@@ -114,31 +117,38 @@ func vmEnvOrUint64(k string, def uint64) uint64 {
 var vmLimiter = rate.NewLimiter(200, 100)
 
 func vmRateLimit(next http.Handler) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        if !vmLimiter.Allow() {
-            http.Error(w, "rate limit", http.StatusTooManyRequests)
-            return
-        }
-        next.ServeHTTP(w, r)
-    })
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !vmLimiter.Allow() {
+			http.Error(w, "rate limit", http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func vmExecuteHandler(w http.ResponseWriter, r *http.Request) {
-    var req struct {
-        Code string        `json:"bytecode"`
-        Ctx  core.VMContext `json:"ctx"`
-    }
-    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-        http.Error(w, err.Error(), http.StatusBadRequest); return
-    }
-    code, err := hex.DecodeString(req.Code)
-    if err != nil { http.Error(w, err.Error(), http.StatusBadRequest); return }
+	var req struct {
+		Code string         `json:"bytecode"`
+		Ctx  core.VMContext `json:"ctx"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	code, err := hex.DecodeString(req.Code)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
-    rec, err := vmImpl.Execute(code, &req.Ctx)
-    if err != nil { http.Error(w, err.Error(), http.StatusInternalServerError); return }
+	rec, err := vmImpl.Execute(code, &req.Ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
-    w.Header().Set("Content-Type", "application/json")
-    _ = json.NewEncoder(w).Encode(rec)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(rec)
 }
 
 // -----------------------------------------------------------------------------
@@ -146,35 +156,44 @@ func vmExecuteHandler(w http.ResponseWriter, r *http.Request) {
 // -----------------------------------------------------------------------------
 
 func vmHandleStart(cmd *cobra.Command, _ []string) error {
-    if vmSrv == nil { return errors.New("middleware not initialised") }
-    if runtimeCtx != nil { fmt.Fprintln(cmd.OutOrStdout(), "vm already running"); return nil }
+	if vmSrv == nil {
+		return errors.New("middleware not initialised")
+	}
+	if runtimeCtx != nil {
+		fmt.Fprintln(cmd.OutOrStdout(), "vm already running")
+		return nil
+	}
 
-    runtimeCtx, runtimeStop = context.WithCancel(context.Background())
-    go func() {
-        if err := vmSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-            vmLogger.Fatalf("vm http: %v", err)
-        }
-    }()
-    vmStartTime = time.Now()
-    fmt.Fprintf(cmd.OutOrStdout(), "vm started on %s (%s)\n", vmSrv.Addr, vmMode)
-    return nil
+	runtimeCtx, runtimeStop = context.WithCancel(context.Background())
+	go func() {
+		if err := vmSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			vmLogger.Fatalf("vm http: %v", err)
+		}
+	}()
+	vmStartTime = time.Now()
+	fmt.Fprintf(cmd.OutOrStdout(), "vm started on %s (%s)\n", vmSrv.Addr, vmMode)
+	return nil
 }
 
 func vmHandleStop(cmd *cobra.Command, _ []string) error {
-    if runtimeCtx == nil { fmt.Fprintln(cmd.OutOrStdout(), "vm not running"); return nil }
-    runtimeStop()
-    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second); defer cancel()
-    _ = vmSrv.Shutdown(ctx)
-    runtimeCtx, runtimeStop = nil, nil
-    fmt.Fprintln(cmd.OutOrStdout(), "vm stopped")
-    return nil
+	if runtimeCtx == nil {
+		fmt.Fprintln(cmd.OutOrStdout(), "vm not running")
+		return nil
+	}
+	runtimeStop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = vmSrv.Shutdown(ctx)
+	runtimeCtx, runtimeStop = nil, nil
+	fmt.Fprintln(cmd.OutOrStdout(), "vm stopped")
+	return nil
 }
 
 func vmHandleStatus(cmd *cobra.Command, _ []string) error {
-    running := runtimeCtx != nil
-    uptime := time.Since(vmStartTime).Truncate(time.Second)
-    fmt.Fprintf(cmd.OutOrStdout(), "running: %v\nlisten: %s\nmode: %s\nuptime: %s\n", running, vmSrv.Addr, vmMode, uptime)
-    return nil
+	running := runtimeCtx != nil
+	uptime := time.Since(vmStartTime).Truncate(time.Second)
+	fmt.Fprintf(cmd.OutOrStdout(), "running: %v\nlisten: %s\nmode: %s\nuptime: %s\n", running, vmSrv.Addr, vmMode, uptime)
+	return nil
 }
 
 // -----------------------------------------------------------------------------
@@ -193,4 +212,5 @@ func init() { vmRootCmd.AddCommand(vmStartCmd, vmStopCmdVar, vmStatusCmd) }
 // -----------------------------------------------------------------------------
 
 var VMCmd = vmRootCmd
+
 func RegisterVM(root *cobra.Command) { root.AddCommand(VMCmd) }

--- a/synnergy-network/cmd/config/config_guide.md
+++ b/synnergy-network/cmd/config/config_guide.md
@@ -1,13 +1,13 @@
 # Synnergy Configuration Guide
 
-This document describes how to configure a Synnergy node using the YAML files in `cmd/config/`. The configuration loader merges `default.yaml` with an optional environment specific file identified by the `SYNN_ENV` variable. All values can be overridden by environment variables thanks to Viper's `AutomaticEnv` integration and the project `.env` file.
+This document describes how to configure a Synnergy node using the YAML files in `cmd/config/`. The configuration loader merges `default.yaml` with an optional environment specific file identified by the `SYNN_ENV` variable. Applications should call `config.LoadFromEnv()` which implements this behaviour. All values can be overridden by environment variables thanks to Viper's `AutomaticEnv` integration and the project `.env` file.
 
 ## Loading Sequence
 
 1. `default.yaml` is loaded first and establishes sane defaults for development.
 2. If `SYNN_ENV` is set (for example `prod` or `bootstrap`) a file with the same name is merged in.
 3. Environment variables are then applied. Keys use dot notation matching the YAML structure (e.g. `network.max_peers`).
-4. The resulting configuration is unmarshaled into the `FullConfig` struct defined in `config.go` and made available as `config.AppConfig`.
+4. The resulting configuration is unmarshaled into the `Config` struct defined in `pkg/config/config.go` and made available as `config.AppConfig`.
 
 Running the CLI without `SYNN_ENV` uses only the default settings which are safe for local testing.
 
@@ -92,7 +92,7 @@ Configuration for the embedded virtual machine.
 
 ## Environment Files and Overrides
 
-The repository contains a `.env` file with additional variables such as API endpoints and secrets. `LoadConfig` reads these values automatically so they can override YAML fields. Typical variables include `API_BIND`, `GOVERNANCE_API_ADDR`, and `JWT_SECRET`. When running in production make sure to provide secure values for any secrets.
+The repository contains a `.env` file with additional variables such as API endpoints and secrets. `config.Load` reads these values automatically so they can override YAML fields. Typical variables include `API_BIND`, `GOVERNANCE_API_ADDR`, and `JWT_SECRET`. When running in production make sure to provide secure values for any secrets.
 
 ## Example Configurations
 
@@ -130,4 +130,8 @@ At start-up the ledger reads this file and creates the first block with the spec
 ## Conclusion
 
 The configuration system is intentionally simple: a layered YAML approach backed by environment variables. By editing these files and the genesis block you can tailor a Synnergy deployment for local testing, dedicated bootstrap nodes or a full production network.
+
+## API Version
+
+The configuration loader API is currently versioned as **v0.1.0**. Future changes will follow semantic versioning guidelines.
 

--- a/synnergy-network/cmd/synnergy/main.go
+++ b/synnergy-network/cmd/synnergy/main.go
@@ -1,18 +1,19 @@
 package main
 
 import (
-	"os"
-
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	cli "synnergy-network/cmd/cli"
-	config "synnergy-network/cmd/config"
+	config "synnergy-network/pkg/config"
 )
 
 func main() {
 	// Load configuration before command execution so that all CLI modules
 	// have access via viper.
-	config.LoadConfig(os.Getenv("SYNN_ENV"))
+	if _, err := config.LoadFromEnv(); err != nil {
+		log.Fatalf("config: %v", err)
+	}
 
 	rootCmd := &cobra.Command{
 		Use:   "synnergy",

--- a/synnergy-network/pkg/config/README.md
+++ b/synnergy-network/pkg/config/README.md
@@ -1,0 +1,14 @@
+# config
+
+Reusable configuration loader for Synnergy applications.
+
+## Versioning
+
+Current version: v0.1.0
+
+## APIs
+
+- `Load(env string) (*Config, error)`: load configuration for the given environment name.
+- `LoadFromEnv() (*Config, error)`: load configuration using the `SYNN_ENV` environment variable.
+
+The resulting configuration is stored in the package variable `AppConfig`.

--- a/synnergy-network/pkg/utils/README.md
+++ b/synnergy-network/pkg/utils/README.md
@@ -1,0 +1,14 @@
+# utils
+
+Shared utility helpers for the Synnergy project.
+
+## Versioning
+
+Current version: v0.1.0
+
+## APIs
+
+- `Wrap(err error, message string) error`: attach context to errors.
+- `EnvOrDefault(key, fallback string) string`: get an environment variable or a default.
+- `EnvOrDefaultInt(key string, fallback int) int`: parse an integer environment variable with a default.
+- `EnvOrDefaultUint64(key string, fallback uint64) uint64`: parse a `uint64` environment variable with a default.

--- a/synnergy-network/pkg/utils/env.go
+++ b/synnergy-network/pkg/utils/env.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"os"
+	"strconv"
+)
+
+// EnvOrDefault returns the value of the environment variable identified by key
+// or the provided fallback if the variable is unset or empty.
+func EnvOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// EnvOrDefaultInt returns the integer value of the environment variable
+// identified by key or the provided fallback if the variable is unset,
+// empty, or cannot be parsed as an integer.
+func EnvOrDefaultInt(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+// EnvOrDefaultUint64 returns the uint64 value of the environment variable
+// identified by key or the provided fallback if the variable is unset,
+// empty, or cannot be parsed as a uint64.
+func EnvOrDefaultUint64(key string, fallback uint64) uint64 {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 64); err == nil {
+			return n
+		}
+	}
+	return fallback
+}

--- a/synnergy-network/pkg/utils/env_test.go
+++ b/synnergy-network/pkg/utils/env_test.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnvOrDefault(t *testing.T) {
+	const key = "UTIL_TEST_STRING"
+	_ = os.Unsetenv(key)
+	if got := EnvOrDefault(key, "fallback"); got != "fallback" {
+		t.Fatalf("expected fallback, got %q", got)
+	}
+	_ = os.Setenv(key, "value")
+	if got := EnvOrDefault(key, "fallback"); got != "value" {
+		t.Fatalf("expected value, got %q", got)
+	}
+}
+
+func TestEnvOrDefaultInt(t *testing.T) {
+	const key = "UTIL_TEST_INT"
+	_ = os.Unsetenv(key)
+	if got := EnvOrDefaultInt(key, 10); got != 10 {
+		t.Fatalf("expected 10, got %d", got)
+	}
+	_ = os.Setenv(key, "5")
+	if got := EnvOrDefaultInt(key, 10); got != 5 {
+		t.Fatalf("expected 5, got %d", got)
+	}
+	_ = os.Setenv(key, "bad")
+	if got := EnvOrDefaultInt(key, 7); got != 7 {
+		t.Fatalf("expected fallback on parse error, got %d", got)
+	}
+}
+
+func TestEnvOrDefaultUint64(t *testing.T) {
+	const key = "UTIL_TEST_UINT64"
+	_ = os.Unsetenv(key)
+	if got := EnvOrDefaultUint64(key, 99); got != 99 {
+		t.Fatalf("expected 99, got %d", got)
+	}
+	_ = os.Setenv(key, "42")
+	if got := EnvOrDefaultUint64(key, 99); got != 42 {
+		t.Fatalf("expected 42, got %d", got)
+	}
+	_ = os.Setenv(key, "bad")
+	if got := EnvOrDefaultUint64(key, 77); got != 77 {
+		t.Fatalf("expected fallback on parse error, got %d", got)
+	}
+}

--- a/synnergy-network/pkg/utils/errors.go
+++ b/synnergy-network/pkg/utils/errors.go
@@ -1,0 +1,13 @@
+// Package utils provides shared utility helpers used across Synnergy.
+// See Version for the module's semantic version.
+package utils
+
+import "fmt"
+
+// Wrap adds context to an error message. It returns nil if err is nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", message, err)
+}

--- a/synnergy-network/pkg/utils/version.go
+++ b/synnergy-network/pkg/utils/version.go
@@ -1,0 +1,4 @@
+package utils
+
+// Version is the semantic version of the utils package.
+const Version = "v0.1.0"


### PR DESCRIPTION
## Summary
- add `pkg/utils` module with error-wrapping helper and docs
- refactor config loader to return errors and add `LoadFromEnv`
- expand env helpers with integer/uint64 parsing, docs, and tests
- update audit and VM CLI modules to use shared utilities

## Testing
- `go vet ./pkg/utils`
- `go test ./pkg/...`
- `go test ./...` *(fails: import cycle and syntax errors in core modules)*

------
https://chatgpt.com/codex/tasks/task_e_688d70124090832087dea3bb1e0e64d6