### PR TITLE
chore: standardize logging for ledger and loanpool CLI

### DIFF
--- a/synnergy-network/cmd/cli/loanpool.go
+++ b/synnergy-network/cmd/cli/loanpool.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"log"
 
 	core "synnergy-network/core"
 )
@@ -100,7 +98,7 @@ var lpSubmitCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Println("proposal", id.Hex())
+		logrus.WithField("proposal_id", id.Hex()).Info("proposal submitted")
 		return nil
 	},
 }

--- a/synnergy-network/core/ledger.go
+++ b/synnergy-network/core/ledger.go
@@ -153,15 +153,28 @@ func (l *Ledger) MintBig(addr []byte, amount *big.Int) {
 }
 
 func (l *Ledger) EmitApproval(tokenID TokenID, owner, spender Address, amount uint64) {
-	fmt.Printf("[EmitApproval] token: %v, owner: %v, spender: %v, amount: %d\n", tokenID, owner, spender, amount)
+	logrus.WithFields(logrus.Fields{
+		"token":   tokenID,
+		"owner":   owner,
+		"spender": spender,
+		"amount":  amount,
+	}).Info("EmitApproval")
 }
 
 func (l *Ledger) EmitTransfer(tokenID TokenID, from, to Address, amount uint64) {
-	fmt.Printf("[EmitTransfer] token: %v, from: %v, to: %v, amount: %d\n", tokenID, from, to, amount)
+	logrus.WithFields(logrus.Fields{
+		"token":  tokenID,
+		"from":   from,
+		"to":     to,
+		"amount": amount,
+	}).Info("EmitTransfer")
 }
 
 func (l *Ledger) DeductGas(addr Address, amount uint64) {
-	fmt.Printf("[DeductGas] from: %v, gas: %d\n", addr, amount)
+	logrus.WithFields(logrus.Fields{
+		"from": addr,
+		"gas":  amount,
+	}).Info("DeductGas")
 }
 
 func (l *Ledger) WithinBlock(fn func() error) error {


### PR DESCRIPTION
## Summary
- replace fmt-based ledger event prints with structured logrus logging
- use logrus in loanpool CLI and clean up imports

## Testing
- `go fmt ./core/ledger.go`
- `go fmt ./cmd/cli/loanpool.go`
- `go build ./core` *(fails: encrypt/decrypt redeclarations and other conflicts)*
- `go build ./cmd/cli` *(fails: encrypt/decrypt redeclarations and other conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_688d8e52155083208d3d0338dd68e652