### PR TITLE
chore: align integration tests with core package

### DIFF
--- a/synnergy-network/tests/consensus_test.go
+++ b/synnergy-network/tests/consensus_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
-	core "synnergy-network/core"
+	. "synnergy-network/core"
 	"testing"
 	"time"
 
@@ -52,6 +52,8 @@ func (m *mockCrypto) Sign(_ string, data []byte) ([]byte, error) {
 }
 
 func (m *mockCrypto) Verify(_, _, _ []byte) bool { return true }
+
+type mockAuthority struct{}
 
 func (m *mockAuthority) ValidatorPubKey(role string) []byte {
 	return []byte("validator-pubkey")

--- a/synnergy-network/tests/cross_chain_test.go
+++ b/synnergy-network/tests/cross_chain_test.go
@@ -1,9 +1,9 @@
 package core_test
 
 import (
-	core "synnergy-network/core"
+	"math/big"
+	. "synnergy-network/core"
 	"testing"
-	"time"
 )
 
 // TestRegisterBridge ensures a bridge is persisted and retrievable
@@ -108,5 +108,4 @@ func (l *simpleLedger) CallContract(Address, Address, []byte, *big.Int, uint64) 
 func (l *simpleLedger) StaticCall(Address, Address, []byte, uint64) ([]byte, bool, error) {
 	return nil, false, nil
 }
-func (l *simpleLedger) SelfDestruct(Address, Address)          {}
-func (l *simpleLedger) Burn(addr Address, amount uint64) error { return nil }
+func (l *simpleLedger) SelfDestruct(Address, Address) {}


### PR DESCRIPTION
## Summary
- fix cross-chain integration test imports and ledger mock
- update consensus tests with direct core imports and mock authority

## Testing
- `cd synnergy-network && go test ./tests -run TestProposeSubBlock -count=1` *(fails: shuffleAddresses redeclared in synnergy-network/core)*

------
https://chatgpt.com/codex/tasks/task_e_688e18d21f80832099fb3ba5fc363e4b