### PR TITLE
Add unit tests for coin and explorer server

### DIFF
--- a/synnergy-network/cmd/explorer/server_test.go
+++ b/synnergy-network/cmd/explorer/server_test.go
@@ -92,3 +92,40 @@ func TestHandleBlocksSuccess(t *testing.T) {
 		t.Fatalf("unexpected response: %v", res)
 	}
 }
+
+func TestHandleTxSuccess(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/tx/abc", nil)
+	rr := httptest.NewRecorder()
+	srv.router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestHandleTxNotFound(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/tx/zzz", nil)
+	rr := httptest.NewRecorder()
+	srv.router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+func TestHandleInfo(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/info", nil)
+	rr := httptest.NewRecorder()
+	srv.router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var res map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if res["height"].(float64) != 1 {
+		t.Fatalf("unexpected response: %v", res)
+	}
+}

--- a/synnergy-network/core/coin_test.go
+++ b/synnergy-network/core/coin_test.go
@@ -1,0 +1,62 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+)
+
+// TestBlockRewardAt verifies the halving schedule for block rewards.
+func TestBlockRewardAt(t *testing.T) {
+	r0 := BlockRewardAt(0)
+	if r0.Cmp(InitialReward) != 0 {
+		t.Fatalf("expected %s got %s", InitialReward.String(), r0.String())
+	}
+	half := new(big.Int).Rsh(new(big.Int).Set(InitialReward), 1)
+	r1 := BlockRewardAt(RewardHalvingPeriod)
+	if r1.Cmp(half) != 0 {
+		t.Fatalf("expected %s got %s", half.String(), r1.String())
+	}
+	quarter := new(big.Int).Rsh(new(big.Int).Set(InitialReward), 2)
+	r2 := BlockRewardAt(RewardHalvingPeriod * 2)
+	if r2.Cmp(quarter) != 0 {
+		t.Fatalf("expected %s got %s", quarter.String(), r2.String())
+	}
+}
+
+// TestCoinMintAndBurn ensures minting and burning adjust supply correctly.
+func TestCoinMintAndBurn(t *testing.T) {
+	ldg := &Ledger{TokenBalances: make(map[string]uint64)}
+	c, err := NewCoin(ldg)
+	if err != nil {
+		t.Fatalf("NewCoin failed: %v", err)
+	}
+	addr := []byte("addr1")
+	if err := c.Mint(addr, 100); err != nil {
+		t.Fatalf("Mint failed: %v", err)
+	}
+	if got := c.TotalSupply(); got != 100 {
+		t.Fatalf("TotalSupply=%d want 100", got)
+	}
+	if bal := c.BalanceOf(addr); bal != 100 {
+		t.Fatalf("Balance=%d want 100", bal)
+	}
+	if err := c.Burn(addr, 40); err != nil {
+		t.Fatalf("Burn failed: %v", err)
+	}
+	if got := c.TotalSupply(); got != 60 {
+		t.Fatalf("TotalSupply=%d want 60", got)
+	}
+}
+
+// TestCoinMintExceedsCap verifies minting beyond MaxSupply is rejected.
+func TestCoinMintExceedsCap(t *testing.T) {
+	ldg := &Ledger{TokenBalances: make(map[string]uint64)}
+	c, err := NewCoin(ldg)
+	if err != nil {
+		t.Fatalf("NewCoin failed: %v", err)
+	}
+	c.totalMinted = MaxSupply
+	if err := c.Mint([]byte("addr"), 1); err == nil {
+		t.Fatalf("expected cap error")
+	}
+}


### PR DESCRIPTION
## Summary
- add coverage for coin mint/burn logic and reward halving
- extend explorer server tests for tx and info handlers

## Testing
- `go test ./core -run TestBlockRewardAt -count=1` *(fails: shuffleAddresses redeclared, hash160 redeclared, undefined: ResourceAllocator, etc.)*
- `go test ./cmd/explorer -run TestHandleTxSuccess -count=1` *(fails: core build errors including redeclarations and undefined references)*


------
https://chatgpt.com/codex/tasks/task_e_688e18c9052c8320a6ac96ee9720b264