### PR TITLE
refactor: unify logging in xchainserver

### DIFF
--- a/synnergy-network/cmd/xchainserver/main.go
+++ b/synnergy-network/cmd/xchainserver/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"log"
 	"net/http"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 
 	"synnergy-network/cmd/xchainserver/server"
 )
@@ -15,8 +16,8 @@ func main() {
 	}
 	r := server.NewRouter()
 
-	log.Printf("cross-chain server listening on %s", addr)
+	log.Infof("cross-chain server listening on %s", addr)
 	if err := http.ListenAndServe(addr, r); err != nil {
-		log.Fatal(err)
+		log.Fatalf("server error: %v", err)
 	}
 }

--- a/synnergy-network/cmd/xchainserver/server/middleware.go
+++ b/synnergy-network/cmd/xchainserver/server/middleware.go
@@ -1,14 +1,18 @@
 package server
 
 import (
-	"log"
 	"net/http"
+
+	log "github.com/sirupsen/logrus"
 )
 
-// RequestLogger writes basic request info to the standard logger.
+// RequestLogger writes basic request info using structured logging.
 func RequestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("%s %s", r.Method, r.URL.Path)
+		log.WithFields(log.Fields{
+			"method": r.Method,
+			"path":   r.URL.Path,
+		}).Info("incoming request")
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
## Summary
- use logrus for cross-chain server logging
- add structured request logging middleware

## Testing
- `gofmt -w synnergy-network/cmd/xchainserver/main.go synnergy-network/cmd/xchainserver/server/middleware.go`
- `go build ./cmd/xchainserver` *(fails: shuffleAddresses redeclared, undefined types, missing methods)*


------
https://chatgpt.com/codex/tasks/task_e_688e1878add8832088718a56656a7dac