### PR TITLE
feat: add consensus start hook

### DIFF
--- a/synnergy-network/core/consensus_start.go
+++ b/synnergy-network/core/consensus_start.go
@@ -1,0 +1,20 @@
+package core
+
+import "context"
+
+// Start initializes consensus processing loops.
+// It currently logs startup and listens for context cancellation.
+func (sc *SynnergyConsensus) Start(ctx context.Context) {
+	if sc == nil {
+		return
+	}
+	if sc.logger != nil {
+		sc.logger.Println("consensus started")
+	}
+	go func() {
+		<-ctx.Done()
+		if sc.logger != nil {
+			sc.logger.Println("consensus stopped")
+		}
+	}()
+}


### PR DESCRIPTION
## Summary
- add Start method to SynnergyConsensus for basic lifecycle logging

## Testing
- `go vet ./synnergy-network/core` *(fails: Address redeclared, shuffleAddresses undefined, RewardHalvingPeriod undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688edb94ec54832092d08f0f8c92be68