### PR TITLE
refactor: align naming with Go conventions

### DIFF
--- a/synnergy-network/core/SYN2369.go
+++ b/synnergy-network/core/SYN2369.go
@@ -69,10 +69,10 @@ func (t *SYN2369Token) TransferItem(id uint64, from, to Address) error {
 	defer t.mu.Unlock()
 	it, ok := t.items[id]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	if it.Owner != from {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	if err := t.Transfer(from, to, 1); err != nil {
 		return err
@@ -87,7 +87,7 @@ func (t *SYN2369Token) UpdateAttributes(id uint64, attrs map[string]string) erro
 	defer t.mu.Unlock()
 	it, ok := t.items[id]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	if it.Attributes == nil {
 		it.Attributes = make(map[string]string)

--- a/synnergy-network/core/Tokens/syn70.go
+++ b/synnergy-network/core/Tokens/syn70.go
@@ -41,12 +41,12 @@ func (t *SYN70Token) Meta() any { return "SYN70" }
 // within the token. If the asset already exists an error is returned.
 func (t *SYN70Token) RegisterAsset(id string, asset *SYN70Asset) error {
 	if id == "" || asset == nil {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if _, ok := t.assets[id]; ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	t.assets[id] = asset
 	return nil
@@ -58,7 +58,7 @@ func (t *SYN70Token) TransferAsset(id string, newOwner Address) error {
 	defer t.mu.Unlock()
 	a, ok := t.assets[id]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	a.Owner = newOwner
 	return nil
@@ -71,7 +71,7 @@ func (t *SYN70Token) UpdateAttributes(id string, attrs map[string]string) error 
 	defer t.mu.Unlock()
 	a, ok := t.assets[id]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	if a.Attributes == nil {
 		a.Attributes = make(map[string]string)
@@ -88,7 +88,7 @@ func (t *SYN70Token) RecordAchievement(id, achievement string) error {
 	defer t.mu.Unlock()
 	a, ok := t.assets[id]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	a.Achievements = append(a.Achievements, achievement)
 	return nil
@@ -119,7 +119,7 @@ func (t *SYN70Token) ListAssets() []SYN70Asset {
 	return out
 }
 
-// ErrInvalidAsset is used by SYN70 operations for generic input errors. The
-// core package defines the real error but we replicate it here to keep the
+// errInvalidAsset is used by SYN70 operations for generic input errors. The
+// core package defines a similar error but we replicate it here to keep the
 // dependency graph flat.
-var ErrInvalidAsset = errors.New("invalid asset")
+var errInvalidAsset = errors.New("invalid asset")

--- a/synnergy-network/core/content_node.go
+++ b/synnergy-network/core/content_node.go
@@ -59,7 +59,7 @@ func UploadContent(data, key []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	nodes, err := chooseContentNodes(ContentReplicationFactor)
+	nodes, err := chooseContentNodes(contentReplicationFactor)
 	if err != nil {
 		return cid, err
 	}
@@ -102,4 +102,4 @@ func ListContentNodes() ([]ContentNetworkNode, error) {
 	return list, nil
 }
 
-var ContentReplicationFactor = 2
+var contentReplicationFactor = 2

--- a/synnergy-network/core/cross_consensus_scaling_networks.go
+++ b/synnergy-network/core/cross_consensus_scaling_networks.go
@@ -19,7 +19,7 @@ type CCSNetwork struct {
 	CreatedAt       time.Time `json:"created_at"`
 }
 
-var TopicCCSRegistry = "ccsn:registry"
+var topicCCSRegistry = "ccsn:registry"
 
 // RegisterCCSNetwork stores a new cross-consensus configuration and broadcasts it.
 func RegisterCCSNetwork(n CCSNetwork) error {
@@ -38,7 +38,7 @@ func RegisterCCSNetwork(n CCSNetwork) error {
 		return err
 	}
 
-	Broadcast(TopicCCSRegistry, raw)
+	Broadcast(topicCCSRegistry, raw)
 	logger.Infof("CCSN %s registered", n.ID)
 	return nil
 }

--- a/synnergy-network/core/custodial_node.go
+++ b/synnergy-network/core/custodial_node.go
@@ -12,9 +12,9 @@ type CustodialConfig struct {
 	Ledger  LedgerConfig
 }
 
-// ErrInsufficientBalance is returned when a withdrawal or transfer exceeds the
+// errInsufficientBalance is returned when a withdrawal or transfer exceeds the
 // stored amount for an account.
-var ErrInsufficientBalance = errors.New("insufficient balance")
+var errInsufficientBalance = errors.New("insufficient balance")
 
 // CustodialNode provides secure asset custody and management services.
 type CustodialNode struct {
@@ -72,7 +72,7 @@ func (c *CustodialNode) Withdraw(addr Address, token TokenID, amount uint64) err
 	defer c.mu.Unlock()
 	bal := c.store[addr][token]
 	if bal < amount {
-		return ErrInsufficientBalance
+		return errInsufficientBalance
 	}
 	c.store[addr][token] -= amount
 	return c.ledger.Burn(addr, amount)
@@ -83,7 +83,7 @@ func (c *CustodialNode) Transfer(from, to Address, token TokenID, amount uint64)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.store[from][token] < amount {
-		return ErrInsufficientBalance
+		return errInsufficientBalance
 	}
 	if _, ok := c.store[to]; !ok {
 		c.store[to] = make(map[TokenID]uint64)

--- a/synnergy-network/core/governance.go
+++ b/synnergy-network/core/governance.go
@@ -26,7 +26,7 @@ type GovProposal struct {
 	Executed     bool              `json:"executed"`
 }
 
-var BlockGasLimit = uint64(1000000)
+var blockGasLimit = uint64(1000000)
 
 func UpdateParam(key, value string) error {
 	switch key {
@@ -35,7 +35,7 @@ func UpdateParam(key, value string) error {
 		if err != nil {
 			return fmt.Errorf("invalid uint: %w", err)
 		}
-		BlockGasLimit = v
+		blockGasLimit = v
 		return nil
 	default:
 		return fmt.Errorf("unknown param: %s", key)
@@ -259,7 +259,7 @@ func BalanceOfAsset(asset AssetRef, addr Address) (uint64, error) {
 	case AssetToken:
 		tok, ok := TokenLedger[asset.TokenID]
 		if !ok {
-			return 0, ErrInvalidAsset
+			return 0, errInvalidAsset
 		}
 		return tok.balances.Get(asset.TokenID, addr), nil
 	default:

--- a/synnergy-network/core/governance_token_voting.go
+++ b/synnergy-network/core/governance_token_voting.go
@@ -23,7 +23,7 @@ func CastTokenVote(tv *TokenVote) error {
 
 	tok, ok := TokenLedger[tv.TokenID]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	if tok.BalanceOf(tv.Voter) < tv.Amount {
 		return ErrUnauthorized

--- a/synnergy-network/core/lightning_node.go
+++ b/synnergy-network/core/lightning_node.go
@@ -47,7 +47,7 @@ func Lightning() *LightningNode { return ln }
 func (l *LightningNode) OpenChannel(a, b Address, token TokenID, amtA, amtB uint64) (LightningChannelID, error) {
 	tok, ok := GetToken(token)
 	if !ok {
-		return LightningChannelID{}, ErrInvalidAsset
+		return LightningChannelID{}, errInvalidAsset
 	}
 	l.mu.Lock()
 	l.nonce++
@@ -81,22 +81,22 @@ func (l *LightningNode) RoutePayment(id LightningChannelID, from Address, amount
 	defer l.mu.Unlock()
 	ch, ok := l.channels[id]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	if from == ch.PartyA {
 		if ch.BalanceA < amount {
-			return ErrInvalidAsset
+			return errInvalidAsset
 		}
 		ch.BalanceA -= amount
 		ch.BalanceB += amount
 	} else if from == ch.PartyB {
 		if ch.BalanceB < amount {
-			return ErrInvalidAsset
+			return errInvalidAsset
 		}
 		ch.BalanceB -= amount
 		ch.BalanceA += amount
 	} else {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	ch.Nonce++
 	return nil
@@ -108,13 +108,13 @@ func (l *LightningNode) CloseChannel(id LightningChannelID) error {
 	ch, ok := l.channels[id]
 	if !ok {
 		l.mu.Unlock()
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	delete(l.channels, id)
 	l.mu.Unlock()
 	tok, ok := GetToken(ch.Token)
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	esc := channelEscrow(id)
 	if ch.BalanceA > 0 {

--- a/synnergy-network/core/syn1155.go
+++ b/synnergy-network/core/syn1155.go
@@ -94,7 +94,7 @@ func (t *SYN1155Token) TransferAsset(from, to Address, id uint64, amount uint64)
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.balances[id] == nil || t.balances[id][from] < amount {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	if t.balances[id] == nil {
 		t.balances[id] = make(map[Address]uint64)
@@ -115,7 +115,7 @@ func (t *SYN1155Token) BatchTransfer(from Address, items []Batch1155Transfer) er
 	// check balances first
 	for _, it := range items {
 		if t.balances[it.ID] == nil || t.balances[it.ID][from] < it.Amount {
-			return ErrInvalidAsset
+			return errInvalidAsset
 		}
 	}
 	for _, it := range items {
@@ -150,7 +150,7 @@ func (t *SYN1155Token) BurnAsset(from Address, id uint64, amount uint64) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.balances[id] == nil || t.balances[id][from] < amount {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	t.balances[id][from] -= amount
 	t.meta.TotalSupply -= amount

--- a/synnergy-network/core/syn1300.go
+++ b/synnergy-network/core/syn1300.go
@@ -46,7 +46,7 @@ func (s *SupplyChainToken) RegisterAsset(asset SupplyChainAsset) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.assets[asset.ID]; ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	asset.Timestamp = time.Now().UTC()
 	s.assets[asset.ID] = asset
@@ -69,7 +69,7 @@ func (s *SupplyChainToken) UpdateLocation(id, loc string) error {
 	defer s.mu.Unlock()
 	asset, ok := s.assets[id]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	asset.Location = loc
 	asset.Timestamp = time.Now().UTC()
@@ -90,7 +90,7 @@ func (s *SupplyChainToken) UpdateStatus(id, status string) error {
 	defer s.mu.Unlock()
 	asset, ok := s.assets[id]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	asset.Status = status
 	asset.Timestamp = time.Now().UTC()
@@ -111,7 +111,7 @@ func (s *SupplyChainToken) TransferAsset(id string, newOwner Address) error {
 	defer s.mu.Unlock()
 	asset, ok := s.assets[id]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	if err := s.Transfer(asset.Owner, newOwner, 1); err != nil {
 		return err

--- a/synnergy-network/core/syn20.go
+++ b/synnergy-network/core/syn20.go
@@ -68,7 +68,7 @@ func (t *SYN20Token) Transfer(from, to Address, amt uint64) error {
 	frozen := t.freeze[from] || t.freeze[to]
 	t.mu.RUnlock()
 	if paused || frozen {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	return t.BaseToken.Transfer(from, to, amt)
 }
@@ -81,7 +81,7 @@ func (t *SYN20Token) TransferWithMemo(from, to Address, amt uint64, memo string)
 // BulkTransfer sends tokens to multiple recipients.
 func (t *SYN20Token) BulkTransfer(from Address, tos []Address, amts []uint64) error {
 	if len(tos) != len(amts) {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	for i, to := range tos {
 		if err := t.Transfer(from, to, amts[i]); err != nil {
@@ -94,7 +94,7 @@ func (t *SYN20Token) BulkTransfer(from Address, tos []Address, amts []uint64) er
 // BulkApprove grants allowances to multiple spenders.
 func (t *SYN20Token) BulkApprove(owner Address, spenders []Address, amts []uint64) error {
 	if len(spenders) != len(amts) {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	for i, s := range spenders {
 		if err := t.Approve(owner, s, amts[i]); err != nil {

--- a/synnergy-network/core/syn3200.go
+++ b/synnergy-network/core/syn3200.go
@@ -71,10 +71,10 @@ func (t *Syn3200Token) PayFraction(billID uint64, payer Address, amount uint64) 
 	defer t.mu.Unlock()
 	b, ok := t.bills[billID]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	if b.Paid || b.Remaining < amount {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	if err := t.Transfer(payer, b.Issuer, amount); err != nil {
 		return err
@@ -98,7 +98,7 @@ func (t *Syn3200Token) AdjustAmount(billID uint64, newAmount uint64) error {
 	defer t.mu.Unlock()
 	b, ok := t.bills[billID]
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	b.Remaining = newAmount
 	b.Adjustments = append(b.Adjustments, Adjustment{NewAmount: newAmount, Date: time.Now().UTC()})

--- a/synnergy-network/core/syn721_token.go
+++ b/synnergy-network/core/syn721_token.go
@@ -59,7 +59,7 @@ func (t *SYN721Token) Approve(owner, spender Address, nftID uint64) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.owners[nftID] != owner {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	t.approvals[nftID] = spender
 	if t.BaseToken.ledger != nil {
@@ -73,7 +73,7 @@ func (t *SYN721Token) Transfer(from, to Address, nftID uint64) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if owner := t.owners[nftID]; owner != from && t.approvals[nftID] != from {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	t.owners[nftID] = to
 	delete(t.approvals, nftID)
@@ -115,7 +115,7 @@ func (t *SYN721Token) Burn(from Address, nftID uint64) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.owners[nftID] != from {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	delete(t.owners, nftID)
 	delete(t.metaStore, nftID)
@@ -140,7 +140,7 @@ func (t *SYN721Token) UpdateMetadata(id uint64, md SYN721Metadata) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if _, ok := t.metaStore[id]; !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	prev := t.metaStore[id]
 	if prev.Data != "" {

--- a/synnergy-network/core/token_management.go
+++ b/synnergy-network/core/token_management.go
@@ -49,7 +49,7 @@ func (tm *TokenManager) Create(meta Metadata, init map[Address]uint64) (TokenID,
 func (tm *TokenManager) Transfer(id TokenID, from, to Address, amount uint64) error {
 	tok, ok := GetToken(id)
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	return tok.Transfer(from, to, amount)
 }
@@ -58,7 +58,7 @@ func (tm *TokenManager) Transfer(id TokenID, from, to Address, amount uint64) er
 func (tm *TokenManager) Mint(id TokenID, to Address, amount uint64) error {
 	tok, ok := GetToken(id)
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	return tok.Mint(to, amount)
 }
@@ -67,7 +67,7 @@ func (tm *TokenManager) Mint(id TokenID, to Address, amount uint64) error {
 func (tm *TokenManager) Burn(id TokenID, from Address, amount uint64) error {
 	tok, ok := GetToken(id)
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	return tok.Burn(from, amount)
 }
@@ -76,7 +76,7 @@ func (tm *TokenManager) Burn(id TokenID, from Address, amount uint64) error {
 func (tm *TokenManager) Approve(id TokenID, owner, spender Address, amount uint64) error {
 	tok, ok := GetToken(id)
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	return tok.Approve(owner, spender, amount)
 }
@@ -85,7 +85,7 @@ func (tm *TokenManager) Approve(id TokenID, owner, spender Address, amount uint6
 func (tm *TokenManager) BalanceOf(id TokenID, addr Address) (uint64, error) {
 	tok, ok := GetToken(id)
 	if !ok {
-		return 0, ErrInvalidAsset
+		return 0, errInvalidAsset
 	}
 	return tok.BalanceOf(addr), nil
 }

--- a/synnergy-network/core/token_management_syn1000.go
+++ b/synnergy-network/core/token_management_syn1000.go
@@ -22,11 +22,11 @@ func (tm *TokenManager) CreateSYN1000(meta Metadata, init map[Address]uint64) (T
 func (tm *TokenManager) AddStableReserve(id TokenID, asset string, amt uint64) error {
 	tok, ok := GetToken(id)
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	sc, ok := tok.(*Tokens.SYN1000Token)
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	sc.AddReserve(asset, amt)
 	return nil
@@ -36,11 +36,11 @@ func (tm *TokenManager) AddStableReserve(id TokenID, asset string, amt uint64) e
 func (tm *TokenManager) RemoveStableReserve(id TokenID, asset string, amt uint64) error {
 	tok, ok := GetToken(id)
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	sc, ok := tok.(*Tokens.SYN1000Token)
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	return sc.RemoveReserve(asset, amt)
 }
@@ -49,11 +49,11 @@ func (tm *TokenManager) RemoveStableReserve(id TokenID, asset string, amt uint64
 func (tm *TokenManager) SetStablePrice(id TokenID, asset string, price float64) error {
 	tok, ok := GetToken(id)
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	sc, ok := tok.(*Tokens.SYN1000Token)
 	if !ok {
-		return ErrInvalidAsset
+		return errInvalidAsset
 	}
 	sc.SetPrice(asset, price)
 	return nil
@@ -63,11 +63,11 @@ func (tm *TokenManager) SetStablePrice(id TokenID, asset string, price float64) 
 func (tm *TokenManager) StableReserveValue(id TokenID) (float64, error) {
 	tok, ok := GetToken(id)
 	if !ok {
-		return 0, ErrInvalidAsset
+		return 0, errInvalidAsset
 	}
 	sc, ok := tok.(*Tokens.SYN1000Token)
 	if !ok {
-		return 0, ErrInvalidAsset
+		return 0, errInvalidAsset
 	}
 	return sc.ReserveValue(), nil
 }

--- a/synnergy-network/core/tokens.go
+++ b/synnergy-network/core/tokens.go
@@ -144,8 +144,8 @@ var standardNames = map[TokenStandard]string{
 	StdSYN5000: "SYN5000",
 }
 
-// ErrInvalidAsset is returned when a token cannot be located in the registry.
-var ErrInvalidAsset = errors.New("invalid token asset")
+// errInvalidAsset is returned when a token cannot be located in the registry.
+var errInvalidAsset = errors.New("invalid token asset")
 
 // Metadata describes a token instance.  Only the most common fields are kept
 // here; specialised tokens may extend this struct in their own packages.

--- a/synnergy-network/core/utility_functions.go
+++ b/synnergy-network/core/utility_functions.go
@@ -413,8 +413,8 @@ func toSigned(x *big.Int) *big.Int {
 	return new(big.Int).Set(x)
 }
 
-// ErrInvalidSignature is returned by opECRECOVER when the signature cannot be recovered.
-var ErrInvalidSignature = errors.New("vm: invalid ecrecover signature")
+// errInvalidSignature is returned by opECRECOVER when the signature cannot be recovered.
+var errInvalidSignature = errors.New("vm: invalid ecrecover signature")
 
 // opECRECOVER pops 4 values (s, r, v, hash) from the stack (in that order),
 // attempts to recover the public key from the ECDSA signature over secp256k1,
@@ -600,15 +600,15 @@ func opCODECOPY(ctx *VMContext) error {
 	return nil
 }
 
-// ErrInvalidJumpDest is returned when a JUMP or JUMPI target is not a valid JUMPDEST.
-var ErrInvalidJumpDest = errors.New("vm: invalid jump destination")
+// errInvalidJumpDest is returned when a JUMP or JUMPI target is not a valid JUMPDEST.
+var errInvalidJumpDest = errors.New("vm: invalid jump destination")
 
 // opJUMP pops a destination off the stack and unconditionally sets PC to that location,
 // if it is a valid JUMPDEST.
 func opJUMP(ctx *VMContext) error {
 	dest := ctx.Stack.Pop().Uint64()
 	if _, ok := ctx.JumpTable[dest]; !ok {
-		return ErrInvalidJumpDest
+		return errInvalidJumpDest
 	}
 	ctx.PC = dest
 	return nil
@@ -620,7 +620,7 @@ func opJUMPI(ctx *VMContext) error {
 	cond := ctx.Stack.Pop()
 	if cond.Sign() != 0 {
 		if _, ok := ctx.JumpTable[dest]; !ok {
-			return ErrInvalidJumpDest
+			return errInvalidJumpDest
 		}
 		ctx.PC = dest
 	}

--- a/synnergy-network/internal/charity_pool_management.go
+++ b/synnergy-network/internal/charity_pool_management.go
@@ -21,9 +21,9 @@ type CharityPoolManager struct {
 var (
 	// ErrAmountZero is returned when the supplied token amount is zero.
 	ErrAmountZero = errors.New("amount must be greater than zero")
-	// ErrInsufficientBalance is returned when an account lacks the funds
+	// errInsufficientBalance is returned when an account lacks the funds
 	// required to complete an operation.
-	ErrInsufficientBalance = errors.New("insufficient balance")
+	errInsufficientBalance = errors.New("insufficient balance")
 )
 
 // CharityBalances represents the current fund distribution between the
@@ -64,7 +64,7 @@ func (m *CharityPoolManager) WithdrawInternal(to core.Address, amount uint64) er
 	defer m.mu.Unlock()
 	bal := m.ledger.BalanceOf(core.InternalCharityAccount)
 	if amount > bal {
-		return ErrInsufficientBalance
+		return errInsufficientBalance
 	}
 	m.logger.Printf("internal withdrawal %d to %s", amount, to.Short())
 	return m.ledger.Transfer(core.InternalCharityAccount, to, amount)


### PR DESCRIPTION
## Summary
- rename internal error variables to unexported camelCase
- lower-case package-level constants meant for internal use

## Testing
- `go vet ./core/... ./internal/...` *(fails: encrypt redeclared, ResourceAllocator redeclared, bridgeAccount redeclared, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688d8df980208320b3039de1d08e2264