### PR TITLE
Define TxPayment type for wallet management

### DIFF
--- a/synnergy-network/core/tx_types_nontokens.go
+++ b/synnergy-network/core/tx_types_nontokens.go
@@ -1,0 +1,18 @@
+//go:build !tokens
+
+package core
+
+// TxType identifiers for basic transaction categories.
+// These values are provided here for builds that do not
+// include the full token implementation (build tag "tokens").
+// When the "tokens" tag is enabled, an extended set of
+// transaction logic is compiled in transactions.go.
+
+const (
+	// TxPayment represents a standard currency transfer.
+	TxPayment TxType = iota + 1
+	// TxContractCall identifies a generic smart contract invocation.
+	TxContractCall
+	// TxReversal denotes an authority-approved transaction reversal.
+	TxReversal
+)


### PR DESCRIPTION
## Summary
- provide transaction type constants for builds without `tokens` tag
- fix undefined `TxPayment` in wallet management by supplying `TxType` enums

## Testing
- `go build wallet_management.go tx_types_nontokens.go` *(fails: undefined Ledger, HDWallet, Address, TxType)*

------
https://chatgpt.com/codex/tasks/task_e_688edb386ee88320a2c74d4d8346fa7f