### PR TITLE
feat: compile token creator contract

### DIFF
--- a/synnergy-network/cmd/smart_contracts/.solhint.json
+++ b/synnergy-network/cmd/smart_contracts/.solhint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "solhint:recommended"
+}

--- a/synnergy-network/cmd/smart_contracts/token_creator.sol
+++ b/synnergy-network/cmd/smart_contracts/token_creator.sol
@@ -1,24 +1,29 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 /// @title TokenCreator illustrates how to deploy new tokens on Synnergy
-///        using custom VM opcodes defined in `opcode_dispatcher.go`.
+/// @notice Deploys new tokens using custom VM opcodes defined in `opcode_dispatcher.go`.
+/// @author Synnergy Team
 contract TokenCreator {
-    /// Deploy a token with metadata and optional initial supply.
-    /// Parameters loosely map to core.Metadata in Go.
+    /// @notice Deploy a token with metadata and optional initial supply.
+    /// @param standard Token standard identifier.
+    /// @param decimals Number of decimals for the token.
+    /// @param isFixed Indicates whether the supply is fixed.
+    /// @param supply Initial supply to mint.
     function create(
         uint8 standard,
         uint8 decimals,
-        bool fixed,
+        bool isFixed,
         uint64 supply
     ) external {
-        bytes4 createOp = 0x190010; // Tokens_Create
-        bytes4 mintOp = 0x1C001A;   // MintToken_VM
+        bytes4 createOp = 0x00190010; // Tokens_Create opcode
+        bytes4 mintOp = 0x001C001A;   // MintToken_VM opcode
+        // solhint-disable-next-line no-inline-assembly
         assembly {
-            // layout: [standard(32)][decimals(32)][fixed(32)][supply(32)]
+            // layout: [standard(32)][decimals(32)][isFixed(32)][supply(32)]
             mstore(0x0, standard)
             mstore(0x20, decimals)
-            mstore(0x40, fixed)
+            mstore(0x40, isFixed)
             mstore(0x60, supply)
             let success := call(gas(), 0, createOp, 0x0, 0x80, 0, 0)
             if iszero(success) { revert(0, 0) }


### PR DESCRIPTION
## Summary
- ensure TokenCreator Solidity contract compiles with Solidity 0.8.24
- document contract with NatSpec comments and add solhint configuration

## Testing
- `solcjs --bin --abi cmd/smart_contracts/token_creator.sol -o /tmp/token_creator_build`
- `solhint --max-warnings 0 -c cmd/smart_contracts/.solhint.json cmd/smart_contracts/token_creator.sol`


------
https://chatgpt.com/codex/tasks/task_e_688e18a5cfc883208028a7d2e4437b6c