### PR TITLE
refactor: cache env lookups and fix lint issues

### DIFF
--- a/synnergy-network/pkg/utils/env.go
+++ b/synnergy-network/pkg/utils/env.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"os"
 	"strconv"
-
+	"sync"
 )
 
 // envCache stores previously fetched non-empty environment variable values so
@@ -30,9 +30,10 @@ func clearEnvCache(key string) {
 }
 
 // EnvOrDefault returns the value of the environment variable identified by key
-// or the provided fallback if the variable is unset or empty.
+// or the provided fallback if the variable is unset or empty. Repeated lookups
+// are cached via getEnv to avoid redundant syscalls.
 func EnvOrDefault(key, fallback string) string {
-	if v, ok := os.LookupEnv(key); ok && v != "" {
+	if v, ok := getEnv(key); ok {
 		return v
 	}
 	return fallback
@@ -40,9 +41,10 @@ func EnvOrDefault(key, fallback string) string {
 
 // EnvOrDefaultInt returns the integer value of the environment variable
 // identified by key or the provided fallback if the variable is unset,
-// empty, or cannot be parsed as an integer.
+// empty, or cannot be parsed as an integer. Values are retrieved through
+// getEnv to leverage caching.
 func EnvOrDefaultInt(key string, fallback int) int {
-	if v, ok := os.LookupEnv(key); ok && v != "" {
+	if v, ok := getEnv(key); ok {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
 		}
@@ -52,9 +54,10 @@ func EnvOrDefaultInt(key string, fallback int) int {
 
 // EnvOrDefaultUint64 returns the uint64 value of the environment variable
 // identified by key or the provided fallback if the variable is unset,
-// empty, or cannot be parsed as a uint64.
+// empty, or cannot be parsed as a uint64. It also benefits from cached
+// lookups via getEnv.
 func EnvOrDefaultUint64(key string, fallback uint64) uint64 {
-	if v, ok := os.LookupEnv(key); ok && v != "" {
+	if v, ok := getEnv(key); ok {
 		if n, err := strconv.ParseUint(v, 10, 64); err == nil {
 			return n
 		}


### PR DESCRIPTION
## Summary
- integrate sync-based cache for environment lookups and wire up helper functions

## Testing
- `go vet ./pkg/utils`
- `staticcheck ./pkg/utils`
- `go test ./pkg/utils`


------
https://chatgpt.com/codex/tasks/task_e_688eb730f6fc83209e1906b6612e7ef5