### PR TITLE
chore: add json tags to config structs

### DIFF
--- a/synnergy-network/core/indexing_node.go
+++ b/synnergy-network/core/indexing_node.go
@@ -19,7 +19,7 @@ type IndexingNode struct {
 
 // IndexingNodeConfig contains the network configuration for a new indexing node.
 type IndexingNodeConfig struct {
-	Network Config
+	Network Config `json:"network"`
 }
 
 // NewIndexingNode constructs a new node with optional initial indexing of the

--- a/synnergy-network/core/regulatory_node.go
+++ b/synnergy-network/core/regulatory_node.go
@@ -9,9 +9,9 @@ import (
 
 // RegulatoryConfig aggregates config required to bootstrap a regulatory node.
 type RegulatoryConfig struct {
-	Network        Config
-	Ledger         LedgerConfig
-	TrustedIssuers [][]byte
+	Network        Config       `json:"network"`
+	Ledger         LedgerConfig `json:"ledger"`
+	TrustedIssuers [][]byte     `json:"trusted_issuers"`
 }
 
 // RegulatoryNode enforces compliance rules and exposes network services.


### PR DESCRIPTION
## Summary
- add JSON field tags to regulatory node config
- tag indexing node config for consistent API encoding

## Testing
- `go vet core/regulatory_node.go` *(fails: undefined: Config)*
- `go vet core/indexing_node.go` *(fails: undefined: BaseNode)*
- `go build core/regulatory_node.go` *(fails: undefined: Config)*
- `go build core/indexing_node.go` *(fails: undefined: BaseNode)*

------
https://chatgpt.com/codex/tasks/task_e_688e184fa9308320960f299b8b96122e