### PR TITLE
Add global AddressZero constant

### DIFF
--- a/synnergy-network/core/address_zero.go
+++ b/synnergy-network/core/address_zero.go
@@ -1,0 +1,9 @@
+package core
+
+// AddressZero represents the zero-value address (all 20 bytes set to zero).
+//
+// The variable is intentionally declared at package level so that all token
+// modules can reference a single sentinel value when performing mint, burn or
+// escrow operations.  Treat it as a read-only value.
+var AddressZero Address
+

--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -698,10 +698,6 @@ type HDWallet struct {
 // Address represents a 20‑byte account identifier.
 type Address [20]byte
 
-// AddressZero represents the zero-value address (all bytes zero).
-// It is used as a sentinel in token and ledger operations.
-var AddressZero Address
-
 // Hash represents a 32‑byte cryptographic hash.
 type Hash [32]byte
 


### PR DESCRIPTION
## Summary
- define AddressZero variable in dedicated file for reuse across token modules
- tidy common_structs.go by removing embedded zero-address declaration

## Testing
- `gofmt -w synnergy-network/core/address_zero.go synnergy-network/core/common_structs.go` *(command not found: gofmt)*
- `apt-get install -y golang-go` *(unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_688f5c9b71b883209e57e212a2f3a19b