### PR TITLE
core: provide FromCommon helper

### DIFF
--- a/synnergy-network/core/from_common.go
+++ b/synnergy-network/core/from_common.go
@@ -1,0 +1,13 @@
+//go:build !tokens
+// +build !tokens
+
+package core
+
+import "github.com/ethereum/go-ethereum/common"
+
+// FromCommon converts an Ethereum common.Address to the Synnergy Address type.
+func FromCommon(a common.Address) Address {
+	var out Address
+	copy(out[:], a.Bytes())
+	return out
+}


### PR DESCRIPTION
## Summary
- expose FromCommon helper when building without tokens tag

## Testing
- `go vet ./synnergy-network/core` *(fails: Address redeclared, undefined: Nodes, RewardHalvingPeriod, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688edb52a0b0832080ff213ca5b6ebdb