### PR TITLE
chore: ignore ESLint configs during linting

### DIFF
--- a/synnergy-network/GUI/smart-contract-marketplace/eslint.config.js
+++ b/synnergy-network/GUI/smart-contract-marketplace/eslint.config.js
@@ -1,5 +1,8 @@
 export default [
   {
+    ignores: ["eslint.config.js"],
+  },
+  {
     files: ["**/*.js"],
     languageOptions: {
       ecmaVersion: 2021,

--- a/synnergy-network/GUI/token-creation-tool/eslint.config.js
+++ b/synnergy-network/GUI/token-creation-tool/eslint.config.js
@@ -1,5 +1,8 @@
 export default [
   {
+    ignores: ["eslint.config.js"],
+  },
+  {
     files: ["**/*.js"],
     languageOptions: {
       ecmaVersion: 2021,


### PR DESCRIPTION
## Summary
- update flat ESLint configs to ignore themselves so lints run clean

## Testing
- `go vet .`
- `golangci-lint run`
- `npx eslint app.js -f json` (smart-contract-marketplace)
- `npx eslint app.js -f json` (token-creation-tool)


------
https://chatgpt.com/codex/tasks/task_e_688eb6a9b7f48320a9ccc490ec2ffc77