### PR TITLE
Add mutex to DataMarketplaceToken

### DIFF
--- a/synnergy-network/core/syn2400.go
+++ b/synnergy-network/core/syn2400.go
@@ -1,10 +1,14 @@
 package core
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // DataMarketplaceToken implements the SYN2400 standard.
 type DataMarketplaceToken struct {
 	BaseToken
+	lock         sync.RWMutex
 	DataHash     string
 	Description  string
 	AccessRights map[Address]string
@@ -37,49 +41,49 @@ func NewDataMarketplaceToken(meta Metadata, hash, desc string, price uint64, ini
 // UpdateMetadata modifies the token data hash and description.
 func (d *DataMarketplaceToken) UpdateMetadata(hash, desc string) {
 	d.lock.Lock()
+	defer d.lock.Unlock()
 	d.DataHash = hash
 	d.Description = desc
 	d.UpdatedAt = time.Now().UTC()
-	d.lock.Unlock()
 }
 
 // SetPrice updates the token price.
 func (d *DataMarketplaceToken) SetPrice(p uint64) {
 	d.lock.Lock()
+	defer d.lock.Unlock()
 	d.Price = p
 	d.UpdatedAt = time.Now().UTC()
-	d.lock.Unlock()
 }
 
 // SetStatus changes the token status string.
 func (d *DataMarketplaceToken) SetStatus(s string) {
 	d.lock.Lock()
+	defer d.lock.Unlock()
 	d.Status = s
 	d.UpdatedAt = time.Now().UTC()
-	d.lock.Unlock()
 }
 
 // GrantAccess gives access rights to an address.
 func (d *DataMarketplaceToken) GrantAccess(a Address, rights string) {
 	d.lock.Lock()
+	defer d.lock.Unlock()
 	if d.AccessRights == nil {
 		d.AccessRights = make(map[Address]string)
 	}
 	d.AccessRights[a] = rights
-	d.lock.Unlock()
 }
 
 // RevokeAccess removes access for an address.
 func (d *DataMarketplaceToken) RevokeAccess(a Address) {
 	d.lock.Lock()
+	defer d.lock.Unlock()
 	delete(d.AccessRights, a)
-	d.lock.Unlock()
 }
 
 // HasAccess checks whether an address has rights.
 func (d *DataMarketplaceToken) HasAccess(a Address) bool {
 	d.lock.RLock()
+	defer d.lock.RUnlock()
 	_, ok := d.AccessRights[a]
-	d.lock.RUnlock()
 	return ok
 }


### PR DESCRIPTION
## Summary
- add RWMutex lock to DataMarketplaceToken
- refactor metadata and access control methods to use deferred locking for thread safety

## Testing
- `go fmt synnergy-network/core/syn2400.go`
- `go vet synnergy-network/core/syn2400.go` *(fails: undefined: BaseToken)*
- `go build synnergy-network/core/syn2400.go` *(fails: undefined: BaseToken)*

------
https://chatgpt.com/codex/tasks/task_e_688edb1d01e08320a89198123c4301be