### PR TITLE
fix: import nodes package in staking node

### DIFF
--- a/synnergy-network/core/staking_node.go
+++ b/synnergy-network/core/staking_node.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	Nodes "synnergy-network/core/Nodes"
+	nodes "synnergy-network/core/Nodes"
 )
 
 // StakingNode combines networking with staking management for PoS consensus.
@@ -52,12 +52,12 @@ func (s *StakingNode) Stop() error {
 }
 
 // Stake locks tokens via the staking manager.
-func (s *StakingNode) Stake(addr Nodes.Address, amount uint64) error {
+func (s *StakingNode) Stake(addr nodes.Address, amount uint64) error {
 	return s.stake.Stake(Address(addr), amount)
 }
 
 // Unstake releases previously locked tokens.
-func (s *StakingNode) Unstake(addr Nodes.Address, amount uint64) error {
+func (s *StakingNode) Unstake(addr nodes.Address, amount uint64) error {
 	return s.stake.Unstake(Address(addr), amount)
 }
 
@@ -81,4 +81,4 @@ func (s *StakingNode) Status() string {
 	}
 }
 
-var _ Nodes.StakingNodeInterface = (*StakingNode)(nil)
+var _ nodes.StakingNodeInterface = (*StakingNode)(nil)


### PR DESCRIPTION
## Summary
- fix undefined Nodes import in staking_node by explicitly importing nodes package

## Testing
- `go build synnergy-network/core/staking_node.go` *(fails: undefined BaseNode, Ledger, DAOStaking, Config, LedgerConfig, NewNode, NewLedger, InitDAOStaking, NewBaseNode; missing method Broadcast)*

------
https://chatgpt.com/codex/tasks/task_e_688f5c8c6b788320aeb34ba211b7a7ba