### PR TITLE
Resolve core naming collisions in node modules

### DIFF
--- a/synnergy-network/core/content_node_impl.go
+++ b/synnergy-network/core/content_node_impl.go
@@ -25,7 +25,8 @@ func NewContentNode(cfg Config) (*ContentNode, error) {
 	return &ContentNode{Node: n, store: make(map[string][]byte)}, nil
 }
 
-func encrypt(data, key []byte) ([]byte, error) {
+// encryptContent applies CFB encryption to the provided data using the key.
+func encryptContent(data, key []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
@@ -40,7 +41,8 @@ func encrypt(data, key []byte) ([]byte, error) {
 	return b, nil
 }
 
-func decrypt(data, key []byte) ([]byte, error) {
+// decryptContent reverses CFB encryption performed by encryptContent.
+func decryptContent(data, key []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
@@ -57,7 +59,7 @@ func decrypt(data, key []byte) ([]byte, error) {
 
 // StoreContent encrypts and pins data returning its CID.
 func (c *ContentNode) StoreContent(data, key []byte) (string, error) {
-	enc, err := encrypt(data, key)
+	enc, err := encryptContent(data, key)
 	if err != nil {
 		return "", err
 	}
@@ -84,7 +86,7 @@ func (c *ContentNode) RetrieveContent(cid string, key []byte) ([]byte, error) {
 			return nil, err
 		}
 	}
-	return decrypt(data, key)
+	return decryptContent(data, key)
 }
 
 // ListContent enumerates pinned content metadata.

--- a/synnergy-network/core/defi.go
+++ b/synnergy-network/core/defi.go
@@ -43,7 +43,8 @@ func (dm *DeFiManager) mint(to Address, token string, amt uint64) error {
 // Insurance
 // ------------------------------------------------------------------
 
-type InsurancePolicy struct {
+// DefiInsurancePolicy represents a basic on-chain insurance record.
+type DefiInsurancePolicy struct {
 	ID      Hash    `json:"id"`
 	Holder  Address `json:"holder"`
 	Premium uint64  `json:"premium"`
@@ -59,7 +60,7 @@ func (dm *DeFiManager) CreateInsurance(id Hash, holder Address, premium, payout 
 	if ok, _ := dm.ledger.HasState(k); ok {
 		return fmt.Errorf("exists")
 	}
-	pol := InsurancePolicy{ID: id, Holder: holder, Premium: premium, Payout: payout, Active: true, Created: time.Now().Unix()}
+	pol := DefiInsurancePolicy{ID: id, Holder: holder, Premium: premium, Payout: payout, Active: true, Created: time.Now().Unix()}
 	if err := dm.ledger.Transfer(holder, BurnAddress, premium); err != nil {
 		return err
 	}
@@ -70,7 +71,7 @@ func (dm *DeFiManager) ClaimInsurance(id Hash) error {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 	k := append([]byte("ins:"), id[:]...)
-	var pol InsurancePolicy
+	var pol DefiInsurancePolicy
 	if err := dm.load(k, &pol); err != nil {
 		return err
 	}

--- a/synnergy-network/core/fault_tolerance.go
+++ b/synnergy-network/core/fault_tolerance.go
@@ -389,18 +389,19 @@ func (p *PredictiveFailureDetector) FailureProb(addr Address) float64 {
 	return avg / p.threshold
 }
 
-// ResourceAllocator dynamically adjusts VM resource limits based on usage.
-type ResourceAllocator struct {
+// DynamicResourceAllocator dynamically adjusts VM resource limits based on usage.
+type DynamicResourceAllocator struct {
 	mu     sync.Mutex
 	limits map[Address]uint64
 }
 
-func NewResourceAllocator() *ResourceAllocator {
-	return &ResourceAllocator{limits: make(map[Address]uint64)}
+// NewDynamicResourceAllocator creates a new instance of the allocator.
+func NewDynamicResourceAllocator() *DynamicResourceAllocator {
+	return &DynamicResourceAllocator{limits: make(map[Address]uint64)}
 }
 
 // Adjust sets the new gas limit for a contract address.
-func (r *ResourceAllocator) Adjust(addr Address, gas uint64) {
+func (r *DynamicResourceAllocator) Adjust(addr Address, gas uint64) {
 	r.mu.Lock()
 	r.limits[addr] = gas
 	r.mu.Unlock()

--- a/synnergy-network/core/governance_reputation_voting.go
+++ b/synnergy-network/core/governance_reputation_voting.go
@@ -8,9 +8,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// reputation token derived from token standard
-var reputationTokenID = deriveID(StdSYN1500)
-
 // AddReputation mints SYN-REP tokens to the specified address.
 func AddReputation(addr Address, amount uint64) error {
 	tok, ok := TokenLedger[reputationTokenID]

--- a/synnergy-network/core/plasma_operations.go
+++ b/synnergy-network/core/plasma_operations.go
@@ -73,7 +73,7 @@ func (p *BridgeCoordinator) Deposit(from Address, token TokenID, amount uint64, 
 	if !ok {
 		return PlasmaBridgeDeposit{}, errors.New("token unknown")
 	}
-	bridge := bridgeAccount(token)
+	bridge := plasmaBridgeAccount(token)
 	if err := tok.Transfer(from, bridge, amount); err != nil {
 		return PlasmaBridgeDeposit{}, err
 	}
@@ -100,7 +100,7 @@ func (p *BridgeCoordinator) StartExit(owner Address, token TokenID, amount uint6
 	if amount == 0 {
 		return PlasmaBridgeExit{}, errors.New("zero amount")
 	}
-	bridge := bridgeAccount(token)
+	bridge := plasmaBridgeAccount(token)
 	bal := p.Ledger.BalanceOf(bridge)
 	if bal < amount {
 		return PlasmaBridgeExit{}, fmt.Errorf("insufficient bridge balance: %d", bal)
@@ -140,7 +140,7 @@ func (p *BridgeCoordinator) FinalizeExit(nonce uint64) error {
 	if !ok {
 		return errors.New("token unknown")
 	}
-	bridge := bridgeAccount(ex.Token)
+	bridge := plasmaBridgeAccount(ex.Token)
 	if err := tok.Transfer(bridge, ex.Owner, ex.Amount); err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func (p *BridgeCoordinator) ListExits(owner Address) ([]PlasmaBridgeExit, error)
 	return out, nil
 }
 
-func bridgeAccount(token TokenID) Address {
+func plasmaBridgeAccount(token TokenID) Address {
 	var a Address
 	copy(a[:4], []byte("PLSM"))
 	a[4] = byte(token >> 24)

--- a/synnergy-network/core/syn131_token.go
+++ b/synnergy-network/core/syn131_token.go
@@ -8,16 +8,16 @@ type ValuationRecord struct {
 	Timestamp time.Time
 }
 
-// SaleRecord captures sale transactions for SYN131 assets.
-type SaleRecord struct {
+// SYN131SaleRecord captures sale transactions for SYN131 assets.
+type SYN131SaleRecord struct {
 	Price     uint64
 	Buyer     Address
 	Seller    Address
 	Timestamp time.Time
 }
 
-// RentalAgreement models rental terms for an asset.
-type RentalAgreement struct {
+// SYN131RentalAgreement models rental terms for an asset.
+type SYN131RentalAgreement struct {
 	Renter Address
 	Start  time.Time
 	End    time.Time
@@ -35,8 +35,8 @@ type LicenseRecord struct {
 type SYN131Token struct {
 	*BaseToken
 	Values   []ValuationRecord
-	Sales    []SaleRecord
-	Rentals  []RentalAgreement
+	Sales    []SYN131SaleRecord
+	Rentals  []SYN131RentalAgreement
 	Licenses []LicenseRecord
 	Shares   map[Address]uint64
 }
@@ -58,11 +58,11 @@ func (t *SYN131Token) UpdateValuation(value uint64) {
 
 // RecordSale appends a sale to the history log.
 func (t *SYN131Token) RecordSale(price uint64, buyer, seller Address) {
-	t.Sales = append(t.Sales, SaleRecord{Price: price, Buyer: buyer, Seller: seller, Timestamp: time.Now().UTC()})
+	t.Sales = append(t.Sales, SYN131SaleRecord{Price: price, Buyer: buyer, Seller: seller, Timestamp: time.Now().UTC()})
 }
 
 // AddRental registers a new rental agreement.
-func (t *SYN131Token) AddRental(r RentalAgreement) {
+func (t *SYN131Token) AddRental(r SYN131RentalAgreement) {
 	t.Rentals = append(t.Rentals, r)
 }
 
@@ -88,8 +88,8 @@ func SYN131_UpdateValuation(t *SYN131Token, value uint64) { t.UpdateValuation(va
 func SYN131_RecordSale(t *SYN131Token, price uint64, buyer, seller Address) {
 	t.RecordSale(price, buyer, seller)
 }
-func SYN131_AddRental(t *SYN131Token, r RentalAgreement)  { t.AddRental(r) }
-func SYN131_IssueLicense(t *SYN131Token, l LicenseRecord) { t.IssueLicense(l) }
+func SYN131_AddRental(t *SYN131Token, r SYN131RentalAgreement) { t.AddRental(r) }
+func SYN131_IssueLicense(t *SYN131Token, l LicenseRecord)      { t.IssueLicense(l) }
 func SYN131_TransferShare(t *SYN131Token, from, to Address, share uint64) {
 	t.TransferShare(from, to, share)
 }

--- a/synnergy-network/core/syn5000_index.go
+++ b/synnergy-network/core/syn5000_index.go
@@ -1,20 +1,5 @@
 package core
 
-import "time"
-
-// BetRecord defines bet metadata for the SYN5000 standard.
-type BetRecord struct {
-	ID       uint64
-	GameType string
-	Bettor   Address
-	Amount   uint64
-	Odds     float64
-	Placed   time.Time
-	Resolved bool
-	Won      bool
-	Payout   uint64
-}
-
 // GamblingToken exposes methods of the SYN5000 token.
 type GamblingToken interface {
 	Token


### PR DESCRIPTION
## Summary
- refactor content node encryption helpers to use unique names
- rename conflicting structs and helpers across core packages
- drop duplicate BetRecord definition from SYN5000 index

## Testing
- `go build -v ./core/Nodes/authority_nodes`
- `go build ./cmd/cli` *(fails: stakePrefix redeclared, BalanceTable redeclared, regMu redeclared, reg redeclared, DecodeTransaction redeclared, undefined: networkAdapter, undefined: securityAdapter, undefined: txPool, undefined: authorityAdapter, undefined: TxType)*

------
https://chatgpt.com/codex/tasks/task_e_688d8dcb0edc83209382bbf246413ff5