### PR TITLE
chore: resolve lint conflict in content node

### DIFF
--- a/synnergy-network/GUI/token-creation-tool/eslint.config.js
+++ b/synnergy-network/GUI/token-creation-tool/eslint.config.js
@@ -1,0 +1,14 @@
+export default [
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: "module",
+      globals: { document: "readonly", fetch: "readonly" }
+    },
+    rules: {
+      "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+      semi: ["error", "always"]
+    }
+  }
+];

--- a/synnergy-network/core/content_node_impl.go
+++ b/synnergy-network/core/content_node_impl.go
@@ -25,7 +25,8 @@ func NewContentNode(cfg Config) (*ContentNode, error) {
 	return &ContentNode{Node: n, store: make(map[string][]byte)}, nil
 }
 
-func encrypt(data, key []byte) ([]byte, error) {
+// encryptContent encrypts the provided data using the supplied key.
+func encryptContent(data, key []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
@@ -40,7 +41,8 @@ func encrypt(data, key []byte) ([]byte, error) {
 	return b, nil
 }
 
-func decrypt(data, key []byte) ([]byte, error) {
+// decryptContent decrypts the provided data using the supplied key.
+func decryptContent(data, key []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
@@ -57,7 +59,7 @@ func decrypt(data, key []byte) ([]byte, error) {
 
 // StoreContent encrypts and pins data returning its CID.
 func (c *ContentNode) StoreContent(data, key []byte) (string, error) {
-	enc, err := encrypt(data, key)
+	enc, err := encryptContent(data, key)
 	if err != nil {
 		return "", err
 	}
@@ -84,7 +86,7 @@ func (c *ContentNode) RetrieveContent(cid string, key []byte) ([]byte, error) {
 			return nil, err
 		}
 	}
-	return decrypt(data, key)
+	return decryptContent(data, key)
 }
 
 // ListContent enumerates pinned content metadata.


### PR DESCRIPTION
## Summary
- avoid encryption helper name collision in content node implementation
- add ESLint config for token creation GUI module

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `cd synnergy-network/GUI/token-creation-tool && npx eslint server`


------
https://chatgpt.com/codex/tasks/task_e_688d8decd8d083209188d71360efc7a0