### PR TITLE
Add staging deployment validation script

### DIFF
--- a/scripts/staging_validate.sh
+++ b/scripts/staging_validate.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Deploy a staging network and execute a sample transaction to validate the release candidate.
+set -euo pipefail
+
+CONF=${1:-cmd/config/staging.yaml}
+BIN_DIR="$(dirname "$0")/../synnergy-network"
+
+cd "$BIN_DIR"
+GOFLAGS="-trimpath" go build -o synnergy ./cmd/synnergy
+
+SYNN_ENV=staging ./synnergy testnet start "$CONF" &
+NET_PID=$!
+
+cleanup() {
+  kill "$NET_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Allow network time to start
+sleep 5
+
+# Execute a token transfer transaction as a basic validation
+./cmd/scripts/token_transfer.sh "SYNN" "addr1" "addr2" 1
+
+wait "$NET_PID"

--- a/synnergy-network/cmd/config/config_guide.md
+++ b/synnergy-network/cmd/config/config_guide.md
@@ -122,10 +122,11 @@ At start-up the ledger reads this file and creates the first block with the spec
 
 ## Creating a New Configuration
 
-1. Copy `default.yaml` to a new file name such as `staging.yaml`.
+1. Copy `default.yaml` to a new file name such as `staging.yaml`. An example `staging.yaml` is included in this repository for release candidate testing.
 2. Modify any fields required for your environment—commonly the `genesis_file` path and `bootstrap_peers`.
 3. Set `SYNN_ENV=staging` before running the `synnergy` binary.
 4. Optionally create or edit a `.env` file to supply secrets and service endpoints.
+5. Use `../scripts/staging_validate.sh` to spin up the staging network and run a sample token transfer.
 
 ## Conclusion
 

--- a/synnergy-network/cmd/config/staging.yaml
+++ b/synnergy-network/cmd/config/staging.yaml
@@ -1,0 +1,27 @@
+network:
+  id: synnergy-staging
+  chain_id: 1216
+  max_peers: 50
+  genesis_file: config/genesis.json
+  rpc_enabled: true
+  p2p_port: 30304
+  listen_addr: "/ip4/0.0.0.0/tcp/4002"
+  discovery_tag: synnergy-staging
+  bootstrap_peers: []
+
+consensus:
+  type: pos
+  block_time_ms: 3000
+  validators_required: 3
+
+vm:
+  max_gas_per_block: 8000000
+  opcode_debug: false
+
+storage:
+  db_path: ./data/staging_db
+  prune: true
+
+logging:
+  level: info
+  file: logs/staging.log


### PR DESCRIPTION
## Summary
- add example `staging.yaml` configuration for release candidate testing
- provide `staging_validate.sh` to start a staging network and run a sample token transfer
- document staging workflow in config guide

## Testing
- `/tmp/shellcheck-v0.9.0/shellcheck scripts/staging_validate.sh`
- `go build ./...` *(fails: undefined types and redeclared identifiers)*

------
https://chatgpt.com/codex/tasks/task_e_688d8f005790832099179d2a8d7e503f