### PR TITLE
chore: refine test naming for go style

### DIFF
--- a/synnergy-network/core/account_and_balance_operations_test.go
+++ b/synnergy-network/core/account_and_balance_operations_test.go
@@ -2,7 +2,7 @@ package core
 
 import "testing"
 
-func TestAccountManager_CreateAndBalance(t *testing.T) {
+func TestAccountManagerCreateAndBalance(t *testing.T) {
 	ledger := &Ledger{TokenBalances: make(map[string]uint64)}
 	am := NewAccountManager(ledger)
 	var addr Address
@@ -25,7 +25,7 @@ func TestAccountManager_CreateAndBalance(t *testing.T) {
 	}
 }
 
-func TestAccountManager_TransferAndDelete(t *testing.T) {
+func TestAccountManagerTransferAndDelete(t *testing.T) {
 	ledger := &Ledger{TokenBalances: make(map[string]uint64)}
 	am := NewAccountManager(ledger)
 

--- a/synnergy-network/core/ledger_test.go
+++ b/synnergy-network/core/ledger_test.go
@@ -31,7 +31,7 @@ func tmpLedgerConfig(t *testing.T, genesis *Block) (LedgerConfig, func()) {
 // Test NewLedger with and without genesis
 //-------------------------------------------------------------
 
-func TestNewLedger_Init(t *testing.T) {
+func TestNewLedgerInit(t *testing.T) {
 	tests := []struct {
 		name       string
 		genesis    *Block
@@ -58,7 +58,7 @@ func TestNewLedger_Init(t *testing.T) {
 // Test AddBlock height validation
 //-------------------------------------------------------------
 
-func TestAddBlock_HeightMismatch(t *testing.T) {
+func TestAddBlockHeightMismatch(t *testing.T) {
 	genesis := &Block{Header: BlockHeader{Height: 0}}
 	cfg, _ := tmpLedgerConfig(t, genesis)
 	led, _ := NewLedger(cfg)
@@ -74,7 +74,7 @@ func TestAddBlock_HeightMismatch(t *testing.T) {
 // Test MintToken and BalanceOf
 //-------------------------------------------------------------
 
-func TestMintToken_Balance(t *testing.T) {
+func TestMintTokenBalance(t *testing.T) {
 	cfg, _ := tmpLedgerConfig(t, nil)
 	led, _ := NewLedger(cfg)
 	addr := Address{0xAA}
@@ -117,7 +117,7 @@ func TestSnapshotRoundTrip(t *testing.T) {
 // Test AppendSubBlock continuity rule
 //-------------------------------------------------------------
 
-func TestAppendSubBlock_HeightCheck(t *testing.T) {
+func TestAppendSubBlockHeightCheck(t *testing.T) {
 	// bootstrap ledger with one block that has no subheaders yet
 	blk := &Block{Header: BlockHeader{Height: 0}, Body: BlockBody{SubHeaders: []SubBlockHeader{}}}
 	cfg, _ := tmpLedgerConfig(t, blk)


### PR DESCRIPTION
## Summary
- Align core ledger tests with Go naming conventions by removing underscores
- Update account manager tests to use Go's PascalCase naming

## Testing
- `go test ./core -run TestNewLedgerInit -count=1` *(fails: Address redeclared, Ledger redeclared, undefined identifiers, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688eb73a51648320a565416bed1540ec