### PR TITLE
refactor: organise integration and bridge helpers

### DIFF
--- a/synnergy-network/core/integration_node.go
+++ b/synnergy-network/core/integration_node.go
@@ -5,10 +5,13 @@ import Nodes "synnergy-network/core/Nodes"
 // IntegrationNode extends a network node with facilities to track external APIs
 // and blockchain bridges. The struct lives in the core package to avoid import
 // cycles with the Nodes subpackage.
+// IntegrationNode represents a network participant that can interface with
+// external APIs and other blockchains. JSON tags are provided for clarity when
+// serialising this structure.
 type IntegrationNode struct {
-	Nodes.NodeInterface
-	Ledger   *Ledger
-	Registry *IntegrationRegistry
+	Nodes.NodeInterface `json:"-"`
+	Ledger              *Ledger              `json:"ledger"`
+	Registry            *IntegrationRegistry `json:"registry"`
 }
 
 // NewIntegrationNode creates a new instance using the provided network node and

--- a/synnergy-network/core/plasma_operations.go
+++ b/synnergy-network/core/plasma_operations.go
@@ -73,7 +73,7 @@ func (p *BridgeCoordinator) Deposit(from Address, token TokenID, amount uint64, 
 	if !ok {
 		return PlasmaBridgeDeposit{}, errors.New("token unknown")
 	}
-	bridge := bridgeAccount(token)
+	bridge := plasmaBridgeAccount(token)
 	if err := tok.Transfer(from, bridge, amount); err != nil {
 		return PlasmaBridgeDeposit{}, err
 	}
@@ -100,7 +100,7 @@ func (p *BridgeCoordinator) StartExit(owner Address, token TokenID, amount uint6
 	if amount == 0 {
 		return PlasmaBridgeExit{}, errors.New("zero amount")
 	}
-	bridge := bridgeAccount(token)
+	bridge := plasmaBridgeAccount(token)
 	bal := p.Ledger.BalanceOf(bridge)
 	if bal < amount {
 		return PlasmaBridgeExit{}, fmt.Errorf("insufficient bridge balance: %d", bal)
@@ -140,7 +140,7 @@ func (p *BridgeCoordinator) FinalizeExit(nonce uint64) error {
 	if !ok {
 		return errors.New("token unknown")
 	}
-	bridge := bridgeAccount(ex.Token)
+	bridge := plasmaBridgeAccount(ex.Token)
 	if err := tok.Transfer(bridge, ex.Owner, ex.Amount); err != nil {
 		return err
 	}
@@ -187,7 +187,10 @@ func (p *BridgeCoordinator) ListExits(owner Address) ([]PlasmaBridgeExit, error)
 	return out, nil
 }
 
-func bridgeAccount(token TokenID) Address {
+// plasmaBridgeAccount returns the address used as a bridge for Plasma
+// operations. It includes a distinct prefix to avoid collisions with other
+// bridge types.
+func plasmaBridgeAccount(token TokenID) Address {
 	var a Address
 	copy(a[:4], []byte("PLSM"))
 	a[4] = byte(token >> 24)

--- a/synnergy-network/core/sidechains.go
+++ b/synnergy-network/core/sidechains.go
@@ -113,7 +113,7 @@ func (sc *SidechainCoordinator) Deposit(chain SidechainID, from Address, to []by
 		return DepositReceipt{}, errors.New("zero amount")
 	}
 	// escrow: transfer from user to bridge account
-	bridgeAcct := bridgeAccount(chain, token)
+	bridgeAcct := sidechainBridgeAccount(chain, token)
 	tok, ok := GetToken(token)
 	if !ok {
 		return DepositReceipt{}, errors.New("token unknown")
@@ -214,7 +214,7 @@ func (sc *SidechainCoordinator) VerifyWithdraw(p WithdrawProof) error {
 	}
 
 	// release funds from escrow
-	bridgeAcct := bridgeAccount(p.Header.ChainID, payload.Token)
+	bridgeAcct := sidechainBridgeAccount(p.Header.ChainID, payload.Token)
 	tok, _ := GetToken(payload.Token)
 	if err := tok.Transfer(bridgeAcct, p.Recipient, payload.Amount); err != nil {
 		return err
@@ -297,7 +297,11 @@ func depositKey(id SidechainID, n uint64) []byte {
 	return append([]byte("sc:dep:"), b...)
 }
 func withdrawnKey(hash [32]byte) []byte { return append([]byte("sc:wd:"), hash[:]...) }
-func bridgeAccount(id SidechainID, token TokenID) Address {
+
+// sidechainBridgeAccount derives the special bridge account used for transfers
+// between the main chain and a given sidechain. The unique prefix ensures the
+// address space does not collide with other bridge mechanisms.
+func sidechainBridgeAccount(id SidechainID, token TokenID) Address {
 	var a Address
 	copy(a[:4], []byte("BRG1"))
 	binary.BigEndian.PutUint32(a[4:], uint32(id))


### PR DESCRIPTION
## Summary
- move IntegrationNode into core package and document JSON tags
- rename bridge account helpers to avoid collisions
- split AES-GCM helpers from content node to prevent function redeclarations

## Testing
- `go list -deps ./...`
- `go mod tidy`
- `go build ./...` *(fails: ResourceAllocator redeclared; RentalAgreement redeclared; reputationTokenID redeclared; InsurancePolicy redeclared; BetRecord redeclared; SaleRecord redeclared; stakePrefix redeclared; BalanceTable redeclared; regMu redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_688d8eb7a1748320bed64a814aba024b