### PR TITLE
cli: block node startup on signals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -772,9 +772,11 @@ To categorise and resolve all current error types across the 701 files in `synne
     - Break import cycles between packages such as Nodes and Tokens.
 14. **Stage 14 – Concurrency & Goroutines**
     - Review goroutine usage and channel operations; apply `-race` tools.
-    - Progress: `cmd/cli/historical_node.go` blocks on `ListenAndServe` and
-      closes gracefully on OS signals. Verified with `go vet`, `go build` and
-      `go test -race` for the `cmd/cli` package.
+    - Progress: `cmd/cli/historical_node.go`, `cmd/cli/full_node.go` and
+      `cmd/cli/bootstrap_node.go` block until an OS signal and stop cleanly.
+      `go vet`, `go build` and `go test -race` were attempted for the
+      `cmd/cli` package; builds currently fail due to unresolved symbols in
+      dependent packages.
 15. **Stage 15 – Resource Leakage**
     - Ensure files, DB handles, and network connections are properly closed.
 16. **Stage 16 – Logging Consistency**

--- a/synnergy-network/cmd/cli/bootstrap_node.go
+++ b/synnergy-network/cmd/cli/bootstrap_node.go
@@ -80,16 +80,13 @@ func bootStart(cmd *cobra.Command, _ []string) error {
 	if b == nil {
 		return fmt.Errorf("not initialised")
 	}
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 	b.Start()
-	go func() {
-		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-		<-sig
-		_ = b.Stop()
-		os.Exit(0)
-	}()
 	fmt.Fprintln(cmd.OutOrStdout(), "bootstrap node started")
-	return nil
+	<-sig
+	signal.Stop(sig)
+	return b.Stop()
 }
 
 func bootStop(cmd *cobra.Command, _ []string) error {

--- a/synnergy-network/cmd/cli/full_node.go
+++ b/synnergy-network/cmd/cli/full_node.go
@@ -76,16 +76,13 @@ func fullStart(cmd *cobra.Command, _ []string) error {
 	if n == nil {
 		return fmt.Errorf("not initialised")
 	}
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 	n.Start()
-	go func() {
-		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-		<-sig
-		_ = n.Stop()
-		os.Exit(0)
-	}()
 	fmt.Fprintln(cmd.OutOrStdout(), "full node started")
-	return nil
+	<-sig
+	signal.Stop(sig)
+	return n.Stop()
 }
 
 func fullStop(cmd *cobra.Command, _ []string) error {


### PR DESCRIPTION
## Summary
- ensure full node CLI blocks until interrupted and stops cleanly
- ensure bootstrap CLI blocks on OS signals and shuts down gracefully
- document Stage 14 concurrency progress for CLI nodes

## Testing
- `go vet ./cmd/cli` *(fails: pkg/utils/env.go:11:14: undefined: sync)*
- `go build ./cmd/cli` *(fails: pkg/utils/env.go:11:14: undefined: sync)*
- `go test -race ./cmd/cli` *(fails: core/txpool_stub.go:8:19: method TxPool.AddTx already declared)*

------
https://chatgpt.com/codex/tasks/task_e_688eb6e64b4c8320af917cf1c951d1df