### PR TITLE
Stage 7: harden networking scripts and dialer

### DIFF
--- a/synnergy-network/cmd/scripts/consensus_start.sh
+++ b/synnergy-network/cmd/scripts/consensus_start.sh
@@ -1,3 +1,16 @@
 #!/usr/bin/env bash
+# Starts the Synnergy consensus engine. Builds the CLI binary if needed.
+
 set -euo pipefail
+
+# Always run relative to this script's directory
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+cd "$SCRIPT_DIR"
+
+# Build the synnergy CLI if it doesn't exist
+if [[ ! -x synnergy ]]; then
+    GOFLAGS="-trimpath" go build -o synnergy ../synnergy
+fi
+
 ./synnergy consensus start
+

--- a/synnergy-network/cmd/scripts/network_peers.sh
+++ b/synnergy-network/cmd/scripts/network_peers.sh
@@ -1,3 +1,16 @@
 #!/usr/bin/env bash
+# Lists connected P2P peers. Builds the CLI binary if needed.
+
 set -euo pipefail
+
+# Always run relative to this script's directory
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+cd "$SCRIPT_DIR"
+
+# Build the synnergy CLI if it doesn't exist
+if [[ ! -x synnergy ]]; then
+    GOFLAGS="-trimpath" go build -o synnergy ../synnergy
+fi
+
 ./synnergy network peers
+

--- a/synnergy-network/cmd/scripts/network_start.sh
+++ b/synnergy-network/cmd/scripts/network_start.sh
@@ -1,3 +1,16 @@
 #!/usr/bin/env bash
+# Starts the Synnergy P2P network. Builds the CLI binary if needed.
+
 set -euo pipefail
+
+# Always run relative to this script's directory
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+cd "$SCRIPT_DIR"
+
+# Build the synnergy CLI if it doesn't exist
+if [[ ! -x synnergy ]]; then
+    GOFLAGS="-trimpath" go build -o synnergy ../synnergy
+fi
+
 ./synnergy network start
+

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -309,7 +309,7 @@ func (d *Dialer) Dial(ctx context.Context, address string) (net.Conn, error) {
 
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
-		return nil, errors.New("dialer: failed to connect: " + err.Error())
+		return nil, fmt.Errorf("dialer: failed to connect to %s: %w", address, err)
 	}
 	return conn, nil
 }


### PR DESCRIPTION
## Summary
- improve Dialer error wrapping for clearer connection failures
- auto-build CLI in network and consensus startup scripts

## Testing
- `shellcheck cmd/scripts/network_start.sh cmd/scripts/network_peers.sh cmd/scripts/consensus_start.sh`
- `go vet core/network.go` *(fails: undefined: Config)*

------
https://chatgpt.com/codex/tasks/task_e_688e182d985c8320880a4c5a624e1ff0