### PR TITLE
feat: add json tags to configuration struct

### DIFF
--- a/synnergy-network/pkg/config/config.go
+++ b/synnergy-network/pkg/config/config.go
@@ -21,37 +21,37 @@ const Version = "v0.1.0"
 // the structure of the YAML files under cmd/config.
 type Config struct {
 	Network struct {
-		ID             string   `mapstructure:"id"`
-		ChainID        int      `mapstructure:"chain_id"`
-		MaxPeers       int      `mapstructure:"max_peers"`
-		GenesisFile    string   `mapstructure:"genesis_file"`
-		RPCEnabled     bool     `mapstructure:"rpc_enabled"`
-		P2PPort        int      `mapstructure:"p2p_port"`
-		ListenAddr     string   `mapstructure:"listen_addr"`
-		DiscoveryTag   string   `mapstructure:"discovery_tag"`
-		BootstrapPeers []string `mapstructure:"bootstrap_peers"`
-	} `mapstructure:"network"`
+		ID             string   `mapstructure:"id" json:"id"`
+		ChainID        int      `mapstructure:"chain_id" json:"chain_id"`
+		MaxPeers       int      `mapstructure:"max_peers" json:"max_peers"`
+		GenesisFile    string   `mapstructure:"genesis_file" json:"genesis_file"`
+		RPCEnabled     bool     `mapstructure:"rpc_enabled" json:"rpc_enabled"`
+		P2PPort        int      `mapstructure:"p2p_port" json:"p2p_port"`
+		ListenAddr     string   `mapstructure:"listen_addr" json:"listen_addr"`
+		DiscoveryTag   string   `mapstructure:"discovery_tag" json:"discovery_tag"`
+		BootstrapPeers []string `mapstructure:"bootstrap_peers" json:"bootstrap_peers"`
+	} `mapstructure:"network" json:"network"`
 
 	Consensus struct {
-		Type               string `mapstructure:"type"`
-		BlockTimeMS        int    `mapstructure:"block_time_ms"`
-		ValidatorsRequired int    `mapstructure:"validators_required"`
-	} `mapstructure:"consensus"`
+		Type               string `mapstructure:"type" json:"type"`
+		BlockTimeMS        int    `mapstructure:"block_time_ms" json:"block_time_ms"`
+		ValidatorsRequired int    `mapstructure:"validators_required" json:"validators_required"`
+	} `mapstructure:"consensus" json:"consensus"`
 
 	VM struct {
-		MaxGasPerBlock int  `mapstructure:"max_gas_per_block"`
-		OpcodeDebug    bool `mapstructure:"opcode_debug"`
-	} `mapstructure:"vm"`
+		MaxGasPerBlock int  `mapstructure:"max_gas_per_block" json:"max_gas_per_block"`
+		OpcodeDebug    bool `mapstructure:"opcode_debug" json:"opcode_debug"`
+	} `mapstructure:"vm" json:"vm"`
 
 	Storage struct {
-		DBPath string `mapstructure:"db_path"`
-		Prune  bool   `mapstructure:"prune"`
-	} `mapstructure:"storage"`
+		DBPath string `mapstructure:"db_path" json:"db_path"`
+		Prune  bool   `mapstructure:"prune" json:"prune"`
+	} `mapstructure:"storage" json:"storage"`
 
 	Logging struct {
-		Level string `mapstructure:"level"`
-		File  string `mapstructure:"file"`
-	} `mapstructure:"logging"`
+		Level string `mapstructure:"level" json:"level"`
+		File  string `mapstructure:"file" json:"file"`
+	} `mapstructure:"logging" json:"logging"`
 }
 
 // AppConfig holds the configuration loaded via Load or LoadFromEnv.


### PR DESCRIPTION
## Summary
- annotate configuration fields with JSON tags so YAML and JSON serialization stay aligned

## Testing
- `go mod tidy`
- `go list -deps ./...`
- `go vet ./pkg/config`
- `go build ./pkg/config`


------
https://chatgpt.com/codex/tasks/task_e_688e18b8c3ec8320bb2bce39396106bd