### PR TITLE
Close HTTP response bodies on error

### DIFF
--- a/synnergy-network/core/compliance.go
+++ b/synnergy-network/core/compliance.go
@@ -299,6 +299,9 @@ func MaskSensitiveFields(data map[string]string, fields []string) map[string]str
 func FetchLegalDoc(url string) (LegalDoc, error) {
 	resp, err := http.Get(url)
 	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
 		return LegalDoc{}, err
 	}
 	defer resp.Body.Close()

--- a/synnergy-network/core/external_sensor.go
+++ b/synnergy-network/core/external_sensor.go
@@ -111,6 +111,9 @@ func PollSensor(id string) ([]byte, error) {
 	}
 	resp, err := http.Get(s.Endpoint)
 	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -137,6 +140,9 @@ func TriggerWebhook(id string, payload []byte) error {
 	}
 	resp, err := http.Post(s.Endpoint, "application/octet-stream", bytes.NewReader(payload))
 	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
 		return err
 	}
 	defer resp.Body.Close()

--- a/synnergy-network/core/gateway_node.go
+++ b/synnergy-network/core/gateway_node.go
@@ -104,6 +104,9 @@ func (g *GatewayNode) QueryExternalData(name string) ([]byte, error) {
 	}
 	resp, err := http.Get(url)
 	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()

--- a/synnergy-network/core/ipfs.go
+++ b/synnergy-network/core/ipfs.go
@@ -86,6 +86,9 @@ func UnpinFile(ctx context.Context, cid string) error {
 	}
 	resp, err := ipfsSvc.client.Do(req)
 	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
 		return err
 	}
 	defer resp.Body.Close()

--- a/synnergy-network/core/storage.go
+++ b/synnergy-network/core/storage.go
@@ -141,6 +141,9 @@ func (s *Storage) Pin(ctx context.Context, data []byte, payer Address) (string, 
 
 	resp, err := s.client.Do(req)
 	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
 		return "", 0, err
 	}
 	defer resp.Body.Close()
@@ -187,6 +190,9 @@ func (s *Storage) Retrieve(ctx context.Context, cidStr string) ([]byte, error) {
 	}
 	resp, err := s.client.Do(req)
 	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
## Summary
- ensure HTTP requests across core packages always close response bodies when errors occur
- harden external sensor, compliance, gateway, storage and IPFS routines against connection leaks

## Testing
- `go vet synnergy-network/core/compliance.go` *(fails: go.mod file not found)*
- `go build ./synnergy-network/core` *(fails: cannot find main module)*

------
https://chatgpt.com/codex/tasks/task_e_688eb6f08c008320b94bd6b80c9e68ba