### PR TITLE
chore: enforce secure randomness and hashing

### DIFF
--- a/synnergy-network/core/kademlia.go
+++ b/synnergy-network/core/kademlia.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"math/big"
 	"sort"
 	"sync"
@@ -15,6 +15,13 @@ type Kademlia struct {
 	buckets [160][]NodeID
 	store   map[[20]byte][]byte
 	mu      sync.RWMutex
+}
+
+func hash160(data []byte) [20]byte {
+	sum := sha256.Sum256(data)
+	var h [20]byte
+	copy(h[:], sum[:20])
+	return h
 }
 
 // NewKademlia creates a new Kademlia instance bound to the given node ID.
@@ -42,10 +49,10 @@ func (k *Kademlia) AddPeer(id NodeID) {
 	k.buckets[idx] = append(list, id)
 }
 
-// Store saves a value under the given key. The key is hashed with SHA1 to
+// Store saves a value under the given key. The key is hashed with SHA-256 (truncated to 160 bits) to
 // produce the internal 160 bit key used by the DHT.
 func (k *Kademlia) Store(key string, value []byte) {
-	var hash [20]byte = sha1.Sum([]byte(key))
+	hash := hash160([]byte(key))
 	k.mu.Lock()
 	k.store[hash] = append([]byte(nil), value...)
 	k.mu.Unlock()
@@ -53,7 +60,7 @@ func (k *Kademlia) Store(key string, value []byte) {
 
 // Lookup retrieves a value by key. It returns the value and true if present.
 func (k *Kademlia) Lookup(key string) ([]byte, bool) {
-	var hash [20]byte = sha1.Sum([]byte(key))
+	hash := hash160([]byte(key))
 	k.mu.RLock()
 	val, ok := k.store[hash]
 	k.mu.RUnlock()
@@ -88,8 +95,8 @@ func (k *Kademlia) Nearest(target NodeID, count int) []NodeID {
 }
 
 func (k *Kademlia) bucketIndex(id NodeID) int {
-	a := sha1.Sum([]byte(k.id))
-	b := sha1.Sum([]byte(id))
+	a := hash160([]byte(k.id))
+	b := hash160([]byte(id))
 	var diff [20]byte
 	for i := 0; i < len(diff); i++ {
 		diff[i] = a[i] ^ b[i]
@@ -102,8 +109,8 @@ func (k *Kademlia) bucketIndex(id NodeID) int {
 }
 
 func (k *Kademlia) distance(a NodeID, b NodeID) *big.Int {
-	aa := sha1.Sum([]byte(a))
-	bb := sha1.Sum([]byte(b))
+	aa := hash160([]byte(a))
+	bb := hash160([]byte(b))
 	var diff [20]byte
 	for i := 0; i < len(diff); i++ {
 		diff[i] = aa[i] ^ bb[i]

--- a/synnergy-network/core/wallet.go
+++ b/synnergy-network/core/wallet.go
@@ -17,6 +17,7 @@ package core
 import (
 	"crypto/ed25519"
 	"crypto/hmac"
+	crand "crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/binary"
@@ -26,7 +27,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	bip39 "github.com/tyler-smith/go-bip39"
 	"golang.org/x/crypto/ripemd160"
-	"math/rand"
 	"time"
 )
 
@@ -239,7 +239,7 @@ func RandomMnemonicEntropy(bits int) ([]byte, error) {
 		return nil, errors.New("entropy bits must be multiple of 32")
 	}
 	b := make([]byte, bits/8)
-	if _, err := rand.Read(b); err != nil {
+	if _, err := crand.Read(b); err != nil {
 		return nil, err
 	}
 	return b, nil


### PR DESCRIPTION
## Summary
- switch wallet entropy to `crypto/rand`
- use cryptographically secure shuffle for authority and peer selection
- replace SHA-1 with truncated SHA-256 in Kademlia DHT

## Testing
- `gosec ./core/... 2>&1 | tail -n 20`
- `go vet ./core/...` *(fails: other declaration of ResourceAllocator, etc.)*
- `go mod verify`


------
https://chatgpt.com/codex/tasks/task_e_688d8ec30f708320929db1ad06701bfd