### PR TITLE
feat: add audit trail archiving

### DIFF
--- a/synnergy-network/core/audit_management.go
+++ b/synnergy-network/core/audit_management.go
@@ -99,6 +99,15 @@ func (am *AuditManager) Events(addr Address) ([]LedgerAuditEvent, error) {
 	return out, nil
 }
 
+// Archive exports the audit trail to the provided destination path and
+// returns the file path and sha256 checksum of the archived log.
+func (am *AuditManager) Archive(dest string) (string, string, error) {
+	if am == nil || am.trail == nil {
+		return "", "", errors.New("audit trail not configured")
+	}
+	return am.trail.Archive(dest)
+}
+
 // Close closes the underlying AuditTrail if configured.
 func (am *AuditManager) Close() error {
 	if am == nil || am.trail == nil {

--- a/synnergy-network/core/audit_node.go
+++ b/synnergy-network/core/audit_node.go
@@ -82,3 +82,12 @@ func (a *AuditNode) AuditEvents(addr Address) ([]LedgerAuditEvent, error) {
 	}
 	return a.mgr.Events(addr)
 }
+
+// ArchiveTrail exports the audit trail to dest and returns the created path
+// and sha256 checksum of the log file.
+func (a *AuditNode) ArchiveTrail(dest string) (string, string, error) {
+	if a.mgr == nil {
+		return "", "", errors.New("audit manager not initialised")
+	}
+	return a.mgr.Archive(dest)
+}

--- a/synnergy-network/core/audit_trail_test.go
+++ b/synnergy-network/core/audit_trail_test.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAuditTrailArchive(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit.log")
+	at, err := NewAuditTrail(logPath, nil)
+	if err != nil {
+		t.Fatalf("NewAuditTrail: %v", err)
+	}
+	defer at.Close()
+	if err := at.Log("event", map[string]string{"k": "v"}); err != nil {
+		t.Fatalf("Log: %v", err)
+	}
+	outDir := filepath.Join(dir, "archive")
+	if err := os.Mkdir(outDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path, sum, err := at.Archive(outDir)
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	want := fmt.Sprintf("%x", sha256.Sum256(data))
+	if sum != want {
+		t.Fatalf("checksum mismatch: got %s want %s", sum, want)
+	}
+	if _, err := os.Stat(path + ".sha256"); err != nil {
+		t.Fatalf("manifest missing: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add audit trail archiving with SHA256 manifest for certification evidence
- expose archive functionality via audit manager and node
- wire CLI command to export audit trail archives
- return archive checksum to callers
- test audit trail archiving logic

## Testing
- `go test ./...` *(fails: import cycle not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_688d705e284483208fb781ea9a40561c