### PR TITLE
refactor: improve packaging and build matrix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+__MACOSX
+dist
+synnergy-network/GUI
+synnergy-network/tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.24.3 AS builder
+FROM golang:1.22 AS builder
 WORKDIR /src
 COPY . .
-RUN cd synnergy-network && go mod download && GOFLAGS="-trimpath" go build -o synnergy ./cmd/synnergy
+RUN cd synnergy-network && go mod download && GOFLAGS="-trimpath" go build -o /synnergy ./cmd/synnergy
 
 FROM debian:bullseye-slim
 WORKDIR /app
-COPY --from=builder /src/synnergy-network ./synnergy-network
+COPY --from=builder /synnergy ./synnergy
 COPY docker-entrypoint.sh ./docker-entrypoint.sh
-RUN chmod +x docker-entrypoint.sh synnergy-network/synnergy
-WORKDIR /app
+RUN chmod +x docker-entrypoint.sh synnergy
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd synnergy-network
-
 ./synnergy network start &
 NET_PID=$!
 

--- a/scripts/build_matrix.sh
+++ b/scripts/build_matrix.sh
@@ -44,9 +44,13 @@ for platform in "${platforms[@]}"; do
 
 done
 
-# Build and validate Docker image
-cd "$ROOT"
-echo "Building Docker image synnergy:latest..."
-docker build -t synnergy:latest .
-docker image inspect synnergy:latest >/dev/null
-echo "Docker image synnergy:latest built successfully"
+# Build and validate Docker image when docker is available
+if command -v docker >/dev/null 2>&1; then
+  cd "$ROOT"
+  echo "Building Docker image synnergy:latest..."
+  docker build -t synnergy:latest .
+  docker image inspect synnergy:latest >/dev/null
+  echo "Docker image synnergy:latest built successfully"
+else
+  echo "Docker not found; skipping Docker image build"
+fi


### PR DESCRIPTION
## Summary
- streamline Dockerfile using stable Go base image and copy only built binary
- simplify docker entrypoint and add docker ignore to trim build context
- harden build matrix script with docker availability check

## Testing
- `shellcheck scripts/build_matrix.sh docker-entrypoint.sh`
- `scripts/build_matrix.sh >/tmp/build_matrix.log && tail -n 20 /tmp/build_matrix.log`

------
https://chatgpt.com/codex/tasks/task_e_688e18e2f954832083929bac933ee5b9