### PR TITLE
docs: add UX feedback guide and template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ux_feedback.md
+++ b/.github/ISSUE_TEMPLATE/ux_feedback.md
@@ -1,0 +1,48 @@
+---
+name: UX Feedback
+about: Provide feedback on GUI or CLI usability and accessibility
+labels: ["ux", "feedback"]
+assignees: []
+---
+
+**Component**
+Describe which GUI module or CLI command is affected.
+
+**Issue Description**
+A clear and concise description of the usability or accessibility issue.
+
+**Steps to Reproduce**
+List the steps to experience the issue.
+
+**Expected Behavior**
+Explain what you expected to happen.
+
+**Screenshots or Recordings**
+If applicable, add screenshots or screen recordings to help explain the problem.
+
+**Environment**
+- OS: [e.g. Windows 11]
+- Browser/Terminal: [e.g. Chrome 110, macOS Terminal]
+- Version: [e.g. v0.1.0]
+
+**User Type**
+Identify whether you are a new user, experienced contributor or accessibility tester.
+
+**Impact**
+Describe the severity of this issue (low, medium, high) and how it affects your workflow.
+
+**Proposed Solution**
+Optional suggestions or ideas for improving the experience.
+
+**Accessibility Notes**
+Detail any barriers for assistive technologies such as missing labels or colour-only cues.
+
+**Workaround**
+If you found a temporary workaround, describe it here.
+
+**Regression**
+Did this work in a previous release? If so, specify the version.
+
+**Additional Context**
+Add any other context about the problem here, including suggested improvements.
+

--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -336,6 +336,14 @@ Those tests may require additional environment variables or mock
 implementations; consult the comments within each test file for setup
 instructions.
 
+## User Feedback and UX
+
+Community input guides interface design across the project.
+
+- Report usability and accessibility issues through the [UX Feedback issue template](../.github/ISSUE_TEMPLATE/ux_feedback.md), including environment details, user type and impact.
+- Follow the [UX Feedback Guide](UX_FEEDBACK_GUIDE.md) for the feedback lifecycle, accessibility checklist and metrics.
+- Issues are triaged weekly and outcomes are summarised in a monthly community call where priorities are set and metrics reviewed.
+
 ## Contributing
 
 Development tasks are organised in stages described in

--- a/synnergy-network/UX_FEEDBACK_GUIDE.md
+++ b/synnergy-network/UX_FEEDBACK_GUIDE.md
@@ -1,0 +1,55 @@
+# User Feedback and UX Guide
+
+Stage 23 focuses on collecting feedback from the community and translating it into user experience improvements for both the GUI projects and the CLI tools.
+
+## Feedback Channels
+- **GitHub Issues** – use the [UX Feedback template](../.github/ISSUE_TEMPLATE/ux_feedback.md) for bug reports or enhancement requests.
+- **Discussion Forum** – raise broader UX ideas in the community forum or Discord.
+- **User Interviews** – schedule periodic calls with power users to capture qualitative insights.
+
+## Gathering Feedback
+- Encourage users to describe their workflow, pain points and desired enhancements.
+- Tag issues with `ux` and the relevant component label (e.g. `wallet`, `cli`).
+- Collect environment details and screenshots to help reproduce problems.
+
+## Triage and Prioritisation
+- Review new UX issues in the weekly triage meeting.
+- Classify each issue by impact (`low`, `medium`, `high`) and assign an owner.
+- Link related issues or design documents to provide context.
+
+## Feedback Lifecycle
+1. **Collect** – capture reports from GitHub, forums and interviews.
+2. **Triage** – prioritise and assign owners in the weekly meeting.
+3. **Implement** – develop and review fixes or enhancements.
+4. **Validate** – verify changes with the original reporter or usability tests.
+5. **Close** – merge the change, update release notes and mark the issue resolved.
+
+## Usability Testing
+- Conduct task‑based testing sessions for new features in GUI modules and CLI commands.
+- Observe users completing common tasks and note friction or confusion.
+- Capture timing metrics, error rates and qualitative comments for each session.
+
+## Accessibility Review
+- Verify GUI components against WCAG 2.1 AA guidelines including:
+  - 4.5:1 colour contrast for text
+  - Navigable focus order and keyboard shortcuts
+  - ARIA labels for interactive elements
+  - Alt text for images and icons
+- For CLI tools, ensure commands provide clear help output and avoid colour‑only cues.
+- Test interfaces with screen readers, high‑contrast themes and limited bandwidth scenarios.
+
+## UX Metrics and Reporting
+- Track task completion rates, error counts and satisfaction scores after each release.
+- Monitor accessibility compliance using automated tools and manual audits.
+- Summarise key metrics and closed issues in the monthly community call.
+
+## Onboarding and Interface Refinement
+- Document first‑run experiences for wallets, explorers and CLI setup commands.
+- Provide contextual help and prompts that guide users through initial configuration.
+- Iterate on layout and terminology based on user feedback to reduce learning curves.
+
+## Tracking Improvements
+- Link UX issues to pull requests that address them.
+- Maintain a changelog section highlighting usability and accessibility fixes.
+- Periodically review open feedback to prioritise future enhancements.
+


### PR DESCRIPTION
## Summary
- expand UX feedback guide with lifecycle, accessibility checklist and reporting metrics
- extend UX issue template to capture user type, accessibility notes and regressions
- note weekly triage cadence and monthly UX review calls in README

## Testing
- `go fmt ./...` *(fails: import cycle and syntax errors)*
- `go vet ./...` *(fails: import cycle)*
- `go build ./...` *(fails: import cycle)*
- `go test ./...` *(fails: import cycle)*


------
https://chatgpt.com/codex/tasks/task_e_688d706a28a483209ca7f00354ece780