### PR TITLE
core: define TxReversal transaction type

### DIFF
--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -621,6 +621,15 @@ type Storage struct {
 // transactions.go but is repeated here to avoid build tag dependencies.
 type TxType uint8
 
+const (
+	// TxPayment transfers value between addresses.
+	TxPayment TxType = iota + 1
+	// TxContractCall executes a smart contract.
+	TxContractCall
+	// TxReversal denotes a reversal of a previous transaction.
+	TxReversal
+)
+
 type Transaction struct {
 	// core fields
 	Type             TxType            `json:"type"`


### PR DESCRIPTION
## Summary
- define TxReversal in TxType enumeration so reversals compile

## Testing
- `go build synnergy-network/core/transactionreversal.go synnergy-network/core/common_structs.go` *(fails: undefined types TokenID, PoolID, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688edb5ef96c8320bcee9c1232b1abbc