### PR TITLE
feat: expose pool ValidateTx in consensus

### DIFF
--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -135,7 +135,7 @@ type SynnergyConsensus struct {
 	ledger *Ledger // ← pointer, not value
 	p2p    interface{}
 	crypto interface{}
-	pool   interface{}
+	pool   txPool
 	auth   interface{}
 
 	mu            sync.Mutex

--- a/synnergy-network/core/consensus.go
+++ b/synnergy-network/core/consensus.go
@@ -70,6 +70,7 @@ const (
 
 type txPool interface {
 	Pick(max int) [][]byte
+	ValidateTx(tx *Transaction) error
 }
 
 type networkAdapter interface {


### PR DESCRIPTION
## Summary
- allow consensus to access transaction validation by adding ValidateTx to txPool
- type SynnergyConsensus pool field with txPool to surface ValidateTx for validator nodes

## Testing
- `go build -tags tokens synnergy-network/core/validator_node.go synnergy-network/core/consensus.go synnergy-network/core/common_structs.go synnergy-network/core/transactions.go` *(fails: interrupted after long dependency download)*

------
https://chatgpt.com/codex/tasks/task_e_688edba3b58883209279f65968f3ade6