### PR TITLE
Add resource cleanup for AI and health checks

### DIFF
--- a/synnergy-network/cmd/cli/ai.go
+++ b/synnergy-network/cmd/cli/ai.go
@@ -154,6 +154,7 @@ var aiCmd = &cobra.Command{
 	Use:               "ai",
 	Short:             "On‑chain AI utilities (fraud, fees, model marketplace)",
 	PersistentPreRunE: ensureAIInitialised,
+	PersistentPostRun: func(cmd *cobra.Command, args []string) { core.ShutdownAI() },
 }
 
 // predict --------------------------------------------------------------------

--- a/synnergy-network/core/ai.go
+++ b/synnergy-network/core/ai.go
@@ -101,6 +101,22 @@ func InitAI(led StateRW, grpcEndpoint string, client AIStubClient) error {
 
 func AI() *AIEngine { return engine }
 
+// Close releases the underlying gRPC connection.
+func (ai *AIEngine) Close() error {
+	if ai == nil || ai.conn == nil {
+		return nil
+	}
+	return ai.conn.Close()
+}
+
+// ShutdownAI closes the singleton AI engine if initialised.
+func ShutdownAI() {
+	if engine != nil {
+		_ = engine.Close()
+		engine = nil
+	}
+}
+
 //---------------------------------------------------------------------
 // PredictAnomaly – returns fraud risk [0,1]; triggers compliance if threshold crossed.
 //---------------------------------------------------------------------

--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -247,6 +247,7 @@ type HealthChecker struct {
 	maxMisses int
 	ping      Pinger
 	changer   ViewChanger
+	stop      chan struct{}
 }
 
 type PeerInfo struct {

--- a/synnergy-network/core/disaster_recovery_node.go
+++ b/synnergy-network/core/disaster_recovery_node.go
@@ -59,6 +59,9 @@ func (d *DisasterRecoveryNode) Stop() error {
 	if d.backup != nil {
 		d.backup.Stop()
 	}
+	if d.recovery != nil {
+		d.recovery.Stop()
+	}
 	return d.Close()
 }
 

--- a/synnergy-network/tests/fault_tolerance_test.go
+++ b/synnergy-network/tests/fault_tolerance_test.go
@@ -60,6 +60,7 @@ func newHC(interval time.Duration, p Pinger, c ViewChanger, peers []Address) *He
 		maxMisses: 3,
 		ping:      p,
 		changer:   c,
+		stop:      make(chan struct{}),
 	}
 	for _, peer := range peers {
 		hc.peers[peer] = &peerStat{}


### PR DESCRIPTION
## Summary
- add stoppable ticker to HealthChecker and wire cleanup through RecoveryManager and disaster recovery node
- expose AIEngine shutdown and close gRPC connections
- ensure CLI AI commands tear down the engine after execution

## Testing
- `go test ./...` *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688d8e45a0b08320a2e20c532e1a923f