### PR TITLE
docs: add final quality gate report

### DIFF
--- a/docs/final-quality-gate.md
+++ b/docs/final-quality-gate.md
@@ -1,0 +1,36 @@
+# Final Quality Gate
+
+The Stage 30 assessment verifies that all preceding remediation stages
+have been successfully completed and the project is ready for production.
+
+## Verification Commands
+
+- `go build ./...` – ensures all Go packages compile
+- `go test ./...` – executes unit test suites
+- `go vet ./...` – performs static analysis
+- `npm audit` – scans JavaScript dependencies for vulnerabilities
+
+## Current Status
+
+Running `go build ./...` produced the following output:
+
+```text
+pattern ./...: directory prefix . does not contain main module or its
+selected dependencies
+```
+
+This indicates that a Go module definition (`go.mod`) is missing or
+incomplete, preventing compilation of the project. As a result, earlier
+stages—particularly Stage 1 (Module Initialization)—are not yet complete.
+
+## Next Steps
+
+1. Create a valid `go.mod` file at the repository root and ensure all
+   packages are included.
+2. Rerun the verification commands listed above and resolve any remaining
+   issues.
+3. When all commands succeed without errors, record the results and
+   obtain final sign-off for production deployment.
+
+Until these prerequisites are satisfied, the project cannot pass the
+final quality gate.


### PR DESCRIPTION
## Summary
- add Stage 30 final quality gate report outlining verification commands and current build status

## Testing
- `markdownlint docs/final-quality-gate.md`
- `go build ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688e18f649c8832084b7259ce8e27ab6