### PR TITLE
Add TxPool snapshot method

### DIFF
--- a/synnergy-network/core/txpool_snapshot.go
+++ b/synnergy-network/core/txpool_snapshot.go
@@ -1,0 +1,15 @@
+//go:build !tokens
+
+package core
+
+// Snapshot returns a copy of all pending transactions in the pool.
+// It acquires a read lock to allow concurrent access while taking the snapshot.
+func (tp *TxPool) Snapshot() []*Transaction {
+	tp.mu.RLock()
+	defer tp.mu.RUnlock()
+
+	// Make a copy to avoid exposing internal slice allowing callers to mutate state.
+	list := make([]*Transaction, len(tp.queue))
+	copy(list, tp.queue)
+	return list
+}


### PR DESCRIPTION
## Summary
- implement a read-locked Snapshot method for TxPool so health logging can inspect pending transactions when tokens build tag is absent

## Testing
- `go build synnergy-network/core/txpool_snapshot.go synnergy-network/core/common_structs.go synnergy-network/core/tokens.go synnergy-network/core/liquidity_pools.go synnergy-network/core/geolocation_network.go synnergy-network/core/virtual_machine.go` *(fails: undefined: AIStubClient)*

------
https://chatgpt.com/codex/tasks/task_e_688f5cbc1b60832080cfcafcf1ebf20b