### PR TITLE
feat(cli): validate transaction and faucet flags

### DIFF
--- a/synnergy-network/cmd/cli/faucet.go
+++ b/synnergy-network/cmd/cli/faucet.go
@@ -74,11 +74,33 @@ var faucetConfigCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Update faucet parameters",
 	Args:  cobra.NoArgs,
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
+		if !cmd.Flags().Changed("amount") && !cmd.Flags().Changed("cooldown") {
+			return fmt.Errorf("provide at least one of --amount or --cooldown")
+		}
+		if cmd.Flags().Changed("amount") {
+			amt, _ := cmd.Flags().GetUint64("amount")
+			if amt == 0 {
+				return fmt.Errorf("--amount must be greater than 0")
+			}
+		}
+		if cmd.Flags().Changed("cooldown") {
+			cd, _ := cmd.Flags().GetDuration("cooldown")
+			if cd <= 0 {
+				return fmt.Errorf("--cooldown must be positive")
+			}
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		amt, _ := cmd.Flags().GetUint64("amount")
 		cd, _ := cmd.Flags().GetDuration("cooldown")
-		faucet.SetAmount(amt)
-		faucet.SetCooldown(cd)
+		if cmd.Flags().Changed("amount") {
+			faucet.SetAmount(amt)
+		}
+		if cmd.Flags().Changed("cooldown") {
+			faucet.SetCooldown(cd)
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), "updated")
 		return nil
 	},

--- a/synnergy-network/cmd/cli/transactions.go
+++ b/synnergy-network/cmd/cli/transactions.go
@@ -325,9 +325,28 @@ var txCreateCmd = &cobra.Command{
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		cf := txCreateFlags{}
 		cf.to, _ = cmd.Flags().GetString("to")
+		if cf.to == "" {
+			return fmt.Errorf("--to required")
+		}
+		if _, err := core.StringToAddress(cf.to); err != nil {
+			return fmt.Errorf("invalid --to address: %w", err)
+		}
+
 		cf.value, _ = cmd.Flags().GetUint64("value")
+		if cf.value == 0 {
+			return fmt.Errorf("--value must be greater than 0")
+		}
+
 		cf.gasLimit, _ = cmd.Flags().GetUint64("gas")
+		if cf.gasLimit == 0 {
+			return fmt.Errorf("--gas must be greater than 0")
+		}
+
 		cf.gasPrice, _ = cmd.Flags().GetUint64("price")
+		if cf.gasPrice == 0 {
+			return fmt.Errorf("--price must be greater than 0")
+		}
+
 		cf.nonce, _ = cmd.Flags().GetUint64("nonce")
 		cf.payload, _ = cmd.Flags().GetString("payload")
 		cf.txType, _ = cmd.Flags().GetString("type")
@@ -396,7 +415,9 @@ var txPoolCmd = &cobra.Command{
 func init() {
 	// create flags
 	txCreateCmd.Flags().String("to", "", "hex recipient address (0x…)")
+	txCreateCmd.MarkFlagRequired("to")
 	txCreateCmd.Flags().Uint64("value", 0, "value in wei")
+	txCreateCmd.MarkFlagRequired("value")
 	txCreateCmd.Flags().Uint64("gas", 21_000, "gas limit")
 	txCreateCmd.Flags().Uint64("price", 1, "gas price in wei")
 	txCreateCmd.Flags().Uint64("nonce", 0, "transaction nonce")


### PR DESCRIPTION
## Summary
- enforce required `--to`/`--value` flags and positive gas/price in `tx create`
- ensure `faucet config` requires valid non-zero amount or cooldown values

## Testing
- `go build ./cmd/cli` *(fails: encrypt redeclared in core/content_node_impl.go)*

------
https://chatgpt.com/codex/tasks/task_e_688d8e795db88320a9bfd4d91360ddf0