### PR TITLE
Improve network peer handling and connection pool tests

### DIFF
--- a/synnergy-network/core/connection_pool_test.go
+++ b/synnergy-network/core/connection_pool_test.go
@@ -1,0 +1,93 @@
+package core
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// startTestServer starts a TCP server that accepts connections and returns listener and slice of accepted conns.
+func startTestServer(t *testing.T) (net.Listener, *[]net.Conn) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	conns := &[]net.Conn{}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			*conns = append(*conns, c)
+		}
+	}()
+	return ln, conns
+}
+
+func closeServer(ln net.Listener, conns *[]net.Conn) {
+	ln.Close()
+	for _, c := range *conns {
+		c.Close()
+	}
+}
+
+func TestConnPoolAcquireReuse(t *testing.T) {
+	ln, conns := startTestServer(t)
+	defer closeServer(ln, conns)
+
+	d := NewDialer(50*time.Millisecond, 50*time.Millisecond)
+	cp := NewConnPool(d, 2, time.Second)
+	defer cp.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	c1, err := cp.Acquire(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("acquire1: %v", err)
+	}
+	cp.Release(c1)
+	if got := cp.Stats(); got != 1 {
+		t.Fatalf("expected 1 idle, got %d", got)
+	}
+
+	c2, err := cp.Acquire(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("acquire2: %v", err)
+	}
+	if c1 != c2 {
+		t.Fatalf("expected to reuse connection")
+	}
+	cp.Release(c2)
+	if got := cp.Stats(); got != 1 {
+		t.Fatalf("expected 1 idle after reuse, got %d", got)
+	}
+}
+
+func TestConnPoolReaper(t *testing.T) {
+	ln, conns := startTestServer(t)
+	defer closeServer(ln, conns)
+
+	d := NewDialer(50*time.Millisecond, 50*time.Millisecond)
+	idle := 100 * time.Millisecond
+	cp := NewConnPool(d, 2, idle)
+	defer cp.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	c, err := cp.Acquire(ctx, ln.Addr().String())
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	cp.Release(c)
+	if got := cp.Stats(); got != 1 {
+		t.Fatalf("expected 1 idle, got %d", got)
+	}
+
+	time.Sleep(3 * idle)
+	if got := cp.Stats(); got != 0 {
+		t.Fatalf("expected reaper to close idle connections, got %d", got)
+	}
+}

--- a/synnergy-network/core/network_test.go
+++ b/synnergy-network/core/network_test.go
@@ -1,0 +1,13 @@
+package core
+
+import "testing"
+
+func TestHandleNetworkMessageReplication(t *testing.T) {
+	ClearReplicatedMessages()
+	msg := NetworkMessage{Topic: "test", Content: []byte("payload")}
+	HandleNetworkMessage(msg)
+	msgs := GetReplicatedMessages("test")
+	if len(msgs) != 1 || string(msgs[0]) != "payload" {
+		t.Fatalf("expected replicated payload, got %v", msgs)
+	}
+}


### PR DESCRIPTION
## Summary
- refine mDNS peer discovery to avoid self-connections and duplicate entries
- expose helper functions for in-memory message replication
- add connection pool and replication unit tests
- use RWMutex and structured logging for network message replication

## Testing
- `go test ./core -run TestHandleNetworkMessageReplication -count=1` *(fails: import cycle not allowed)*


------
https://chatgpt.com/codex/tasks/task_e_688d71a0d5748320833f9ddeae3ea27c