### PR TITLE
chore(core): clarify json tags

### DIFF
--- a/synnergy-network/core/authority_apply.go
+++ b/synnergy-network/core/authority_apply.go
@@ -30,7 +30,7 @@ type AuthApplication struct {
 	ID           Hash          `json:"id"`
 	Candidate    Address       `json:"candidate"`
 	Role         AuthorityRole `json:"role"`
-	Description  string        `json:"desc"`
+	Description  string        `json:"description"`
 	Electorate   []Address     `json:"electorate"`
 	VotesFor     uint32        `json:"votes_for"`
 	VotesAgainst uint32        `json:"votes_against"`

--- a/synnergy-network/core/loanpool.go
+++ b/synnergy-network/core/loanpool.go
@@ -84,7 +84,7 @@ type Proposal struct {
 	Recipient   Address      `json:"recipient"`
 	Type        ProposalType `json:"type"`
 	Amount      uint64       `json:"amount_wei"`
-	Description string       `json:"desc"`
+	Description string       `json:"description"`
 
 	// Vote buckets
 	AuthYes uint32 `json:"auth_yes"`
@@ -96,7 +96,7 @@ type Proposal struct {
 	Deadline       int64     `json:"deadline_unix"`
 
 	Status     ProposalStatus `json:"status"`
-	ExecutedAt int64          `json:"exec_unix,omitempty"`
+	ExecutedAt int64          `json:"executed_unix,omitempty"`
 }
 
 func (p *Proposal) Marshal() []byte { b, _ := json.Marshal(p); return b }

--- a/synnergy-network/core/supply_chain.go
+++ b/synnergy-network/core/supply_chain.go
@@ -11,9 +11,9 @@ import (
 // SupplyItem represents a tracked asset in the supply chain.
 type SupplyItem struct {
 	ID          string    `json:"id"`
-	Description string    `json:"desc"`
+	Description string    `json:"description"`
 	Owner       Address   `json:"owner"`
-	Location    string    `json:"loc"`
+	Location    string    `json:"location"`
 	Status      string    `json:"status"`
 	Updated     time.Time `json:"updated"`
 }

--- a/synnergy-network/core/syn1500.go
+++ b/synnergy-network/core/syn1500.go
@@ -11,7 +11,7 @@ import (
 type ReputationEvent struct {
 	Timestamp   time.Time `json:"ts"`
 	Delta       int64     `json:"delta"`
-	Description string    `json:"desc"`
+	Description string    `json:"description"`
 }
 
 // ReputationRecord tracks score, trust level and history for an address.


### PR DESCRIPTION
## Summary
- align AuthApplication struct JSON tags with full descriptors
- standardize SupplyItem and ReputationEvent JSON field names
- expand LoanPool Proposal tags for clarity and serialization consistency

## Testing
- `go vet core/loanpool.go` *(fails: undefined: Hash)*

------
https://chatgpt.com/codex/tasks/task_e_688eb6c6ed3483209c0fef6639c6a504