### PR TITLE
core: update SYN2400 access timestamps

### DIFF
--- a/synnergy-network/core/syn2400.go
+++ b/synnergy-network/core/syn2400.go
@@ -71,6 +71,7 @@ func (d *DataMarketplaceToken) GrantAccess(a Address, rights string) {
 		d.AccessRights = make(map[Address]string)
 	}
 	d.AccessRights[a] = rights
+	d.UpdatedAt = time.Now().UTC()
 }
 
 // RevokeAccess removes access for an address.
@@ -78,6 +79,7 @@ func (d *DataMarketplaceToken) RevokeAccess(a Address) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	delete(d.AccessRights, a)
+	d.UpdatedAt = time.Now().UTC()
 }
 
 // HasAccess checks whether an address has rights.


### PR DESCRIPTION
## Summary
- update SYN2400 data token access controls to refresh `UpdatedAt`

## Testing
- `go build syn2400.go stub_syn2400.go`

------
https://chatgpt.com/codex/tasks/task_e_688f5cb141ec832091dc87feae40e537