### PR TITLE
fix: expose ProposeSubBlock

### DIFF
--- a/synnergy-network/core/consensus.go
+++ b/synnergy-network/core/consensus.go
@@ -1,6 +1,3 @@
-//go:build tokens
-// +build tokens
-
 package core
 
 // SynnergyConsensus – hybrid PoH + PoS sub‑blocks, aggregated under PoW main block.
@@ -29,13 +26,8 @@ import (
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"math/big"
-	Tokens "synnergy-network/core/Tokens"
 	"time"
 )
-
-// Compile-time assertion to ensure the token interfaces are linked
-// Reference to TokenInterfaces for package usage
-var _ Tokens.TokenInterfaces
 
 // ---------------------------------------------------------------------
 // Consensus constants


### PR DESCRIPTION
## Summary
- remove token build constraint and compile-time token dependency from consensus engine

## Testing
- `go build synnergy-network/core/consensus.go synnergy-network/core/common_structs.go` *(fails: undefined: AuthorityRole)*

------
https://chatgpt.com/codex/tasks/task_e_688edbb0a5f88320bed633d54dd618f9