### PR TITLE
Import Nodes package and add staking node interface

### DIFF
--- a/synnergy-network/core/Nodes/staking_node_interface.go
+++ b/synnergy-network/core/Nodes/staking_node_interface.go
@@ -1,0 +1,21 @@
+package Nodes
+
+// StakingNodeInterface defines behaviour for nodes participating in
+// proof-of-stake consensus mechanisms.
+type StakingNodeInterface interface {
+	NodeInterface
+	// Start begins node networking and staking services.
+	Start()
+	// Stop terminates node services and frees resources.
+	Stop() error
+	// Stake locks tokens for participation in consensus.
+	Stake(Address, uint64) error
+	// Unstake releases previously locked tokens.
+	Unstake(Address, uint64) error
+	// ProposeBlock broadcasts a block proposal to peers.
+	ProposeBlock([]byte) error
+	// ValidateBlock broadcasts the validation result for a block.
+	ValidateBlock([]byte) error
+	// Status reports the current operational state.
+	Status() string
+}

--- a/synnergy-network/core/staking_node.go
+++ b/synnergy-network/core/staking_node.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 	"sync"
+
+	Nodes "synnergy-network/core/Nodes"
 )
 
 // StakingNode combines networking with staking management for PoS consensus.
@@ -50,13 +52,13 @@ func (s *StakingNode) Stop() error {
 }
 
 // Stake locks tokens via the staking manager.
-func (s *StakingNode) Stake(addr Address, amount uint64) error {
-	return s.stake.Stake(addr, amount)
+func (s *StakingNode) Stake(addr Nodes.Address, amount uint64) error {
+	return s.stake.Stake(Address(addr), amount)
 }
 
 // Unstake releases previously locked tokens.
-func (s *StakingNode) Unstake(addr Address, amount uint64) error {
-	return s.stake.Unstake(addr, amount)
+func (s *StakingNode) Unstake(addr Nodes.Address, amount uint64) error {
+	return s.stake.Unstake(Address(addr), amount)
 }
 
 // ProposeBlock broadcasts a new block proposal.


### PR DESCRIPTION
## Summary
- Import Nodes package into StakingNode and use Nodes.Address for staking operations
- Introduce StakingNodeInterface in Nodes package

## Testing
- `go build synnergy-network/core/Nodes`
- `go build synnergy-network/core/staking_node.go` *(fails: undefined BaseNode, Ledger, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688edaf0062c8320aedc601c66ab8aa3