### PR TITLE
Optimize env lookup utilities

### DIFF
--- a/synnergy-network/pkg/utils/env.go
+++ b/synnergy-network/pkg/utils/env.go
@@ -1,39 +1,39 @@
 package utils
 
 import (
-	"os"
-	"strconv"
+        "os"
+        "strconv"
 )
 
 // EnvOrDefault returns the value of the environment variable identified by key
 // or the provided fallback if the variable is unset or empty.
 func EnvOrDefault(key, fallback string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return fallback
+        if v, ok := os.LookupEnv(key); ok && v != "" {
+                return v
+        }
+        return fallback
 }
 
 // EnvOrDefaultInt returns the integer value of the environment variable
 // identified by key or the provided fallback if the variable is unset,
 // empty, or cannot be parsed as an integer.
 func EnvOrDefaultInt(key string, fallback int) int {
-	if v := os.Getenv(key); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			return n
-		}
-	}
-	return fallback
+        if v, ok := os.LookupEnv(key); ok && v != "" {
+                if n, err := strconv.Atoi(v); err == nil {
+                        return n
+                }
+        }
+        return fallback
 }
 
 // EnvOrDefaultUint64 returns the uint64 value of the environment variable
 // identified by key or the provided fallback if the variable is unset,
 // empty, or cannot be parsed as a uint64.
 func EnvOrDefaultUint64(key string, fallback uint64) uint64 {
-	if v := os.Getenv(key); v != "" {
-		if n, err := strconv.ParseUint(v, 10, 64); err == nil {
-			return n
-		}
-	}
-	return fallback
+        if v, ok := os.LookupEnv(key); ok && v != "" {
+                if n, err := strconv.ParseUint(v, 10, 64); err == nil {
+                        return n
+                }
+        }
+        return fallback
 }

--- a/synnergy-network/pkg/utils/env_benchmark_test.go
+++ b/synnergy-network/pkg/utils/env_benchmark_test.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+    "os"
+    "testing"
+)
+
+func BenchmarkEnvOrDefault(b *testing.B) {
+    os.Unsetenv("BENCH_KEY")
+    b.ReportAllocs()
+    for i := 0; i < b.N; i++ {
+        EnvOrDefault("BENCH_KEY", "fallback")
+    }
+}
+
+func BenchmarkEnvOrDefaultInt(b *testing.B) {
+    os.Setenv("BENCH_INT", "123")
+    b.ReportAllocs()
+    for i := 0; i < b.N; i++ {
+        EnvOrDefaultInt("BENCH_INT", 0)
+    }
+}
+
+func BenchmarkEnvOrDefaultUint64(b *testing.B) {
+    os.Setenv("BENCH_UINT", "123")
+    b.ReportAllocs()
+    for i := 0; i < b.N; i++ {
+        EnvOrDefaultUint64("BENCH_UINT", 0)
+    }
+}
+


### PR DESCRIPTION
## Summary
- speed up environment helper functions by using `os.LookupEnv`
- add benchmarks for environment helpers
- profile environment helpers with `pprof`

## Testing
- `go test`
- `go test -bench EnvOr -benchmem -cpuprofile=cpu.out -memprofile mem.out`
- `go tool pprof -top cpu.out`
- `go tool pprof -top mem.out`


------
https://chatgpt.com/codex/tasks/task_e_688d8ee784b48320b1be201475dbb3ce