### PR TITLE
refactor: remove core dependency from optimization node

### DIFF
--- a/synnergy-network/core/Nodes/optimization_nodes/index.go
+++ b/synnergy-network/core/Nodes/optimization_nodes/index.go
@@ -1,11 +1,26 @@
 package optimization_nodes
 
 import coreNodes "synnergy-network/core/Nodes"
-import core "synnergy-network/core"
+
+// Transaction represents the minimal transaction information required for
+// optimisation without importing the core package. Only the gas price is
+// needed to order transactions.
+type Transaction struct {
+	GasPrice uint64
+}
+
+// Ledger defines the small portion of ledger functionality the optimisation
+// node relies on. Decoupling via this interface prevents an import cycle with
+// the core package.
+type Ledger interface {
+	ListPool(limit int) []*Transaction
+}
 
 // OptimizationAPI defines the exposed functionality of an optimization node.
+// It operates on the lightweight Transaction type to avoid pulling in the
+// heavyweight core dependencies, eliminating potential circular imports.
 type OptimizationAPI interface {
 	coreNodes.NodeInterface
-	OptimizeTransactions([]*core.Transaction) []*core.Transaction
+	OptimizeTransactions([]*Transaction) []*Transaction
 	BalanceLoad(peers []string)
 }

--- a/synnergy-network/core/Nodes/optimization_nodes/optimization.go
+++ b/synnergy-network/core/Nodes/optimization_nodes/optimization.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 	"sync"
 
-	core "synnergy-network/core"
 	coreNodes "synnergy-network/core/Nodes"
 )
 
@@ -12,12 +11,12 @@ import (
 // and basic load balancing.
 type OptimizationNode struct {
 	base   coreNodes.NodeInterface
-	ledger *core.Ledger
+	ledger Ledger
 	mu     sync.Mutex
 }
 
 // NewOptimizationNode creates a node using an existing network node and ledger.
-func NewOptimizationNode(base coreNodes.NodeInterface, led *core.Ledger) *OptimizationNode {
+func NewOptimizationNode(base coreNodes.NodeInterface, led Ledger) *OptimizationNode {
 	return &OptimizationNode{base: base, ledger: led}
 }
 
@@ -40,7 +39,7 @@ func (o *OptimizationNode) Close() error { return o.base.Close() }
 func (o *OptimizationNode) Peers() []string { return o.base.Peers() }
 
 // OptimizeTransactions orders transactions by gas price descending.
-func (o *OptimizationNode) OptimizeTransactions(txs []*core.Transaction) []*core.Transaction {
+func (o *OptimizationNode) OptimizeTransactions(txs []*Transaction) []*Transaction {
 	sort.Slice(txs, func(i, j int) bool {
 		return txs[i].GasPrice > txs[j].GasPrice
 	})
@@ -54,7 +53,7 @@ func (o *OptimizationNode) BalanceLoad(peers []string) {
 }
 
 // ProcessPool fetches transactions from the ledger pool and optimizes them.
-func (o *OptimizationNode) ProcessPool(limit int) []*core.Transaction {
+func (o *OptimizationNode) ProcessPool(limit int) []*Transaction {
 	if o.ledger == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- decouple optimization node from core by defining lightweight transaction and ledger abstractions
- update optimization node to operate on these local types, preventing circular imports

## Testing
- `go build ./core/Nodes/optimization_nodes`


------
https://chatgpt.com/codex/tasks/task_e_688e1860b8808320a111c476319258a5