### PR TITLE
core: add FromCommon helper for fee distribution

### DIFF
--- a/synnergy-network/core/address_from_common.go
+++ b/synnergy-network/core/address_from_common.go
@@ -1,0 +1,13 @@
+//go:build !tokens
+
+package core
+
+import "github.com/ethereum/go-ethereum/common"
+
+// FromCommon converts a go-ethereum common.Address into the core Address type.
+// It copies the 20-byte address into our Address array.
+func FromCommon(a common.Address) Address {
+	var out Address
+	copy(out[:], a.Bytes())
+	return out
+}


### PR DESCRIPTION
## Summary
- add `FromCommon` helper for non-token builds so fee distribution can convert `common.Address` to internal `Address`

## Testing
- `go build synnergy-network/core/transaction_distribution.go synnergy-network/core/address_from_common.go synnergy-network/core/common_structs.go` *(fails: undefined: Log)*

------
https://chatgpt.com/codex/tasks/task_e_688edb458eac83208055687eac53c2df