### PR TITLE
Add circular import detection script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
 .RECIPEPREFIX := >
 GO_MODULE_DIR := synnergy-network
 
-.PHONY: go-build go-test node-install node-test all
+.PHONY: go-build go-test go-cycle node-install node-test all
 
 go-build:
 >cd $(GO_MODULE_DIR) && go build ./...
 
 go-test:
 >cd $(GO_MODULE_DIR) && go test ./...
+
+go-cycle:
+>./scripts/check_circular_imports.sh
 
 node-install:
 >cd synnergy-network/GUI/token-creation-tool/server && npm ci
@@ -23,4 +26,4 @@ node-test:
 >cd synnergy-network/GUI/storage-marketplace/backend && npm run test --if-present
 >cd synnergy-network/GUI/nft_marketplace/backend && npm run test --if-present
 
-all: go-build node-install
+all: go-build go-cycle node-install

--- a/scripts/check_circular_imports.sh
+++ b/scripts/check_circular_imports.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# check_circular_imports.sh - detects Go import cycles within the module
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MOD_ROOT="$REPO_ROOT/synnergy-network"
+
+cd "$MOD_ROOT"
+
+# Capture output of go list to analyse potential import cycles
+if OUTPUT=$(go list ./... 2>&1); then
+    echo "$OUTPUT" >/dev/null
+    echo "No circular imports detected"
+else
+    echo "$OUTPUT"
+    if echo "$OUTPUT" | grep -qi 'import cycle'; then
+        echo "Circular imports detected"
+    fi
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add script to detect circular imports using `go list`
- wire new `go-cycle` make target and include in default `all` workflow

## Testing
- `./scripts/check_circular_imports.sh`
- `make go-cycle`


------
https://chatgpt.com/codex/tasks/task_e_688d8e2e882c83208f53bd758b5d4efa