### PR TITLE
refactor: centralize zero address constant

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -81,7 +81,7 @@ func deploy(path string) error {
         return err
     }
     reg := core.GetContractRegistry()
-    return reg.Deploy(core.Address{}, code, nil, 1_000_000)
+    return reg.Deploy(core.AddressZero, code, nil, 1_000_000)
 }
 ```
 

--- a/synnergy-network/cmd/cli/contracts.go
+++ b/synnergy-network/cmd/cli/contracts.go
@@ -155,7 +155,7 @@ func handleDeploy(cmd *cobra.Command, _ []string) error {
 	}
 
 	// derive address & register
-	caller := core.Address{} // system account 0x0…; could be flag in future
+	caller := core.AddressZero // system account 0x0…; could be flag in future
 	addr := core.DeriveContractAddress(caller, code)
 	cr := core.GetContractRegistry()
 	if err := cr.Deploy(addr, code, ricData, df.gas); err != nil {
@@ -191,7 +191,7 @@ func handleInvoke(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("args must be hex bytes")
 	}
 
-	caller := core.Address{} // could add flag later
+	caller := core.AddressZero // could add flag later
 	out, err := core.GetContractRegistry().Invoke(caller, addr, inv.method, argBytes, inv.gas)
 	if err != nil {
 		return err
@@ -214,7 +214,7 @@ func handleDebug(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("args must be hex bytes")
 	}
 
-	caller := core.Address{}
+	caller := core.AddressZero
 	rec, err := core.GetContractRegistry().InvokeWithReceipt(caller, addr, df.method, argBytes, df.gas)
 	if err != nil {
 		return err

--- a/synnergy-network/cmd/cli/data_resource_management.go
+++ b/synnergy-network/cmd/cli/data_resource_management.go
@@ -22,7 +22,7 @@ func newDRController() *DataResourceController {
 func drmParseAddr(a string) (core.Address, error) {
 	b, err := hex.DecodeString(strings.TrimPrefix(a, "0x"))
 	if err != nil || len(b) != 20 {
-		return core.Address{}, fmt.Errorf("invalid address")
+		return core.AddressZero, fmt.Errorf("invalid address")
 	}
 	var out core.Address
 	copy(out[:], b)

--- a/synnergy-network/cmd/cli/defi.go
+++ b/synnergy-network/cmd/cli/defi.go
@@ -41,7 +41,7 @@ func defiCreateInsurance(cmd *cobra.Command, args []string) error {
 	}
 	var id core.Hash
 	copy(id[:], idBytes)
-	holder := core.Address{}
+	holder := core.AddressZero
 	b, err := hex.DecodeString(args[1])
 	if err != nil || len(b) != len(holder) {
 		return fmt.Errorf("bad address")

--- a/synnergy-network/cmd/cli/energy_efficient_node.go
+++ b/synnergy-network/cmd/cli/energy_efficient_node.go
@@ -39,7 +39,7 @@ func effInit(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	node, err := core.NewEnergyNode(cfg, led, core.Address{})
+	node, err := core.NewEnergyNode(cfg, led, core.AddressZero)
 	if err != nil {
 		return err
 	}

--- a/synnergy-network/cmd/cli/healthcare.go
+++ b/synnergy-network/cmd/cli/healthcare.go
@@ -14,7 +14,7 @@ import (
 func hcParseAddr(s string) (core.Address, error) {
 	b, err := hex.DecodeString(s)
 	if err != nil || len(b) != 20 {
-		return core.Address{}, fmt.Errorf("bad address")
+		return core.AddressZero, fmt.Errorf("bad address")
 	}
 	var a core.Address
 	copy(a[:], b)

--- a/synnergy-network/cmd/cli/insurance_token.go
+++ b/synnergy-network/cmd/cli/insurance_token.go
@@ -15,7 +15,7 @@ var (
 func itParseAddr(s string) (core.Address, error) {
 	b, err := hex.DecodeString(s)
 	if err != nil || len(b) != 20 {
-		return core.Address{}, fmt.Errorf("bad address")
+		return core.AddressZero, fmt.Errorf("bad address")
 	}
 	var a core.Address
 	copy(a[:], b)

--- a/synnergy-network/cmd/cli/master_node.go
+++ b/synnergy-network/cmd/cli/master_node.go
@@ -14,7 +14,7 @@ func ensureMaster(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	n, _ := core.NewNode(core.Config{})
-	master = core.NewMasterNode(n, &core.Ledger{}, &core.SynnergyConsensus{}, nil, core.Address{}, 0)
+	master = core.NewMasterNode(n, &core.Ledger{}, &core.SynnergyConsensus{}, nil, core.AddressZero, 0)
 	return nil
 }
 

--- a/synnergy-network/cmd/cli/plasma_management.go
+++ b/synnergy-network/cmd/cli/plasma_management.go
@@ -24,7 +24,7 @@ var plasmaDepositCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		from, err := hex.DecodeString(args[0])
-		if err != nil || len(from) != len(core.Address{}) {
+		if err != nil || len(from) != len(core.AddressZero) {
 			return fmt.Errorf("invalid from address")
 		}
 		var addr core.Address
@@ -56,7 +56,7 @@ var plasmaWithdrawCmd = &cobra.Command{
 			return err
 		}
 		toBytes, err := hex.DecodeString(args[1])
-		if err != nil || len(toBytes) != len(core.Address{}) {
+		if err != nil || len(toBytes) != len(core.AddressZero) {
 			return fmt.Errorf("invalid address")
 		}
 		var to core.Address

--- a/synnergy-network/cmd/cli/real_estate.go
+++ b/synnergy-network/cmd/cli/real_estate.go
@@ -59,7 +59,7 @@ var reRegisterCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ownerBytes, err := hex.DecodeString(args[0])
-		if err != nil || len(ownerBytes) != len(core.Address{}) {
+		if err != nil || len(ownerBytes) != len(core.AddressZero) {
 			return fmt.Errorf("invalid owner address")
 		}
 		var owner core.Address

--- a/synnergy-network/cmd/cli/rental_token.go
+++ b/synnergy-network/cmd/cli/rental_token.go
@@ -55,12 +55,12 @@ func (r rentalCtrl) register(tokenID uint32, propertyID, tenantStr, landlordStr 
 }
 
 func (r rentalCtrl) pay(id string, amount uint64) error {
-	ctx := core.NewContext(core.Address{})
+	ctx := core.NewContext(core.AddressZero)
 	return core.PayRent(ctx, id, amount)
 }
 
 func (r rentalCtrl) terminate(id string) error {
-	ctx := core.NewContext(core.Address{})
+	ctx := core.NewContext(core.AddressZero)
 	return core.TerminateRentalAgreement(ctx, id)
 }
 

--- a/synnergy-network/cmd/cli/syn1200.go
+++ b/synnergy-network/cmd/cli/syn1200.go
@@ -28,7 +28,7 @@ func syn1200HandleAddBridge(cmd *cobra.Command, args []string) error {
 	}
 	chain := args[1]
 	addrBytes, err := hex.DecodeString(args[2])
-	if err != nil || len(addrBytes) != len(core.Address{}) {
+	if err != nil || len(addrBytes) != len(core.AddressZero) {
 		return fmt.Errorf("bad address")
 	}
 	var addr core.Address

--- a/synnergy-network/cmd/cli/warehouse.go
+++ b/synnergy-network/cmd/cli/warehouse.go
@@ -44,11 +44,11 @@ func whInit(cmd *cobra.Command, _ []string) error {
 type warehouseController struct{}
 
 func (warehouseController) Add(id, name string, qty uint64) error {
-	ctx := &core.Context{Caller: core.Address{}}
+	ctx := &core.Context{Caller: core.AddressZero}
 	return wh.AddItem(ctx, id, name, qty)
 }
 func (warehouseController) Remove(id string) error {
-	ctx := &core.Context{Caller: core.Address{}}
+	ctx := &core.Context{Caller: core.AddressZero}
 	return wh.RemoveItem(ctx, id)
 }
 func (warehouseController) Move(id, owner string) error {
@@ -56,7 +56,7 @@ func (warehouseController) Move(id, owner string) error {
 	if err != nil {
 		return err
 	}
-	ctx := &core.Context{Caller: core.Address{}}
+	ctx := &core.Context{Caller: core.AddressZero}
 	return wh.MoveItem(ctx, id, addr)
 }
 func (warehouseController) List() error {

--- a/synnergy-network/core/Tokens/base.go
+++ b/synnergy-network/core/Tokens/base.go
@@ -124,7 +124,7 @@ func (b *BaseToken) Transfer(from, to Address, amount uint64) error {
 	if bt == nil {
 		return fmt.Errorf("balances not initialised")
 	}
-	if from == (Address{}) || to == (Address{}) {
+	if from == AddressZero || to == AddressZero {
 		return fmt.Errorf("zero address")
 	}
 	if err := bt.Sub(b.id, from, amount); err != nil {
@@ -170,7 +170,7 @@ func (b *BaseToken) Allowance(owner, spender Address) uint64 {
 func (b *BaseToken) Approve(owner, spender Address, amount uint64) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if owner == (Address{}) || spender == (Address{}) {
+	if owner == AddressZero || spender == AddressZero {
 		return fmt.Errorf("zero address")
 	}
 	if b.allowance == nil {
@@ -190,7 +190,7 @@ func (b *BaseToken) Mint(to Address, amount uint64) error {
 	if b.meta.FixedSupply {
 		return fmt.Errorf("fixed supply token")
 	}
-	if to == (Address{}) {
+	if to == AddressZero {
 		return fmt.Errorf("zero address")
 	}
 	if b.balances == nil {
@@ -208,7 +208,7 @@ func (b *BaseToken) Burn(from Address, amount uint64) error {
 	if b.balances == nil {
 		return fmt.Errorf("balances not initialised")
 	}
-	if from == (Address{}) {
+	if from == AddressZero {
 		return fmt.Errorf("zero address")
 	}
 	if err := b.balances.Sub(b.id, from, amount); err != nil {

--- a/synnergy-network/core/contract_management.go
+++ b/synnergy-network/core/contract_management.go
@@ -50,11 +50,11 @@ func (cm *ContractManager) TransferOwnership(addr, newOwner Address) error {
 // owner has been recorded an empty Address is returned.
 func (cm *ContractManager) OwnerOf(addr Address) (Address, error) {
 	if cm.ledger == nil {
-		return Address{}, errors.New("ledger not available")
+		return AddressZero, errors.New("ledger not available")
 	}
 	b, err := cm.ledger.GetState(ownerKey(addr))
 	if err != nil {
-		return Address{}, err
+		return AddressZero, err
 	}
 	var out Address
 	copy(out[:], b)

--- a/synnergy-network/core/contract_vm_test.go
+++ b/synnergy-network/core/contract_vm_test.go
@@ -27,12 +27,12 @@ func TestHeavyVMInvokeWithReceipt(t *testing.T) {
 	vm := core.NewHeavyVM(led, core.NewGasMeter(1_000_000), wasmer.NewEngine())
 	core.InitContracts(led, vm)
 
-	addr := core.DeriveContractAddress(core.Address{}, wasm)
+	addr := core.DeriveContractAddress(core.AddressZero, wasm)
 	if err := core.GetContractRegistry().Deploy(addr, wasm, nil, 1_000_000); err != nil {
 		t.Fatalf("deploy contract: %v", err)
 	}
 
-	rec, err := core.GetContractRegistry().InvokeWithReceipt(core.Address{}, addr, "", nil, 0)
+	rec, err := core.GetContractRegistry().InvokeWithReceipt(core.AddressZero, addr, "", nil, 0)
 	if err != nil || !rec.Status {
 		t.Fatalf("invoke error: %v %+v", err, rec)
 	}

--- a/synnergy-network/core/energy_tokens.go
+++ b/synnergy-network/core/energy_tokens.go
@@ -66,7 +66,7 @@ func (e *EnergyEngine) sustainKey(id uint64, ts int64) []byte {
 
 // RegisterAsset records a new energy asset and mints tokens to the owner.
 func (e *EnergyEngine) RegisterAsset(owner Address, assetType string, qty uint64, valid time.Time, location, cert string) (uint64, error) {
-	if owner == (Address{}) || qty == 0 || assetType == "" {
+	if owner == AddressZero || qty == 0 || assetType == "" {
 		return 0, errors.New("invalid asset parameters")
 	}
 	e.mu.Lock()

--- a/synnergy-network/core/governance.go
+++ b/synnergy-network/core/governance.go
@@ -99,7 +99,7 @@ func quorumReached(p *GovProposal) bool {
 func ParseAddress(s string) (Address, error) {
 	b, err := hex.DecodeString(s)
 	if err != nil || len(b) != 20 {
-		return Address{}, fmt.Errorf("invalid address: %s", s)
+		return AddressZero, fmt.Errorf("invalid address: %s", s)
 	}
 	var a Address
 	copy(a[:], b)

--- a/synnergy-network/core/ledger.go
+++ b/synnergy-network/core/ledger.go
@@ -864,7 +864,7 @@ func (l *Ledger) ChargeStorageRent(addr Address, bytes int64) error {
 		return nil
 	}
 	cost := uint64(bytes)
-	zero := Address{}
+	zero := AddressZero
 	return l.Transfer(addr, zero, cost)
 }
 

--- a/synnergy-network/core/loanpool.go
+++ b/synnergy-network/core/loanpool.go
@@ -191,7 +191,7 @@ func (h Hash) Hex() string {
 	return hex.EncodeToString(h[:])
 }
 
-var BurnAddress = Address{} // zeroed address [20]byte
+var BurnAddress = AddressZero // zeroed address [20]byte
 
 func (lp *LoanPool) Submit(creator, recipient Address, pType ProposalType, amount uint64, desc string) (Hash, error) {
 	if amount == 0 {

--- a/synnergy-network/core/monomaniac_recovery.go
+++ b/synnergy-network/core/monomaniac_recovery.go
@@ -71,10 +71,10 @@ func (ar *AccountRecovery) Recover(owner Address, provided RecoveryInfo) error {
 	}
 
 	matches := 0
-	if stored.IDTokenWallet == provided.IDTokenWallet && stored.IDTokenWallet != (Address{}) {
+	if stored.IDTokenWallet == provided.IDTokenWallet && stored.IDTokenWallet != AddressZero {
 		matches++
 	}
-	if stored.RecoveryWallet == provided.RecoveryWallet && stored.RecoveryWallet != (Address{}) {
+	if stored.RecoveryWallet == provided.RecoveryWallet && stored.RecoveryWallet != AddressZero {
 		matches++
 	}
 	if stored.PhoneNumber != "" && stored.PhoneNumber == provided.PhoneNumber {

--- a/synnergy-network/core/peer_management.go
+++ b/synnergy-network/core/peer_management.go
@@ -39,7 +39,7 @@ func (pm *PeerManagement) DiscoverPeers() []PeerInfo {
 	defer pm.node.peerLock.RUnlock()
 	infos := make([]PeerInfo, 0, len(pm.node.peers))
 	for _, p := range pm.node.peers {
-		infos = append(infos, PeerInfo{Address: Address{}, RTT: float64(p.Latency.Milliseconds()), Updated: time.Now().Unix()})
+		infos = append(infos, PeerInfo{Address: AddressZero, RTT: float64(p.Latency.Milliseconds()), Updated: time.Now().Unix()})
 	}
 	return infos
 }

--- a/synnergy-network/core/real_estate.go
+++ b/synnergy-network/core/real_estate.go
@@ -84,7 +84,7 @@ func ListProperties(addr Address) ([]Property, error) {
 		if err := json.Unmarshal(it.Value(), &p); err != nil {
 			return nil, err
 		}
-		if addr == (Address{}) || p.Owner == addr {
+		if addr == AddressZero || p.Owner == addr {
 			res = append(res, p)
 		}
 	}

--- a/synnergy-network/core/syn3200.go
+++ b/synnergy-network/core/syn3200.go
@@ -60,7 +60,7 @@ func (t *Syn3200Token) CreateBill(issuer, payer Address, amount uint64, due time
 	t.bills[id] = b
 	_ = t.Mint(payer, amount)
 	if t.ledger != nil {
-		t.ledger.EmitTransfer(t.ID(), Address{}, payer, amount)
+		t.ledger.EmitTransfer(t.ID(), AddressZero, payer, amount)
 	}
 	return id
 }

--- a/synnergy-network/core/syn721_token.go
+++ b/synnergy-network/core/syn721_token.go
@@ -95,7 +95,7 @@ func (t *SYN721Token) MintWithMeta(to Address, md SYN721Metadata) (uint64, error
 	t.metaStore[id] = md
 	t.meta.TotalSupply++
 	if t.BaseToken.ledger != nil {
-		t.BaseToken.ledger.EmitTransfer(t.BaseToken.id, Address{}, to, 1)
+		t.BaseToken.ledger.EmitTransfer(t.BaseToken.id, AddressZero, to, 1)
 	}
 	return id, nil
 }
@@ -122,7 +122,7 @@ func (t *SYN721Token) Burn(from Address, nftID uint64) error {
 	delete(t.approvals, nftID)
 	t.meta.TotalSupply--
 	if t.BaseToken.ledger != nil {
-		t.BaseToken.ledger.EmitTransfer(t.BaseToken.id, from, Address{}, 1)
+		t.BaseToken.ledger.EmitTransfer(t.BaseToken.id, from, AddressZero, 1)
 	}
 	return nil
 }

--- a/synnergy-network/core/transaction_distribution.go
+++ b/synnergy-network/core/transaction_distribution.go
@@ -29,7 +29,7 @@ func NewTxDistributor(ledger *Ledger) *TxDistributor {
 func AddressFromPubKey(pub []byte) (Address, error) {
 	key, err := crypto.UnmarshalPubkey(pub)
 	if err != nil {
-		return Address{}, err
+		return AddressZero, err
 	}
 	return FromCommon(crypto.PubkeyToAddress(*key)), nil
 }

--- a/synnergy-network/core/wallet.go
+++ b/synnergy-network/core/wallet.go
@@ -208,7 +208,7 @@ func pubKeyToAddress(pub ed25519.PublicKey) Address {
 func (w *HDWallet) NewAddress(account, index uint32) (Address, error) {
 	_, pub, err := w.PrivateKey(account, index)
 	if err != nil {
-		return Address{}, err
+		return AddressZero, err
 	}
 	return pubKeyToAddress(pub), nil
 }

--- a/synnergy-network/tests/cross_chain_test.go
+++ b/synnergy-network/tests/cross_chain_test.go
@@ -88,7 +88,7 @@ func (l *simpleLedger) GetCode(Address) []byte                              { re
 func (l *simpleLedger) GetCodeHash(Address) Hash                            { return Hash{} }
 func (l *simpleLedger) AddLog(*Log)                                         {}
 func (l *simpleLedger) CreateContract(Address, []byte, *big.Int, uint64) (Address, []byte, bool, error) {
-	return Address{}, nil, false, nil
+	return AddressZero, nil, false, nil
 }
 func (l *simpleLedger) DelegateCall(Address, Address, []byte, *big.Int, uint64) error { return nil }
 func (l *simpleLedger) Call(Address, Address, []byte, *big.Int, uint64) ([]byte, error) {

--- a/synnergy-network/tests/wallet_test.go
+++ b/synnergy-network/tests/wallet_test.go
@@ -112,7 +112,7 @@ func TestSignTx(t *testing.T) {
 	if len(tx.Sig) != 96 {
 		t.Errorf("signature length want 96 got %d", len(tx.Sig))
 	}
-	if (tx.From == Address{}) {
+	if tx.From == AddressZero {
 		t.Errorf("tx.From not set")
 	}
 }


### PR DESCRIPTION
## Summary
- replace hard-coded zero addresses with `AddressZero` across core, CLI, tests, and docs for consistent sentinel value handling

## Testing
- `go test` in `synnergy-network/core/Tokens`
- `go test` in `synnergy-network/core` *(fails: NewConsensus redeclared in this block)*

------
https://chatgpt.com/codex/tasks/task_e_688f5ca664e883208014fdb50c74a0fe