### PR TITLE
Add Transaction IDHex helper

### DIFF
--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -10,6 +10,7 @@ package core
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -649,6 +650,11 @@ type Transaction struct {
 func (tx *Transaction) HashTx() Hash {
 	b, _ := json.Marshal(tx)
 	return sha256.Sum256(b)
+}
+
+// IDHex returns the transaction hash as a hex string.
+func (tx *Transaction) IDHex() string {
+	return hex.EncodeToString(tx.Hash[:])
 }
 
 type TxInput struct {

--- a/synnergy-network/core/transactions.go
+++ b/synnergy-network/core/transactions.go
@@ -210,10 +210,6 @@ func NewTxPool(
 	}
 }
 
-func (tx *Transaction) IDHex() string {
-	return hex.EncodeToString(tx.Hash[:])
-}
-
 // -----------------------------------------------------------------------------
 // TxPool operations
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expose `Transaction.IDHex` to return a hex string of a transaction hash
- remove duplicate `IDHex` implementation from `transactions.go`

## Testing
- `go test ./synnergy-network/core -run TestDummy` *(fails: command interrupted after dependency download)*

------
https://chatgpt.com/codex/tasks/task_e_688edbcb5e208320b213db7fd79de458