### PR TITLE
core: remove unused errors import

### DIFF
--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -4,9 +4,10 @@ package core
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/libp2p/go-libp2p"
@@ -14,8 +15,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/sirupsen/logrus"
-	"net"
-	"sync"
 )
 
 func NewNode(cfg Config) (*Node, error) {


### PR DESCRIPTION
## Summary
- remove unused `errors` import from core/network.go and tidy import grouping

## Testing
- `go test network.go network_test.go common_structs.go nat_traversal.go` *(fails: undefined: Log, TokenID, Token, PoolID, Location)*

------
https://chatgpt.com/codex/tasks/task_e_688edbd8801c83208aa9a6fb80288ed9