### PR TITLE
stage6: validate token addresses and enforce CLI flags

### DIFF
--- a/synnergy-network/cmd/cli/tokens.go
+++ b/synnergy-network/cmd/cli/tokens.go
@@ -207,16 +207,26 @@ func init() {
 	tokTransferCmd.Flags().String("from", "", "source address")
 	tokTransferCmd.Flags().String("to", "", "destination address")
 	tokTransferCmd.Flags().Uint64("amt", 0, "amount")
+	tokTransferCmd.MarkFlagRequired("from")
+	tokTransferCmd.MarkFlagRequired("to")
+	tokTransferCmd.MarkFlagRequired("amt")
 
 	tokMintCmd.Flags().String("to", "", "recipient address")
 	tokMintCmd.Flags().Uint64("amt", 0, "amount")
+	tokMintCmd.MarkFlagRequired("to")
+	tokMintCmd.MarkFlagRequired("amt")
 
 	tokBurnCmd.Flags().String("from", "", "address to burn from")
 	tokBurnCmd.Flags().Uint64("amt", 0, "amount")
+	tokBurnCmd.MarkFlagRequired("from")
+	tokBurnCmd.MarkFlagRequired("amt")
 
 	tokApproveCmd.Flags().String("owner", "", "owner address")
 	tokApproveCmd.Flags().String("spender", "", "spender address")
 	tokApproveCmd.Flags().Uint64("amt", 0, "amount")
+	tokApproveCmd.MarkFlagRequired("owner")
+	tokApproveCmd.MarkFlagRequired("spender")
+	tokApproveCmd.MarkFlagRequired("amt")
 
 	tokensCmd.AddCommand(tokListCmd, tokInfoCmd, tokBalanceCmd, tokTransferCmd, tokMintCmd, tokBurnCmd, tokApproveCmd, tokAllowanceCmd)
 }

--- a/synnergy-network/core/Tokens/base.go
+++ b/synnergy-network/core/Tokens/base.go
@@ -114,6 +114,9 @@ func (b *BaseToken) Transfer(from, to Address, amount uint64) error {
 	if b.balances == nil {
 		return fmt.Errorf("balances not initialised")
 	}
+	if from == (Address{}) || to == (Address{}) {
+		return fmt.Errorf("zero address")
+	}
 	if err := b.balances.Sub(b.id, from, amount); err != nil {
 		return err
 	}
@@ -140,7 +143,6 @@ func (b *BaseToken) TransferFrom(owner, spender, to Address, amount uint64) erro
 	return nil
 }
 
-
 // Allowance returns the approved spend for a spender.
 func (b *BaseToken) Allowance(owner, spender Address) uint64 {
 	b.mu.RLock()
@@ -158,6 +160,9 @@ func (b *BaseToken) Allowance(owner, spender Address) uint64 {
 func (b *BaseToken) Approve(owner, spender Address, amount uint64) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if owner == (Address{}) || spender == (Address{}) {
+		return fmt.Errorf("zero address")
+	}
 	if b.allowance == nil {
 		b.allowance = make(map[Address]map[Address]uint64)
 	}
@@ -173,6 +178,9 @@ func (b *BaseToken) Mint(to Address, amount uint64) error {
 	if b.meta.FixedSupply {
 		return fmt.Errorf("fixed supply token")
 	}
+	if to == (Address{}) {
+		return fmt.Errorf("zero address")
+	}
 	if b.balances == nil {
 		b.balances = NewBalanceTable()
 	}
@@ -185,6 +193,9 @@ func (b *BaseToken) Mint(to Address, amount uint64) error {
 func (b *BaseToken) Burn(from Address, amount uint64) error {
 	if b.balances == nil {
 		return fmt.Errorf("balances not initialised")
+	}
+	if from == (Address{}) {
+		return fmt.Errorf("zero address")
 	}
 	if err := b.balances.Sub(b.id, from, amount); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- add zero-address checks to core token operations
- require mandatory flags for token CLI commands

## Testing
- `go build ./core/Tokens`
- `go test ./core/Tokens`
- `go build cmd/cli/tokens.go`


------
https://chatgpt.com/codex/tasks/task_e_688d8dd5f2d08320b843717d28632c9d