### PR TITLE
chore: standardize logging across explorer and bank node

### DIFF
--- a/synnergy-network/cmd/explorer/logger.go
+++ b/synnergy-network/cmd/explorer/logger.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+var logger = log.New(os.Stdout, "[EXPLORER] ", log.LstdFlags|log.Lmicroseconds)

--- a/synnergy-network/cmd/explorer/main.go
+++ b/synnergy-network/cmd/explorer/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"log"
-
 	"github.com/joho/godotenv"
 	"github.com/spf13/viper"
 
@@ -22,7 +20,7 @@ func main() {
 		ledgerPath = "./ledger.db"
 	}
 	if err := core.InitLedger(ledgerPath); err != nil {
-		log.Fatalf("ledger init: %v", err)
+		logger.Fatalf("ledger init: %v", err)
 	}
 
 	addr := viper.GetString("EXPLORER_BIND")
@@ -32,13 +30,13 @@ func main() {
 
 	svc, err := NewLedgerService()
 	if err != nil {
-		log.Fatalf("init service: %v", err)
+		logger.Fatalf("init service: %v", err)
 	}
 
 	srv := NewServer(addr, svc)
 
-	log.Printf("Explorer listening on %s", addr)
+	logger.Printf("listening on %s", addr)
 	if err := srv.Start(); err != nil {
-		log.Fatalf("server: %v", err)
+		logger.Fatalf("server: %v", err)
 	}
 }

--- a/synnergy-network/cmd/explorer/middleware.go
+++ b/synnergy-network/cmd/explorer/middleware.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"log"
 	"net/http"
 )
 
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("%s %s", r.Method, r.URL.Path)
+		logger.Printf("%s %s", r.Method, r.URL.Path)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/synnergy-network/core/bank_institutional_node.go
+++ b/synnergy-network/core/bank_institutional_node.go
@@ -91,7 +91,7 @@ func (n *BankInstitutionalNode) ComplianceReport() ([]byte, error) {
 
 // ConnectFinancialNetwork simulates establishing secure connections to legacy systems.
 func (n *BankInstitutionalNode) ConnectFinancialNetwork(endpoint string) error {
-	log.Printf("connecting to financial endpoint %s", endpoint)
+	log.Printf("[BANK NODE] connecting to financial endpoint %s", endpoint)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add centralized `[EXPLORER]` logger with microsecond precision
- route explorer main and middleware logging through the new logger
- prefix bank institutional node connection logs with `[BANK NODE]`

## Testing
- `go build ./synnergy-network/cmd/explorer` *(fails: cannot find main module)*
- `go build synnergy-network/core/bank_institutional_node.go` *(fails: undefined: Ledger)*

------
https://chatgpt.com/codex/tasks/task_e_688eb6fabd988320bf4927710d9b9d33