### PR TITLE
chore: align json struct tags

### DIFF
--- a/synnergy-network/core/coin.go
+++ b/synnergy-network/core/coin.go
@@ -32,7 +32,7 @@ func NewCoin(lg *Ledger) (*Coin, error) {
 
 	// extract the TokenBalances field
 	var state struct {
-		TokenBalances map[string]uint64 `json:"TokenBalances"`
+		TokenBalances map[string]uint64 `json:"token_balances"`
 	}
 	if err := json.Unmarshal(snap, &state); err != nil {
 		return nil, fmt.Errorf("coin: failed to unmarshal snapshot: %w", err)

--- a/synnergy-network/core/storage.go
+++ b/synnergy-network/core/storage.go
@@ -150,8 +150,8 @@ func (s *Storage) Pin(ctx context.Context, data []byte, payer Address) (string, 
 	}
 
 	var meta struct {
-		Hash string `json:"Hash"`
-		Size string `json:"Size"`
+		Hash string `json:"hash"`
+		Size string `json:"size"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
 		return "", 0, fmt.Errorf("decode: %w", err)

--- a/synnergy-network/tests/sidechain_test.go
+++ b/synnergy-network/tests/sidechain_test.go
@@ -266,9 +266,9 @@ func TestVerifyWithdraw(t *testing.T) {
 
 	recipient := scAddr(0x99)
 	payload := struct {
-		Recipient Address `json:"Recipient"`
-		Token     TokenID `json:"Token"`
-		Amount    uint64  `json:"Amount"`
+		Recipient Address `json:"recipient"`
+		Token     TokenID `json:"token"`
+		Amount    uint64  `json:"amount"`
 	}{Recipient: recipient, Token: 1, Amount: 42}
 	txData, _ := json.Marshal(payload)
 


### PR DESCRIPTION
## Summary
- normalize JSON tags in storage meta struct
- correct token balances snapshot tags
- use lowercase JSON fields in sidechain test payload

## Testing
- `go test ./...` *(fails: undefined identifiers and package build errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d8e195ce4832091bb4a91f4746d96