### PR TITLE
chore: guard network topic/sub maps with locks

### DIFF
--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -434,16 +434,18 @@ type Config struct {
 }
 
 type Node struct {
-	host     host.Host
-	pubsub   *pubsub.PubSub
-	topics   map[string]*pubsub.Topic
-	subs     map[string]*pubsub.Subscription
-	peerLock sync.RWMutex
-	peers    map[NodeID]*Peer
-	nat      *NATManager
-	ctx      context.Context
-	cancel   context.CancelFunc
-	cfg      Config
+	host      host.Host
+	pubsub    *pubsub.PubSub
+	topics    map[string]*pubsub.Topic
+	subs      map[string]*pubsub.Subscription
+	topicLock sync.RWMutex
+	subLock   sync.RWMutex
+	peerLock  sync.RWMutex
+	peers     map[NodeID]*Peer
+	nat       *NATManager
+	ctx       context.Context
+	cancel    context.CancelFunc
+	cfg       Config
 }
 
 //---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add mutexes to Node for topic and subscription maps
- lock around Broadcast and Subscribe to avoid concurrent map access

## Testing
- `go vet ./core` (fails: shuffleAddresses redeclared...)
- `go build ./core` (fails: shuffleAddresses redeclared...)
- `go test -race ./core` (fails: shuffleAddresses redeclared...)


------
https://chatgpt.com/codex/tasks/task_e_688e186875b4832086f57e131d26840e