### PR TITLE
refactor: clarify env variable names

### DIFF
--- a/synnergy-network/pkg/utils/env.go
+++ b/synnergy-network/pkg/utils/env.go
@@ -1,39 +1,39 @@
 package utils
 
 import (
-        "os"
-        "strconv"
+	"os"
+	"strconv"
 )
 
 // EnvOrDefault returns the value of the environment variable identified by key
 // or the provided fallback if the variable is unset or empty.
 func EnvOrDefault(key, fallback string) string {
-        if v, ok := os.LookupEnv(key); ok && v != "" {
-                return v
-        }
-        return fallback
+	if value, ok := os.LookupEnv(key); ok && value != "" {
+		return value
+	}
+	return fallback
 }
 
 // EnvOrDefaultInt returns the integer value of the environment variable
 // identified by key or the provided fallback if the variable is unset,
 // empty, or cannot be parsed as an integer.
 func EnvOrDefaultInt(key string, fallback int) int {
-        if v, ok := os.LookupEnv(key); ok && v != "" {
-                if n, err := strconv.Atoi(v); err == nil {
-                        return n
-                }
-        }
-        return fallback
+	if value, ok := os.LookupEnv(key); ok && value != "" {
+		if num, err := strconv.Atoi(value); err == nil {
+			return num
+		}
+	}
+	return fallback
 }
 
 // EnvOrDefaultUint64 returns the uint64 value of the environment variable
 // identified by key or the provided fallback if the variable is unset,
 // empty, or cannot be parsed as a uint64.
 func EnvOrDefaultUint64(key string, fallback uint64) uint64 {
-        if v, ok := os.LookupEnv(key); ok && v != "" {
-                if n, err := strconv.ParseUint(v, 10, 64); err == nil {
-                        return n
-                }
-        }
-        return fallback
+	if value, ok := os.LookupEnv(key); ok && value != "" {
+		if num, err := strconv.ParseUint(value, 10, 64); err == nil {
+			return num
+		}
+	}
+	return fallback
 }


### PR DESCRIPTION
## Summary
- use descriptive names when reading environment variables

## Testing
- `go vet ./pkg/utils/...`
- `go test ./pkg/utils -run TestEnvOrDefault -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688e18b04d008320b68781edf289c917