### PR TITLE
chore: standardize Go formatting

### DIFF
--- a/synnergy-network/cmd/explorer/server_test.go
+++ b/synnergy-network/cmd/explorer/server_test.go
@@ -123,7 +123,6 @@ func TestHandleTxSuccess(t *testing.T) {
 	}
 }
 
-
 func TestHandleInfo(t *testing.T) {
 	srv := newTestServer()
 	req := httptest.NewRequest(http.MethodGet, "/api/info", nil)

--- a/synnergy-network/core/audit_node.go
+++ b/synnergy-network/core/audit_node.go
@@ -68,7 +68,6 @@ func (a *AuditNode) Close() error { return a.Stop() }
 // Peers returns the current peer list.
 func (a *AuditNode) Peers() []string { return a.node.Peers() }
 
-
 // LogAudit records an audit event via the manager.
 func (a *AuditNode) LogAudit(addr Address, event string, meta map[string]string) error {
 	if a.mgr == nil {

--- a/synnergy-network/core/kademlia.go
+++ b/synnergy-network/core/kademlia.go
@@ -25,7 +25,6 @@ func hash160(data []byte) [20]byte {
 	return h
 }
 
-
 // NewKademlia creates a new Kademlia instance bound to the given node ID.
 func NewKademlia(id NodeID) *Kademlia {
 	return &Kademlia{

--- a/synnergy-network/core/resource_allocator.go
+++ b/synnergy-network/core/resource_allocator.go
@@ -2,7 +2,6 @@ package core
 
 // ResourceAllocator tracks per-address gas allowances.
 type ResourceAllocator struct {
-
 	limits map[Address]uint64
 }
 

--- a/synnergy-network/core/staking_node.go
+++ b/synnergy-network/core/staking_node.go
@@ -80,4 +80,3 @@ func (s *StakingNode) Status() string {
 }
 
 var _ Nodes.StakingNodeInterface = (*StakingNode)(nil)
-

--- a/synnergy-network/core/txpool_addtx.go
+++ b/synnergy-network/core/txpool_addtx.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package core
 
 import "fmt"

--- a/synnergy-network/core/txpool_stub.go
+++ b/synnergy-network/core/txpool_stub.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package core
 
 import "errors"

--- a/synnergy-network/pkg/utils/env.go
+++ b/synnergy-network/pkg/utils/env.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"os"
 	"strconv"
-
+	"sync"
 )
 
 // envCache stores previously fetched non-empty environment variable values so


### PR DESCRIPTION
## Summary
- run gofmt across repo and normalize Go formatting
- guard stub TxPool implementations with `//go:build ignore`
- add missing `sync` import for env utility cache

## Testing
- `gofmt -l $(git ls-files '*.go')`
- `npx --yes prettier --write "**/*.{js,css,html}"`
- `go build -a -v ./pkg/utils`
- `go test ./cmd/explorer` *(fails: undefined identifiers in core packages)*


------
https://chatgpt.com/codex/tasks/task_e_688eb65fb5b48320ae1a8b2749ae2aa9