### PR TITLE
Add unit tests for token balance table and explorer endpoint

### DIFF
--- a/synnergy-network/cmd/explorer/server_test.go
+++ b/synnergy-network/cmd/explorer/server_test.go
@@ -76,6 +76,23 @@ func TestHandleBalanceError(t *testing.T) {
 	}
 }
 
+func TestHandleBalanceSuccess(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest(http.MethodGet, "/api/balance/good", nil)
+	rr := httptest.NewRecorder()
+	srv.router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var res map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &res); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if res["balance"].(float64) != 42 {
+		t.Fatalf("unexpected balance: %v", res)
+	}
+}
+
 func TestHandleBlocksSuccess(t *testing.T) {
 	srv := newTestServer()
 	req := httptest.NewRequest(http.MethodGet, "/api/blocks", nil)
@@ -122,7 +139,6 @@ func TestHandleTxSuccess(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 }
-
 
 func TestHandleInfo(t *testing.T) {
 	srv := newTestServer()

--- a/synnergy-network/core/Tokens/balance_table_test.go
+++ b/synnergy-network/core/Tokens/balance_table_test.go
@@ -1,0 +1,46 @@
+package Tokens
+
+import "testing"
+
+// TestBalanceTableAddGet ensures Add and Get work as expected.
+func TestBalanceTableAddGet(t *testing.T) {
+	bt := NewBalanceTable()
+	id := TokenID(1)
+	var addr Address
+	addr[0] = 0x01
+	bt.Add(id, addr, 100)
+	if got := bt.Get(id, addr); got != 100 {
+		t.Fatalf("balance %d want 100", got)
+	}
+}
+
+// TestBalanceTableSub verifies subtraction and error on insufficient funds.
+func TestBalanceTableSub(t *testing.T) {
+	bt := NewBalanceTable()
+	id := TokenID(1)
+	var addr Address
+	addr[0] = 0x02
+	bt.Add(id, addr, 50)
+	if err := bt.Sub(id, addr, 30); err != nil {
+		t.Fatalf("Sub returned error: %v", err)
+	}
+	if got := bt.Get(id, addr); got != 20 {
+		t.Fatalf("balance %d want 20", got)
+	}
+	if err := bt.Sub(id, addr, 30); err == nil {
+		t.Fatalf("expected error for insufficient balance")
+	}
+}
+
+// TestBalanceTableSet ensures Set overwrites previous balances.
+func TestBalanceTableSet(t *testing.T) {
+	bt := NewBalanceTable()
+	id := TokenID(1)
+	var addr Address
+	addr[0] = 0x03
+	bt.Add(id, addr, 5)
+	bt.Set(id, addr, 77)
+	if got := bt.Get(id, addr); got != 77 {
+		t.Fatalf("balance %d want 77", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add BalanceTable tests covering add, subtract, set and get operations
- extend explorer server tests with successful balance query

## Testing
- `go test ./core/Tokens -count=1`
- `go test ./cmd/explorer -count=1` *(fails: undefined symbols in core package)*


------
https://chatgpt.com/codex/tasks/task_e_688eb766d788832085d2c25b002f523e