### PR TITLE
refactor loanpool config handling

### DIFF
--- a/synnergy-network/cmd/cli/loanpool.go
+++ b/synnergy-network/cmd/cli/loanpool.go
@@ -35,7 +35,7 @@ func ensureLoanPool(cmd *cobra.Command, _ []string) error {
 		return errors.New("ledger not initialised")
 	}
 	std := log.New(logrus.StandardLogger().Out, "", log.LstdFlags)
-	loanPool = core.NewLoanPool(std, led, lpElector{}, &core.LoanPool{})
+	loanPool = core.NewLoanPool(std, led, lpElector{}, &core.LoanPoolConfig{})
 	return nil
 }
 

--- a/synnergy-network/core/loanpool.go
+++ b/synnergy-network/core/loanpool.go
@@ -137,14 +137,7 @@ type LoanPool struct {
 	ledger StateRW
 	auth   electorateSelector
 
-	cfg struct {
-		ElectorateSize       int                       `yaml:"electorate_size"`
-		VotePeriod           time.Duration             `yaml:"vote_period"`
-		SpamFee              uint64                    `yaml:"spam_fee"`
-		RedistributeInterval time.Duration             `yaml:"redistribute_interval"`
-		RedistributePerc     int                       `yaml:"redistribute_perc"`
-		Rules                map[ProposalType]VoteRule `yaml:"rules"`
-	}
+	cfg LoanPoolConfig
 
 	nextRand         uint64
 	lastRedistribute int64
@@ -161,19 +154,15 @@ func init() {
 	}
 }
 
-func NewLoanPool(lg *log.Logger, led StateRW, auth electorateSelector, cfgYAML *LoanPool) *LoanPool {
-	// cfgYAML is loaded elsewhere, cast values we need.
+func NewLoanPool(lg *log.Logger, led StateRW, auth electorateSelector, cfg *LoanPoolConfig) *LoanPool {
 	lp := &LoanPool{
 		logger: lg,
 		ledger: led,
 		auth:   auth,
 	}
-	lp.cfg.ElectorateSize = cfgYAML.cfg.ElectorateSize
-	lp.cfg.VotePeriod = cfgYAML.cfg.VotePeriod
-	lp.cfg.SpamFee = cfgYAML.cfg.SpamFee
-	lp.cfg.RedistributeInterval = cfgYAML.cfg.RedistributeInterval
-	lp.cfg.RedistributePerc = cfgYAML.cfg.RedistributePerc
-	lp.cfg.Rules = cfgYAML.cfg.Rules
+	if cfg != nil {
+		lp.cfg = *cfg
+	}
 	return lp
 }
 

--- a/synnergy-network/core/loanpool_config.go
+++ b/synnergy-network/core/loanpool_config.go
@@ -1,0 +1,13 @@
+package core
+
+import "time"
+
+// LoanPoolConfig defines configuration parameters for LoanPool.
+type LoanPoolConfig struct {
+	ElectorateSize       int                       `yaml:"electorate_size"`
+	VotePeriod           time.Duration             `yaml:"vote_period"`
+	SpamFee              uint64                    `yaml:"spam_fee"`
+	RedistributeInterval time.Duration             `yaml:"redistribute_interval"`
+	RedistributePerc     int                       `yaml:"redistribute_perc"`
+	Rules                map[ProposalType]VoteRule `yaml:"rules"`
+}

--- a/synnergy-network/tests/loanpool_test.go
+++ b/synnergy-network/tests/loanpool_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
-	core "synnergy-network/core"
+	. "synnergy-network/core"
 	"testing"
 	"time"
 )
@@ -109,12 +109,11 @@ func addrWith(b byte) Address { return Address{b} }
 
 func TestLoanPoolSubmit(t *testing.T) {
 	led := newLpLedger()
-	lpCfg := &LoanPool{}
-	lpCfg.cfg.ElectorateSize = 3
-	lpCfg.cfg.VotePeriod = time.Hour
-	lpCfg.cfg.SpamFee = 0
-	lpCfg.cfg.Rules = map[ProposalType]VoteRule{
-		StandardLoan: {EnableAuthVotes: true},
+	lpCfg := &LoanPoolConfig{
+		ElectorateSize: 3,
+		VotePeriod:     time.Hour,
+		SpamFee:        0,
+		Rules:          map[ProposalType]VoteRule{StandardLoan: {EnableAuthVotes: true}},
 	}
 	elector := mockElector{authSet: map[Address]bool{addrWith(1): true}, elect: []Address{addrWith(1)}}
 	lp := NewLoanPool(nil, led, elector, lpCfg)
@@ -163,10 +162,11 @@ func TestLoanPoolVote(t *testing.T) {
 	rules := map[ProposalType]VoteRule{
 		EducationGrant: {EnableAuthVotes: true, EnablePublicVotes: true, AuthQuorum: 1, AuthMajority: 50, PubQuorum: 1, PubMajority: 50},
 	}
-	cfgLP := &LoanPool{}
-	cfgLP.cfg.ElectorateSize = 1
-	cfgLP.cfg.VotePeriod = time.Hour
-	cfgLP.cfg.Rules = rules
+	cfgLP := &LoanPoolConfig{
+		ElectorateSize: 1,
+		VotePeriod:     time.Hour,
+		Rules:          rules,
+	}
 	lp := NewLoanPool(nil, led, mockElector{authSet: map[Address]bool{authAddr: true}, elect: []Address{authAddr}}, cfgLP)
 	id, _ := lp.Submit(authAddr, addrWith(9), EducationGrant, 100, "edu")
 
@@ -201,8 +201,7 @@ func TestLoanPoolDisburse(t *testing.T) {
 	led := newLpLedger()
 	recipient := addrWith(5)
 
-	cfg := &LoanPool{}
-	cfg.cfg.Rules = map[ProposalType]VoteRule{}
+	cfg := &LoanPoolConfig{Rules: map[ProposalType]VoteRule{}}
 	lp := NewLoanPool(nil, led, mockElector{}, cfg)
 	id := Hash(sha256.Sum256([]byte("x")))
 	prop := Proposal{ID: id, Status: Passed, Recipient: recipient, Amount: 77}
@@ -231,9 +230,10 @@ func TestLoanPoolDisburse(t *testing.T) {
 
 func TestLoanPoolTick(t *testing.T) {
 	led := newLpLedger()
-	cfg := &LoanPool{}
-	cfg.cfg.Rules = map[ProposalType]VoteRule{StandardLoan: {EnableAuthVotes: false, EnablePublicVotes: false}}
-	cfg.cfg.VotePeriod = time.Second
+	cfg := &LoanPoolConfig{
+		Rules:      map[ProposalType]VoteRule{StandardLoan: {EnableAuthVotes: false, EnablePublicVotes: false}},
+		VotePeriod: time.Second,
+	}
 	lp := NewLoanPool(nil, led, mockElector{}, cfg)
 
 	id, _ := lp.Submit(addrWith(3), addrWith(4), StandardLoan, 50, "short")


### PR DESCRIPTION
## Summary
- decouple loan pool configuration into dedicated `LoanPoolConfig`
- update core, CLI, and tests to consume the new config struct

## Testing
- `go list -deps ./core`
- `go list -deps ./cmd/cli`
- `go mod tidy`
- `go build ./cmd/cli` *(fails: undefined symbols in core)*

------
https://chatgpt.com/codex/tasks/task_e_688eb749846c8320ad55023446227686