### PR TITLE
feat(tokens): add allowance transfers and CLI

### DIFF
--- a/synnergy-network/cmd/cli/tokens.go
+++ b/synnergy-network/cmd/cli/tokens.go
@@ -1,104 +1,17 @@
 package cli
 
-// ──────────────────────────────────────────────────────────────────────────────
-// Synthron Tokens CLI – inspect & administer on‑chain assets (collision‑free)
-// ──────────────────────────────────────────────────────────────────────────────
-// Root group   : `tokens`
-// Micro‑routes : list, info, balance, transfer, mint, burn, approve, allowance
-// All handler / command identifiers are uniquely prefixed with **tok*** to avoid
-// name clashes with other CLI modules that expose generic symbols like listCmd.
-// ──────────────────────────────────────────────────────────────────────────────
-
 import (
 	"encoding/hex"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/joho/godotenv"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
-	"synnergy-network/core"
+	Tokens "synnergy-network/core/Tokens"
 )
 
-// -----------------------------------------------------------------------------
-// Globals & middleware (runs once)
-// -----------------------------------------------------------------------------
-
-var (
-	tokLedger *core.Ledger
-	tokLogger = logrus.StandardLogger()
-	tokOnce   sync.Once
-)
-
-func tokInitMiddleware(cmd *cobra.Command, _ []string) error {
-	var err error
-	tokOnce.Do(func() {
-		_ = godotenv.Load()
-		lvl := os.Getenv("LOG_LEVEL")
-		if lvl == "" {
-			lvl = "info"
-		}
-		lv, e := logrus.ParseLevel(lvl)
-		if e != nil {
-			err = e
-			return
-		}
-		tokLogger.SetLevel(lv)
-
-		path := os.Getenv("LEDGER_PATH")
-		if path == "" {
-			err = fmt.Errorf("LEDGER_PATH not set")
-			return
-		}
-		tokLedger, e = core.OpenLedger(path)
-		if e != nil {
-			err = e
-		}
-	})
-	return err
-}
-
-// -----------------------------------------------------------------------------
-// Helper utilities
-// -----------------------------------------------------------------------------
-
-func tokResolveToken(idOrSym string) (core.Token, error) {
-	// by symbol
-	for _, t := range core.GetRegistryTokens() {
-		if strings.EqualFold(t.Meta().Symbol, idOrSym) {
-			return t, nil
-		}
-	}
-	// by id (hex or decimal)
-	if strings.HasPrefix(idOrSym, "0x") {
-		n, err := strconv.ParseUint(idOrSym[2:], 16, 32)
-		if err != nil {
-			return nil, err
-		}
-		tok, ok := core.GetToken(core.TokenID(n))
-		if !ok {
-			return nil, core.ErrInvalidAsset
-		}
-		return tok, nil
-	}
-	n, err := strconv.ParseUint(idOrSym, 10, 32)
-	if err != nil {
-		return nil, err
-	}
-	tok, ok := core.GetToken(core.TokenID(n))
-	if !ok {
-		return nil, core.ErrInvalidAsset
-	}
-	return tok, nil
-}
-
-func tokParseAddr(h string) (core.Address, error) {
-	var a core.Address
+func parseTokAddr(h string) (Tokens.Address, error) {
+	var a Tokens.Address
 	b, err := hex.DecodeString(strings.TrimPrefix(h, "0x"))
 	if err != nil || len(b) != len(a) {
 		return a, fmt.Errorf("bad address")
@@ -107,199 +20,205 @@ func tokParseAddr(h string) (core.Address, error) {
 	return a, nil
 }
 
-// -----------------------------------------------------------------------------
-// Controllers (prefixed names)
-// -----------------------------------------------------------------------------
-
-func tokHandleList(cmd *cobra.Command, _ []string) error {
-	for _, t := range core.GetRegistryTokens() {
-		m := t.Meta()
-		fmt.Fprintf(cmd.OutOrStdout(), "%d\t%s\t%s\t%d\t%d\n", t.ID(), m.Symbol, m.Name, m.Decimals, m.TotalSupply)
+func resolveTok(idOrSym string) (Tokens.Token, Tokens.Metadata, error) {
+	for _, t := range Tokens.GetRegistryTokens() {
+		if m, ok := t.Meta().(Tokens.Metadata); ok {
+			if strings.EqualFold(m.Symbol, idOrSym) {
+				return t, m, nil
+			}
+		}
 	}
-	return nil
+	base := 10
+	if strings.HasPrefix(idOrSym, "0x") {
+		idOrSym = idOrSym[2:]
+		base = 16
+	}
+	n, err := strconv.ParseUint(idOrSym, base, 32)
+	if err != nil {
+		return nil, Tokens.Metadata{}, err
+	}
+	tok, ok := Tokens.GetToken(Tokens.TokenID(n))
+	if !ok {
+		return nil, Tokens.Metadata{}, fmt.Errorf("token not found")
+	}
+	m, _ := tok.Meta().(Tokens.Metadata)
+	return tok, m, nil
 }
-
-func tokHandleInfo(cmd *cobra.Command, args []string) error {
-	tok, err := tokResolveToken(args[0])
-	if err != nil {
-		return err
-	}
-	m := tok.Meta()
-	fmt.Fprintf(cmd.OutOrStdout(), "ID: %d\nSymbol: %s\nName: %s\nDecimals: %d\nStandard: 0x%X\nTotalSupply: %d\nCreated: %s\nFixed: %v\n", tok.ID(), m.Symbol, m.Name, m.Decimals, m.Standard, m.TotalSupply, m.Created.Format(time.RFC3339), m.FixedSupply)
-	return nil
-}
-
-func tokHandleBalance(cmd *cobra.Command, args []string) error {
-	tok, err := tokResolveToken(args[0])
-	if err != nil {
-		return err
-	}
-	addr, err := tokParseAddr(args[1])
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(cmd.OutOrStdout(), "%d\n", tok.BalanceOf(addr))
-	return nil
-}
-
-func tokHandleTransfer(cmd *cobra.Command, args []string) error {
-	tok, err := tokResolveToken(args[0])
-	if err != nil {
-		return err
-	}
-	fromStr, _ := cmd.Flags().GetString("from")
-	toStr, _ := cmd.Flags().GetString("to")
-	amt, _ := cmd.Flags().GetUint64("amt")
-	if fromStr == "" || toStr == "" {
-		return fmt.Errorf("--from and --to required")
-	}
-	from, err := tokParseAddr(fromStr)
-	if err != nil {
-		return err
-	}
-	to, err := tokParseAddr(toStr)
-	if err != nil {
-		return err
-	}
-	if err := tok.Transfer(from, to, amt); err != nil {
-		return err
-	}
-	fmt.Fprintln(cmd.OutOrStdout(), "transfer ok ✔")
-	return nil
-}
-
-func tokHandleMint(cmd *cobra.Command, args []string) error {
-	tok, err := tokResolveToken(args[0])
-	if err != nil {
-		return err
-	}
-	toStr, _ := cmd.Flags().GetString("to")
-	amt, _ := cmd.Flags().GetUint64("amt")
-	to, err := tokParseAddr(toStr)
-	if err != nil {
-		return err
-	}
-	if err := tok.Mint(to, amt); err != nil {
-		return err
-	}
-	fmt.Fprintln(cmd.OutOrStdout(), "mint ok ✔")
-	return nil
-}
-
-func tokHandleBurn(cmd *cobra.Command, args []string) error {
-	tok, err := tokResolveToken(args[0])
-	if err != nil {
-		return err
-	}
-	fromStr, _ := cmd.Flags().GetString("from")
-	amt, _ := cmd.Flags().GetUint64("amt")
-	from, err := tokParseAddr(fromStr)
-	if err != nil {
-		return err
-	}
-	if err := tok.Burn(from, amt); err != nil {
-		return err
-	}
-	fmt.Fprintln(cmd.OutOrStdout(), "burn ok ✔")
-	return nil
-}
-
-func tokHandleApprove(cmd *cobra.Command, args []string) error {
-	tok, err := tokResolveToken(args[0])
-	if err != nil {
-		return err
-	}
-	ownerStr, _ := cmd.Flags().GetString("owner")
-	spenderStr, _ := cmd.Flags().GetString("spender")
-	amt, _ := cmd.Flags().GetUint64("amt")
-	owner, err := tokParseAddr(ownerStr)
-	if err != nil {
-		return err
-	}
-	spender, err := tokParseAddr(spenderStr)
-	if err != nil {
-		return err
-	}
-	if err := tok.Approve(owner, spender, amt); err != nil {
-		return err
-	}
-	fmt.Fprintln(cmd.OutOrStdout(), "approve ok ✔")
-	return nil
-}
-
-func tokHandleAllowance(cmd *cobra.Command, args []string) error {
-	tok, err := tokResolveToken(args[0])
-	if err != nil {
-		return err
-	}
-	owner, err := tokParseAddr(args[1])
-	if err != nil {
-		return err
-	}
-	spender, err := tokParseAddr(args[2])
-	if err != nil {
-		return err
-	}
-	fmt.Fprintf(cmd.OutOrStdout(), "%d\n", tok.Allowance(owner, spender))
-	return nil
-}
-
-// -----------------------------------------------------------------------------
-// Cobra command tree (tok‑prefixed vars)
-// -----------------------------------------------------------------------------
 
 var tokensCmd = &cobra.Command{
-	Use:               "tokens",
-	Short:             "Inspect and administer Synthron tokens",
-	PersistentPreRunE: tokInitMiddleware,
+	Use:   "tokens",
+	Short: "Inspect and administer registered tokens",
 }
 
-var tokListCmd = &cobra.Command{Use: "list", Short: "List tokens", Args: cobra.NoArgs, RunE: tokHandleList}
-var tokInfoCmd = &cobra.Command{Use: "info <id|symbol>", Short: "Token metadata", Args: cobra.ExactArgs(1), RunE: tokHandleInfo}
-var tokBalCmd = &cobra.Command{Use: "balance <tok> <addr>", Short: "Balance", Args: cobra.ExactArgs(2), RunE: tokHandleBalance}
-var tokTransferCmd = &cobra.Command{Use: "transfer <tok>", Short: "Transfer", Args: cobra.ExactArgs(1), RunE: tokHandleTransfer}
-var tokMintCmd = &cobra.Command{Use: "mint <tok>", Short: "Mint (admin)", Args: cobra.ExactArgs(1), RunE: tokHandleMint}
-var tokBurnCmd = &cobra.Command{Use: "burn <tok>", Short: "Burn (admin)", Args: cobra.ExactArgs(1), RunE: tokHandleBurn}
-var tokApproveCmd = &cobra.Command{Use: "approve <tok>", Short: "Approve spender", Args: cobra.ExactArgs(1), RunE: tokHandleApprove}
-var tokAllowanceCmd = &cobra.Command{Use: "allowance <tok> <owner> <spender>", Short: "Allowance", Args: cobra.ExactArgs(3), RunE: tokHandleAllowance}
+var tokListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List registered tokens",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		for _, t := range Tokens.GetRegistryTokens() {
+			if m, ok := t.Meta().(Tokens.Metadata); ok {
+				fmt.Fprintf(cmd.OutOrStdout(), "%d\t%s\t%s\t%d\n", t.ID(), m.Symbol, m.Name, m.TotalSupply)
+			}
+		}
+		return nil
+	},
+}
+
+var tokInfoCmd = &cobra.Command{
+	Use:   "info <id|symbol>",
+	Short: "Show token metadata",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tok, m, err := resolveTok(args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "ID: %d\nSymbol: %s\nName: %s\nDecimals: %d\nTotalSupply: %d\n", tok.ID(), m.Symbol, m.Name, m.Decimals, m.TotalSupply)
+		return nil
+	},
+}
+
+var tokBalanceCmd = &cobra.Command{
+	Use:   "balance <id|symbol> <address>",
+	Short: "Query token balance",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tok, _, err := resolveTok(args[0])
+		if err != nil {
+			return err
+		}
+		addr, err := parseTokAddr(args[1])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%d\n", tok.BalanceOf(addr))
+		return nil
+	},
+}
+
+var tokTransferCmd = &cobra.Command{
+	Use:   "transfer <id|symbol>",
+	Short: "Transfer tokens between accounts",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tok, _, err := resolveTok(args[0])
+		if err != nil {
+			return err
+		}
+		fromStr, _ := cmd.Flags().GetString("from")
+		toStr, _ := cmd.Flags().GetString("to")
+		amt, _ := cmd.Flags().GetUint64("amt")
+		from, err := parseTokAddr(fromStr)
+		if err != nil {
+			return err
+		}
+		to, err := parseTokAddr(toStr)
+		if err != nil {
+			return err
+		}
+		return tok.Transfer(from, to, amt)
+	},
+}
+
+var tokMintCmd = &cobra.Command{
+	Use:   "mint <id|symbol>",
+	Short: "Mint new tokens",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tok, _, err := resolveTok(args[0])
+		if err != nil {
+			return err
+		}
+		toStr, _ := cmd.Flags().GetString("to")
+		amt, _ := cmd.Flags().GetUint64("amt")
+		to, err := parseTokAddr(toStr)
+		if err != nil {
+			return err
+		}
+		return tok.Mint(to, amt)
+	},
+}
+
+var tokBurnCmd = &cobra.Command{
+	Use:   "burn <id|symbol>",
+	Short: "Burn tokens from an address",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tok, _, err := resolveTok(args[0])
+		if err != nil {
+			return err
+		}
+		fromStr, _ := cmd.Flags().GetString("from")
+		amt, _ := cmd.Flags().GetUint64("amt")
+		from, err := parseTokAddr(fromStr)
+		if err != nil {
+			return err
+		}
+		return tok.Burn(from, amt)
+	},
+}
+
+var tokApproveCmd = &cobra.Command{
+	Use:   "approve <id|symbol>",
+	Short: "Approve spender allowance",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tok, _, err := resolveTok(args[0])
+		if err != nil {
+			return err
+		}
+		ownerStr, _ := cmd.Flags().GetString("owner")
+		spenderStr, _ := cmd.Flags().GetString("spender")
+		amt, _ := cmd.Flags().GetUint64("amt")
+		owner, err := parseTokAddr(ownerStr)
+		if err != nil {
+			return err
+		}
+		spender, err := parseTokAddr(spenderStr)
+		if err != nil {
+			return err
+		}
+		return tok.Approve(owner, spender, amt)
+	},
+}
+
+var tokAllowanceCmd = &cobra.Command{
+	Use:   "allowance <id|symbol> <owner> <spender>",
+	Short: "Check approved allowance",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tok, _, err := resolveTok(args[0])
+		if err != nil {
+			return err
+		}
+		owner, err := parseTokAddr(args[1])
+		if err != nil {
+			return err
+		}
+		spender, err := parseTokAddr(args[2])
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%d\n", tok.Allowance(owner, spender))
+		return nil
+	},
+}
 
 func init() {
-	// transfer flags
-	tokTransferCmd.Flags().String("from", "", "sender address")
-	tokTransferCmd.Flags().String("to", "", "recipient address")
+	tokTransferCmd.Flags().String("from", "", "source address")
+	tokTransferCmd.Flags().String("to", "", "destination address")
 	tokTransferCmd.Flags().Uint64("amt", 0, "amount")
-	tokTransferCmd.MarkFlagRequired("from")
-	tokTransferCmd.MarkFlagRequired("to")
-	tokTransferCmd.MarkFlagRequired("amt")
 
-	// mint flags
 	tokMintCmd.Flags().String("to", "", "recipient address")
 	tokMintCmd.Flags().Uint64("amt", 0, "amount")
-	tokMintCmd.MarkFlagRequired("to")
-	tokMintCmd.MarkFlagRequired("amt")
 
-	// burn flags
-	tokBurnCmd.Flags().String("from", "", "holder")
+	tokBurnCmd.Flags().String("from", "", "address to burn from")
 	tokBurnCmd.Flags().Uint64("amt", 0, "amount")
-	tokBurnCmd.MarkFlagRequired("from")
-	tokBurnCmd.MarkFlagRequired("amt")
 
-	// approve flags
 	tokApproveCmd.Flags().String("owner", "", "owner address")
 	tokApproveCmd.Flags().String("spender", "", "spender address")
 	tokApproveCmd.Flags().Uint64("amt", 0, "amount")
-	tokApproveCmd.MarkFlagRequired("owner")
-	tokApproveCmd.MarkFlagRequired("spender")
-	tokApproveCmd.MarkFlagRequired("amt")
 
-	// attach sub‑commands to root
-	tokensCmd.AddCommand(tokListCmd, tokInfoCmd, tokBalCmd, tokTransferCmd, tokMintCmd, tokBurnCmd, tokApproveCmd, tokAllowanceCmd)
+	tokensCmd.AddCommand(tokListCmd, tokInfoCmd, tokBalanceCmd, tokTransferCmd, tokMintCmd, tokBurnCmd, tokApproveCmd, tokAllowanceCmd)
 }
 
-// -----------------------------------------------------------------------------
-// Consolidated export
-// -----------------------------------------------------------------------------
-
 var TokensCmd = tokensCmd
-
-func RegisterTokens(root *cobra.Command) { root.AddCommand(TokensCmd) }

--- a/synnergy-network/core/Tokens/SYN1000.go
+++ b/synnergy-network/core/Tokens/SYN1000.go
@@ -1,8 +1,8 @@
 package Tokens
 
 import (
+	"fmt"
 	"sync"
-	core "synnergy-network/core"
 	"time"
 )
 
@@ -16,23 +16,24 @@ type ReserveEntry struct {
 
 // SYN1000Token defines the stablecoin token with reserve management.
 type SYN1000Token struct {
-	*core.BaseToken
+	*BaseToken
 	mu       sync.RWMutex
 	reserves map[string]*ReserveEntry
 }
 
-// NewSYN1000Token creates a SYN1000 stablecoin bound to the ledger and gas model.
-func NewSYN1000Token(meta core.Metadata, init map[core.Address]uint64, ledger *core.Ledger, gas core.GasCalculator) (*SYN1000Token, error) {
-	tok, err := (core.Factory{}).Create(meta, init)
-	if err != nil {
-		return nil, err
+// NewSYN1000Token creates and registers a SYN1000 stablecoin.
+func NewSYN1000Token(meta Metadata, init map[Address]uint64) *SYN1000Token {
+	if meta.Created.IsZero() {
+		meta.Created = time.Now().UTC()
 	}
-	bt := tok.(*core.BaseToken)
+	bt := &BaseToken{id: deriveID(meta.Standard), meta: meta, balances: NewBalanceTable()}
+	for a, v := range init {
+		bt.balances.Set(bt.id, a, v)
+		bt.meta.TotalSupply += v
+	}
 	sc := &SYN1000Token{BaseToken: bt, reserves: make(map[string]*ReserveEntry)}
-	bt.ledger = ledger
-	bt.gas = gas
-	core.RegisterToken(sc)
-	return sc, nil
+	RegisterToken(sc)
+	return sc
 }
 
 // AddReserve adds collateral to the stablecoin reserve.
@@ -54,7 +55,7 @@ func (t *SYN1000Token) RemoveReserve(asset string, amt uint64) error {
 	defer t.mu.Unlock()
 	r, ok := t.reserves[asset]
 	if !ok || r.Amount < amt {
-		return core.ErrInvalidAsset
+		return fmt.Errorf("insufficient reserve")
 	}
 	r.Amount -= amt
 	r.Updated = time.Now().UTC()

--- a/synnergy-network/core/Tokens/SYN3000.go
+++ b/synnergy-network/core/Tokens/SYN3000.go
@@ -6,7 +6,7 @@ import "time"
 type RentalTokenMetadata struct {
 	TokenID     uint64    `json:"token_id"`
 	PropertyID  string    `json:"property_id"`
-	Tenant      string    `json:"tenant"`
+	Tenant      Address   `json:"tenant"`
 	LeaseStart  time.Time `json:"lease_start"`
 	LeaseEnd    time.Time `json:"lease_end"`
 	MonthlyRent uint64    `json:"monthly_rent"`

--- a/synnergy-network/core/Tokens/Tokens_manual.md
+++ b/synnergy-network/core/Tokens/Tokens_manual.md
@@ -1,1 +1,67 @@
 # Tokens Manual
+
+This document outlines the token standards used throughout the Synnergy
+network.  All token implementations must conform to these conventions to
+ensure interoperability across nodes, wallets and smart contracts.
+
+## Core Concepts
+
+### Address
+
+All tokens operate on 20‑byte account identifiers represented by the
+`Address` type.  The type is defined once in `index.go` and reused across
+the package to avoid duplication and keep the package free from direct
+dependencies on the parent `core` module.
+
+### TokenInterfaces
+
+Every token exposes the `TokenInterfaces` interface.  At minimum a token
+must provide a `Meta` method returning implementation specific metadata.
+Specialised tokens embed this interface to signal compatibility with the
+Synnergy tooling.
+
+### BaseToken and Registry
+
+Common balance and allowance logic is provided by the `BaseToken`
+implementation in `base.go`.  Constructors derive a deterministic token
+ID with `deriveID`, populate initial balances via `NewBalanceTable` and
+register themselves using `RegisterToken` so that other packages can
+discover them by `TokenID`.
+
+#### Allowances
+
+`BaseToken` mirrors ERC‑20 style spending approvals.  The `Approve`
+method sets allowances for third‑party spenders while `TransferFrom`
+consumes those allowances and moves funds on behalf of the owner.
+Allowances are decremented after each successful transfer.
+
+### Standards
+
+The `TokenStandard` enumeration lists all SYN standards.  Each concrete
+token specifies its standard via the `Standard` field in the metadata
+structure.  Implementations must embed this identifier into their token
+ID so that clients can route transactions to the correct handlers.
+
+## Example Tokens
+
+* **SYN10** – Basic currency token providing exchange rate information.
+* **SYN200** – Carbon credit tokens with verification records for
+  environmental projects.
+* **SYN845** – Debt instruments tracking principal, interest and payment
+  history.
+* **SYN1100** – Healthcare record tokens offering fine‑grained access
+  control to encrypted medical data.
+
+Each specialised token should keep its implementation self‑contained and
+only rely on the shared types and interfaces defined within this
+package.  This consolidation simplifies maintenance and ensures that new
+tokens automatically integrate with existing network tooling.
+
+## CLI Integration
+
+The `tokens` command in the CLI provides a uniform interface to inspect
+and administer any registered token.  It supports listing tokens,
+querying balances, transferring funds, minting, burning and managing
+allowances.  Addresses are supplied as hex strings and decoded into the
+common 20‑byte `Address` format.
+

--- a/synnergy-network/core/Tokens/base.go
+++ b/synnergy-network/core/Tokens/base.go
@@ -1,0 +1,257 @@
+package Tokens
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// TokenID uniquely identifies a token instance within the registry.
+type TokenID uint32
+
+// Metadata captures generic token attributes.
+type Metadata struct {
+	Name        string
+	Symbol      string
+	Decimals    uint8
+	Standard    TokenStandard
+	Created     time.Time
+	FixedSupply bool
+	TotalSupply uint64
+}
+
+// Token describes the behaviour common to all token implementations.
+type Token interface {
+	TokenInterfaces
+	ID() TokenID
+	BalanceOf(Address) uint64
+	Transfer(from, to Address, amount uint64) error
+	TransferFrom(owner, spender, to Address, amount uint64) error
+	Allowance(owner, spender Address) uint64
+	Approve(owner, spender Address, amount uint64) error
+	Mint(to Address, amount uint64) error
+	Burn(from Address, amount uint64) error
+}
+
+// BalanceTable maintains balances for many tokens concurrently.
+type BalanceTable struct {
+	mu       sync.RWMutex
+	balances map[TokenID]map[Address]uint64
+}
+
+// NewBalanceTable creates an empty balance table.
+func NewBalanceTable() *BalanceTable {
+	return &BalanceTable{balances: make(map[TokenID]map[Address]uint64)}
+}
+
+// Add increases the balance of an address.
+func (bt *BalanceTable) Add(id TokenID, addr Address, amount uint64) {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+	if bt.balances[id] == nil {
+		bt.balances[id] = make(map[Address]uint64)
+	}
+	bt.balances[id][addr] += amount
+}
+
+// Sub decreases the balance of an address.
+func (bt *BalanceTable) Sub(id TokenID, addr Address, amount uint64) error {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+	if bt.balances[id] == nil || bt.balances[id][addr] < amount {
+		return fmt.Errorf("insufficient balance")
+	}
+	bt.balances[id][addr] -= amount
+	return nil
+}
+
+// Get retrieves the balance for the address.
+func (bt *BalanceTable) Get(id TokenID, addr Address) uint64 {
+	bt.mu.RLock()
+	defer bt.mu.RUnlock()
+	if bt.balances[id] == nil {
+		return 0
+	}
+	return bt.balances[id][addr]
+}
+
+// Set explicitly sets a balance value.
+func (bt *BalanceTable) Set(id TokenID, addr Address, amount uint64) {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+	if bt.balances[id] == nil {
+		bt.balances[id] = make(map[Address]uint64)
+	}
+	bt.balances[id][addr] = amount
+}
+
+// BaseToken provides balance and allowance tracking used by concrete tokens.
+type BaseToken struct {
+	id        TokenID
+	meta      Metadata
+	balances  *BalanceTable
+	allowance map[Address]map[Address]uint64
+	mu        sync.RWMutex
+}
+
+// ID returns the token identifier.
+func (b *BaseToken) ID() TokenID { return b.id }
+
+// Meta returns immutable token metadata.
+func (b *BaseToken) Meta() any { return b.meta }
+
+// BalanceOf retrieves the balance for an address.
+func (b *BaseToken) BalanceOf(a Address) uint64 {
+	if b.balances == nil {
+		return 0
+	}
+	return b.balances.Get(b.id, a)
+}
+
+// Transfer moves funds between accounts.
+func (b *BaseToken) Transfer(from, to Address, amount uint64) error {
+	if b.balances == nil {
+		return fmt.Errorf("balances not initialised")
+	}
+	if err := b.balances.Sub(b.id, from, amount); err != nil {
+		return err
+	}
+	b.balances.Add(b.id, to, amount)
+	return nil
+}
+
+// TransferFrom moves funds on behalf of the owner using an approved allowance.
+func (b *BaseToken) TransferFrom(owner, spender, to Address, amount uint64) error {
+	b.mu.Lock()
+	if b.allowance == nil || b.allowance[owner] == nil || b.allowance[owner][spender] < amount {
+		b.mu.Unlock()
+		return fmt.Errorf("allowance exceeded")
+	}
+	b.allowance[owner][spender] -= amount
+	b.mu.Unlock()
+	if err := b.Transfer(owner, to, amount); err != nil {
+		// roll back allowance on failure
+		b.mu.Lock()
+		b.allowance[owner][spender] += amount
+		b.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+// Allowance returns the approved spend for a spender.
+func (b *BaseToken) Allowance(owner, spender Address) uint64 {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if b.allowance == nil {
+		return 0
+	}
+	if m, ok := b.allowance[owner]; ok {
+		return m[spender]
+	}
+	return 0
+}
+
+// Approve sets the allowance for a spender.
+func (b *BaseToken) Approve(owner, spender Address, amount uint64) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.allowance == nil {
+		b.allowance = make(map[Address]map[Address]uint64)
+	}
+	if b.allowance[owner] == nil {
+		b.allowance[owner] = make(map[Address]uint64)
+	}
+	b.allowance[owner][spender] = amount
+	return nil
+}
+
+// Mint adds new supply to the given address.
+func (b *BaseToken) Mint(to Address, amount uint64) error {
+	if b.meta.FixedSupply {
+		return fmt.Errorf("fixed supply token")
+	}
+	if b.balances == nil {
+		b.balances = NewBalanceTable()
+	}
+	b.balances.Add(b.id, to, amount)
+	b.meta.TotalSupply += amount
+	return nil
+}
+
+// Burn removes supply from the address.
+func (b *BaseToken) Burn(from Address, amount uint64) error {
+	if b.balances == nil {
+		return fmt.Errorf("balances not initialised")
+	}
+	if err := b.balances.Sub(b.id, from, amount); err != nil {
+		return err
+	}
+	if b.meta.TotalSupply >= amount {
+		b.meta.TotalSupply -= amount
+	}
+	return nil
+}
+
+var (
+	regMu sync.RWMutex
+	reg   = make(map[TokenID]Token)
+)
+
+// deriveID returns a deterministic identifier for the given token standard.
+func deriveID(standard TokenStandard) TokenID {
+	return TokenID(0x53000000 | uint32(standard)<<8)
+}
+
+// RegisterToken adds the token to the global registry.
+func RegisterToken(t Token) {
+	regMu.Lock()
+	defer regMu.Unlock()
+	reg[t.ID()] = t
+}
+
+// GetToken retrieves a token by identifier.
+func GetToken(id TokenID) (Token, bool) {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	t, ok := reg[id]
+	return t, ok
+}
+
+// GetRegistryTokens returns all registered tokens sorted by ID.
+func GetRegistryTokens() []Token {
+	regMu.RLock()
+	defer regMu.RUnlock()
+	list := make([]Token, 0, len(reg))
+	for _, t := range reg {
+		list = append(list, t)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].ID() < list[j].ID() })
+	return list
+}
+
+// Factory constructs tokens of various standards.
+type Factory struct{}
+
+// Create instantiates a new token with the provided metadata and initial balances.
+func (Factory) Create(meta Metadata, init map[Address]uint64) (Token, error) {
+	if meta.Created.IsZero() {
+		meta.Created = time.Now().UTC()
+	}
+	id := deriveID(meta.Standard)
+	if _, exists := GetToken(id); exists {
+		return nil, fmt.Errorf("token standard %d already registered", meta.Standard)
+	}
+	bt := &BaseToken{
+		id:       id,
+		meta:     meta,
+		balances: NewBalanceTable(),
+	}
+	for a, v := range init {
+		bt.balances.Set(bt.id, a, v)
+		bt.meta.TotalSupply += v
+	}
+	RegisterToken(bt)
+	return bt, nil
+}

--- a/synnergy-network/core/Tokens/base_test.go
+++ b/synnergy-network/core/Tokens/base_test.go
@@ -1,0 +1,66 @@
+package Tokens
+
+import "testing"
+
+// helper to create distinct addresses
+func addr(b byte) Address {
+	var a Address
+	a[19] = b
+	return a
+}
+
+func TestBaseTokenLifecycle(t *testing.T) {
+	regMu.Lock()
+	reg = make(map[TokenID]Token)
+	regMu.Unlock()
+	owner := addr(1)
+	spender := addr(2)
+	recipient := addr(3)
+
+	meta := Metadata{Name: "TestToken", Symbol: "TT", Decimals: 2, Standard: StdSYN10}
+	tokInt, err := (Factory{}).Create(meta, map[Address]uint64{owner: 100})
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	tok := tokInt.(*BaseToken)
+
+	if bal := tok.BalanceOf(owner); bal != 100 {
+		t.Fatalf("owner balance %d", bal)
+	}
+
+	if err := tok.Transfer(owner, recipient, 40); err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+	if bal := tok.BalanceOf(recipient); bal != 40 {
+		t.Fatalf("recipient balance %d", bal)
+	}
+
+	if err := tok.Approve(owner, spender, 50); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if err := tok.TransferFrom(owner, spender, recipient, 30); err != nil {
+		t.Fatalf("transferFrom: %v", err)
+	}
+	if al := tok.Allowance(owner, spender); al != 20 {
+		t.Fatalf("allowance %d", al)
+	}
+
+	if err := tok.Burn(recipient, 10); err != nil {
+		t.Fatalf("burn: %v", err)
+	}
+	if tok.meta.TotalSupply != 90 {
+		t.Fatalf("total supply %d", tok.meta.TotalSupply)
+	}
+}
+
+func TestFixedSupplyMint(t *testing.T) {
+	regMu.Lock()
+	reg = make(map[TokenID]Token)
+	regMu.Unlock()
+	owner := addr(1)
+	meta := Metadata{Name: "Fixed", Symbol: "FX", Standard: StdSYN20, FixedSupply: true}
+	tok := &BaseToken{id: deriveID(meta.Standard), meta: meta, balances: NewBalanceTable()}
+	if err := tok.Mint(owner, 1); err == nil {
+		t.Fatalf("expected mint to fail for fixed supply")
+	}
+}

--- a/synnergy-network/core/Tokens/syn1100.go
+++ b/synnergy-network/core/Tokens/syn1100.go
@@ -2,10 +2,6 @@ package Tokens
 
 import "time"
 
-// Address defines a 20-byte account identifier compatible with core.Address
-// but declared locally to avoid circular dependencies.
-type Address [20]byte
-
 // HealthcareRecord represents encrypted healthcare data tied to an owner.
 type HealthcareRecord struct {
 	ID        string

--- a/synnergy-network/core/Tokens/syn200.go
+++ b/synnergy-network/core/Tokens/syn200.go
@@ -2,9 +2,6 @@ package Tokens
 
 import "time"
 
-// Address defines a 20 byte account address independent of core dependencies.
-type Address [20]byte
-
 // CarbonCreditMetadata captures details about a carbon credit.
 type CarbonCreditMetadata struct {
 	CreditID  string

--- a/synnergy-network/core/Tokens/syn2600.go
+++ b/synnergy-network/core/Tokens/syn2600.go
@@ -6,7 +6,7 @@ import "time"
 type InvestorTokenMeta struct {
 	TokenID  uint32
 	Asset    string
-	Owner    string
+	Owner    Address
 	Shares   uint64
 	IssuedAt time.Time
 	Expiry   time.Time
@@ -16,8 +16,8 @@ type InvestorTokenMeta struct {
 // InvestorToken provides structures for managing investor rights and returns.
 type InvestorToken struct {
 	MetaData         InvestorTokenMeta
-	OwnershipRecords map[string]uint64
-	ReturnRecords    map[string]uint64
+	OwnershipRecords map[Address]uint64
+	ReturnRecords    map[Address]uint64
 }
 
 // Meta returns the token metadata to satisfy TokenInterfaces.
@@ -27,22 +27,22 @@ func (it *InvestorToken) Meta() any { return it.MetaData }
 func NewInvestorToken(meta InvestorTokenMeta) *InvestorToken {
 	return &InvestorToken{
 		MetaData:         meta,
-		OwnershipRecords: make(map[string]uint64),
-		ReturnRecords:    make(map[string]uint64),
+		OwnershipRecords: make(map[Address]uint64),
+		ReturnRecords:    make(map[Address]uint64),
 	}
 }
 
 // AdjustOwnership sets fractional ownership for the given address.
-func (it *InvestorToken) AdjustOwnership(addr string, shares uint64) {
+func (it *InvestorToken) AdjustOwnership(addr Address, shares uint64) {
 	it.OwnershipRecords[addr] = shares
 }
 
 // RecordReturn adds return amount for the given address.
-func (it *InvestorToken) RecordReturn(addr string, amount uint64) {
+func (it *InvestorToken) RecordReturn(addr Address, amount uint64) {
 	it.ReturnRecords[addr] += amount
 }
 
 // Returns retrieves accumulated returns for the given address.
-func (it *InvestorToken) Returns(addr string) uint64 {
+func (it *InvestorToken) Returns(addr Address) uint64 {
 	return it.ReturnRecords[addr]
 }

--- a/synnergy-network/core/Tokens/syn2800.go
+++ b/synnergy-network/core/Tokens/syn2800.go
@@ -5,8 +5,8 @@ import "time"
 // LifePolicy defines the metadata for a SYN2800 life insurance token.
 type LifePolicy struct {
 	PolicyID       string
-	Insured        string
-	Beneficiary    string
+	Insured        Address
+	Beneficiary    Address
 	Premium        uint64
 	CoverageAmount uint64
 	StartDate      time.Time

--- a/synnergy-network/core/Tokens/syn2900.go
+++ b/synnergy-network/core/Tokens/syn2900.go
@@ -6,7 +6,7 @@ import "time"
 // direct dependencies to prevent cycles.
 type InsurancePolicy struct {
 	ID            string
-	Holder        [20]byte
+	Holder        Address
 	Coverage      string
 	Premium       uint64
 	Payout        uint64
@@ -20,7 +20,7 @@ type InsurancePolicy struct {
 // InsuranceToken exposes the SYN2900 insurance-specific methods.
 type InsuranceToken interface {
 	TokenInterfaces
-	IssuePolicy(holder [20]byte, coverage string, premium, payout, deductible, limit uint64, start, end time.Time) (string, error)
+	IssuePolicy(holder Address, coverage string, premium, payout, deductible, limit uint64, start, end time.Time) (string, error)
 	GetPolicy(id string) (InsurancePolicy, bool)
 	UpdatePolicy(pol InsurancePolicy) error
 	CancelPolicy(id string) error

--- a/synnergy-network/core/Tokens/syn70.go
+++ b/synnergy-network/core/Tokens/syn70.go
@@ -11,7 +11,7 @@ import (
 type SYN70Asset struct {
 	TokenID      uint32            // globally unique token identifier
 	Name         string            // item or currency name
-	Owner        string            // hex encoded owner address
+	Owner        Address           // owner address
 	Balance      uint64            // optional quantity for fungible assets
 	GameID       string            // identifier of the game this asset belongs to
 	Attributes   map[string]string // extensible key/value attributes
@@ -53,7 +53,7 @@ func (t *SYN70Token) RegisterAsset(id string, asset *SYN70Asset) error {
 }
 
 // TransferAsset updates ownership of an existing asset.
-func (t *SYN70Token) TransferAsset(id, newOwner string) error {
+func (t *SYN70Token) TransferAsset(id string, newOwner Address) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	a, ok := t.assets[id]

--- a/synnergy-network/core/Tokens/syn845.go
+++ b/synnergy-network/core/Tokens/syn845.go
@@ -6,8 +6,6 @@ import (
 	"time"
 )
 
-type Address [20]byte
-
 // DebtMetadata stores comprehensive data about a debt instrument.
 type DebtMetadata struct {
 	ID              string

--- a/synnergy-network/core/token_management_syn1000.go
+++ b/synnergy-network/core/token_management_syn1000.go
@@ -4,7 +4,7 @@ import Tokens "synnergy-network/core/Tokens"
 
 // CreateSYN1000 creates a new SYN1000 stablecoin and registers it with the ledger.
 func (tm *TokenManager) CreateSYN1000(meta Metadata, init map[Address]uint64) (TokenID, error) {
-	tok, err := NewSYN1000(meta, init, tm.ledger, tm.gas)
+	tok, err := NewSYN1000(meta, init)
 	if err != nil {
 		return 0, err
 	}

--- a/synnergy-network/core/tokens_syn1000.go
+++ b/synnergy-network/core/tokens_syn1000.go
@@ -14,10 +14,7 @@ type StablecoinToken interface {
 }
 
 // NewSYN1000 creates and registers a SYN1000 stablecoin.
-func NewSYN1000(meta Metadata, init map[Address]uint64, ledger *Ledger, gas GasCalculator) (*Tokens.SYN1000Token, error) {
-	tok, err := Tokens.NewSYN1000Token(meta, init, ledger, gas)
-	if err != nil {
-		return nil, err
-	}
+func NewSYN1000(meta Metadata, init map[Address]uint64) (*Tokens.SYN1000Token, error) {
+	tok := Tokens.NewSYN1000Token(meta, init)
 	return tok, nil
 }


### PR DESCRIPTION
## Summary
- support allowance-based `TransferFrom` and enforce fixed-supply minting in BaseToken
- rewrite token CLI to use new registry with list/info/balance/transfer/mint/burn/approve/allowance commands
- document allowance semantics and CLI usage in token manual and add unit tests

## Testing
- `go test ./core/Tokens`
- `go vet ./core/Tokens`
- `go vet ./cmd/cli` *(fails: syntax error in core/Nodes/index.go)*

------
https://chatgpt.com/codex/tasks/task_e_688d6fb146cc8320b20abf476c720658