### PR TITLE
fix: add sync import for env cache

### DIFF
--- a/synnergy-network/pkg/utils/env.go
+++ b/synnergy-network/pkg/utils/env.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"os"
 	"strconv"
-
+	"sync"
 )
 
 // envCache stores previously fetched non-empty environment variable values so


### PR DESCRIPTION
## Summary
- import `sync` for env cache

## Testing
- `go fmt pkg/utils/env.go`
- `go build ./pkg/utils`


------
https://chatgpt.com/codex/tasks/task_e_688eb7266bc48320a56874ee17d3b80d