### PR TITLE
Use AddressZero constant across token modules

### DIFF
--- a/synnergy-network/core/Tokens/base.go
+++ b/synnergy-network/core/Tokens/base.go
@@ -124,7 +124,7 @@ func (b *BaseToken) Transfer(from, to Address, amount uint64) error {
 	if bt == nil {
 		return fmt.Errorf("balances not initialised")
 	}
-	if from == (Address{}) || to == (Address{}) {
+	if from == AddressZero || to == AddressZero {
 		return fmt.Errorf("zero address")
 	}
 	if err := bt.Sub(b.id, from, amount); err != nil {
@@ -170,7 +170,7 @@ func (b *BaseToken) Allowance(owner, spender Address) uint64 {
 func (b *BaseToken) Approve(owner, spender Address, amount uint64) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if owner == (Address{}) || spender == (Address{}) {
+	if owner == AddressZero || spender == AddressZero {
 		return fmt.Errorf("zero address")
 	}
 	if b.allowance == nil {
@@ -190,7 +190,7 @@ func (b *BaseToken) Mint(to Address, amount uint64) error {
 	if b.meta.FixedSupply {
 		return fmt.Errorf("fixed supply token")
 	}
-	if to == (Address{}) {
+	if to == AddressZero {
 		return fmt.Errorf("zero address")
 	}
 	if b.balances == nil {
@@ -208,7 +208,7 @@ func (b *BaseToken) Burn(from Address, amount uint64) error {
 	if b.balances == nil {
 		return fmt.Errorf("balances not initialised")
 	}
-	if from == (Address{}) {
+	if from == AddressZero {
 		return fmt.Errorf("zero address")
 	}
 	if err := b.balances.Sub(b.id, from, amount); err != nil {

--- a/synnergy-network/core/Tokens/index.go
+++ b/synnergy-network/core/Tokens/index.go
@@ -11,6 +11,9 @@ import "time"
 // of direct core dependencies.
 type Address [20]byte
 
+// AddressZero represents the zero-value address for the token packages.
+var AddressZero Address
+
 // TokenStandard mirrors core.TokenStandard.  It enumerates every supported token
 // specification within the Synnergy ecosystem.  Each constant corresponds to a
 // dedicated file containing the token's implementation (e.g. syn10.go,

--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -683,6 +683,9 @@ type HDWallet struct {
 // Address represents a 20‑byte account identifier.
 type Address [20]byte
 
+// AddressZero represents the zero-value address (all bytes set to 0).
+var AddressZero Address
+
 // Hash represents a 32‑byte cryptographic hash.
 type Hash [32]byte
 

--- a/synnergy-network/core/loanpool.go
+++ b/synnergy-network/core/loanpool.go
@@ -191,7 +191,7 @@ func (h Hash) Hex() string {
 	return hex.EncodeToString(h[:])
 }
 
-var BurnAddress = Address{} // zeroed address [20]byte
+var BurnAddress = AddressZero // zeroed address [20]byte
 
 func (lp *LoanPool) Submit(creator, recipient Address, pType ProposalType, amount uint64, desc string) (Hash, error) {
 	if amount == 0 {

--- a/synnergy-network/core/syn3200.go
+++ b/synnergy-network/core/syn3200.go
@@ -60,7 +60,7 @@ func (t *Syn3200Token) CreateBill(issuer, payer Address, amount uint64, due time
 	t.bills[id] = b
 	_ = t.Mint(payer, amount)
 	if t.ledger != nil {
-		t.ledger.EmitTransfer(t.ID(), Address{}, payer, amount)
+		t.ledger.EmitTransfer(t.ID(), AddressZero, payer, amount)
 	}
 	return id
 }

--- a/synnergy-network/core/syn721_token.go
+++ b/synnergy-network/core/syn721_token.go
@@ -95,7 +95,7 @@ func (t *SYN721Token) MintWithMeta(to Address, md SYN721Metadata) (uint64, error
 	t.metaStore[id] = md
 	t.meta.TotalSupply++
 	if t.BaseToken.ledger != nil {
-		t.BaseToken.ledger.EmitTransfer(t.BaseToken.id, Address{}, to, 1)
+		t.BaseToken.ledger.EmitTransfer(t.BaseToken.id, AddressZero, to, 1)
 	}
 	return id, nil
 }
@@ -122,7 +122,7 @@ func (t *SYN721Token) Burn(from Address, nftID uint64) error {
 	delete(t.approvals, nftID)
 	t.meta.TotalSupply--
 	if t.BaseToken.ledger != nil {
-		t.BaseToken.ledger.EmitTransfer(t.BaseToken.id, from, Address{}, 1)
+		t.BaseToken.ledger.EmitTransfer(t.BaseToken.id, from, AddressZero, 1)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- define `AddressZero` in core and token packages
- replace hard-coded zero addresses in Syn3200, Syn721, base token, and loan pool modules

## Testing
- `go vet synnergy-network/core/syn3200.go` *(fails: undefined: Address)*
- `go vet synnergy-network/core/Tokens/base.go` *(fails: undefined: TokenStandard)*

------
https://chatgpt.com/codex/tasks/task_e_688edb0df5788320b39395eb5a5dc90a