### PR TITLE
feat(cli): enforce recovery flag validation

### DIFF
--- a/synnergy-network/cmd/cli/monomaniac_recovery.go
+++ b/synnergy-network/cmd/cli/monomaniac_recovery.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -13,47 +14,81 @@ var recoveryCmd = &cobra.Command{
 	Short: "Account recovery operations",
 }
 
+// recoveryFlags aggregates inputs for recovery commands.
+type recoveryFlags struct {
+	owner    core.Address
+	recovery core.Address
+	phone    string
+	email    string
+}
+
 var registerRecCmd = &cobra.Command{
 	Use:   "register",
 	Short: "Register recovery credentials",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
 		ownerStr, _ := cmd.Flags().GetString("owner")
 		recStr, _ := cmd.Flags().GetString("recovery")
 		phone, _ := cmd.Flags().GetString("phone")
 		email, _ := cmd.Flags().GetString("email")
-		if ownerStr == "" {
-			return errors.New("--owner required")
+		if ownerStr == "" || recStr == "" {
+			return errors.New("--owner and --recovery required")
+		}
+		if phone == "" && email == "" {
+			return errors.New("provide --phone or --email for contact")
 		}
 		owner, err := core.StringToAddress(ownerStr)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid owner address: %w", err)
 		}
-		recAddr, _ := core.StringToAddress(recStr)
+		recAddr, err := core.StringToAddress(recStr)
+		if err != nil {
+			return fmt.Errorf("invalid recovery address: %w", err)
+		}
+		rf := recoveryFlags{owner: owner, recovery: recAddr, phone: phone, email: email}
+		ctx := context.WithValue(cmd.Context(), "recoveryFlags", rf)
+		cmd.SetContext(ctx)
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		rf := cmd.Context().Value("recoveryFlags").(recoveryFlags)
 		mgr := core.NewAccountRecovery(core.CurrentLedger())
-		info := core.RecoveryInfo{RecoveryWallet: recAddr, PhoneNumber: phone, Email: email}
-		return mgr.Register(owner, info)
+		info := core.RecoveryInfo{RecoveryWallet: rf.recovery, PhoneNumber: rf.phone, Email: rf.email}
+		return mgr.Register(rf.owner, info)
 	},
 }
 
 var recoverCmd = &cobra.Command{
 	Use:   "recover",
 	Short: "Recover an account using credentials",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
 		ownerStr, _ := cmd.Flags().GetString("owner")
 		recStr, _ := cmd.Flags().GetString("recovery")
 		phone, _ := cmd.Flags().GetString("phone")
 		email, _ := cmd.Flags().GetString("email")
-		if ownerStr == "" {
-			return errors.New("--owner required")
+		if ownerStr == "" || recStr == "" {
+			return errors.New("--owner and --recovery required")
+		}
+		if phone == "" && email == "" {
+			return errors.New("provide --phone or --email for contact")
 		}
 		owner, err := core.StringToAddress(ownerStr)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid owner address: %w", err)
 		}
-		recAddr, _ := core.StringToAddress(recStr)
+		recAddr, err := core.StringToAddress(recStr)
+		if err != nil {
+			return fmt.Errorf("invalid recovery address: %w", err)
+		}
+		rf := recoveryFlags{owner: owner, recovery: recAddr, phone: phone, email: email}
+		ctx := context.WithValue(cmd.Context(), "recoveryFlags", rf)
+		cmd.SetContext(ctx)
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		rf := cmd.Context().Value("recoveryFlags").(recoveryFlags)
 		mgr := core.NewAccountRecovery(core.CurrentLedger())
-		info := core.RecoveryInfo{RecoveryWallet: recAddr, PhoneNumber: phone, Email: email}
-		if err := mgr.Recover(owner, info); err != nil {
+		info := core.RecoveryInfo{RecoveryWallet: rf.recovery, PhoneNumber: rf.phone, Email: rf.email}
+		if err := mgr.Recover(rf.owner, info); err != nil {
 			return err
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), "account recovered")
@@ -66,10 +101,16 @@ func init() {
 	registerRecCmd.Flags().String("recovery", "", "recovery wallet")
 	registerRecCmd.Flags().String("phone", "", "phone number")
 	registerRecCmd.Flags().String("email", "", "email address")
+	registerRecCmd.MarkFlagRequired("owner")
+	registerRecCmd.MarkFlagRequired("recovery")
+
 	recoverCmd.Flags().String("owner", "", "owner address")
 	recoverCmd.Flags().String("recovery", "", "recovery wallet")
 	recoverCmd.Flags().String("phone", "", "phone number")
 	recoverCmd.Flags().String("email", "", "email address")
+	recoverCmd.MarkFlagRequired("owner")
+	recoverCmd.MarkFlagRequired("recovery")
+
 	recoveryCmd.AddCommand(registerRecCmd, recoverCmd)
 }
 


### PR DESCRIPTION
## Summary
- validate required flags for account recovery commands
- improve user feedback for missing contact info

## Testing
- `go vet ./cmd/cli/monomaniac_recovery.go` *(fails: synnergy-network/core/... undefined: RewardHalvingPeriod)*
- `go build ./cmd/cli/monomaniac_recovery.go` *(fails: synnergy-network/core/... undefined: RewardHalvingPeriod)*

------
https://chatgpt.com/codex/tasks/task_e_688eb71c086c8320946dfc82380521d9