### PR TITLE
fix: supply gas price to flat calculator

### DIFF
--- a/synnergy-network/cmd/cli/event_ticket.go
+++ b/synnergy-network/cmd/cli/event_ticket.go
@@ -33,7 +33,7 @@ func etInit(cmd *cobra.Command, _ []string) error {
 			err = e
 			return
 		}
-		gas := core.NewFlatGasCalculator()
+		gas := core.NewFlatGasCalculator(core.DefaultGasPrice)
 		meta := core.Metadata{Name: "Event Ticket", Symbol: "SYNTIX", Decimals: 0, Standard: core.StdSYN1700}
 		etToken, err = Tokens.NewEventTicketToken(meta, led, gas, nil)
 		if err != nil {

--- a/synnergy-network/cmd/cli/identity_token.go
+++ b/synnergy-network/cmd/cli/identity_token.go
@@ -35,7 +35,7 @@ func itInit(cmd *cobra.Command, _ []string) error {
 			return
 		}
 		itLedger = led
-		core.InitTokens(led, nil, core.NewFlatGasCalculator())
+		core.InitTokens(led, nil, core.NewFlatGasCalculator(core.DefaultGasPrice))
 	})
 	return err
 }

--- a/synnergy-network/cmd/cli/legal_token.go
+++ b/synnergy-network/cmd/cli/legal_token.go
@@ -60,7 +60,7 @@ var ltCreateCmd = &cobra.Command{
 			return err
 		}
 		meta := core.Metadata{Name: name, Symbol: symbol, Decimals: 0}
-		id, err := core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator()).NewLegalToken(meta, docType, hash, parties, expiry, map[core.Address]uint64{owner: supply})
+		id, err := core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator(core.DefaultGasPrice)).NewLegalToken(meta, docType, hash, parties, expiry, map[core.Address]uint64{owner: supply})
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ var ltSignCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator()).LegalAddSignature(core.TokenID(id64), party, sig)
+		return core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator(core.DefaultGasPrice)).LegalAddSignature(core.TokenID(id64), party, sig)
 	},
 }
 
@@ -97,7 +97,7 @@ var ltRevokeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator()).LegalRevokeSignature(core.TokenID(id64), party)
+		return core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator(core.DefaultGasPrice)).LegalRevokeSignature(core.TokenID(id64), party)
 	},
 }
 
@@ -107,7 +107,7 @@ var ltStatusCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id64, _ := strconv.ParseUint(args[0], 10, 32)
-		return core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator()).LegalUpdateStatus(core.TokenID(id64), args[1])
+		return core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator(core.DefaultGasPrice)).LegalUpdateStatus(core.TokenID(id64), args[1])
 	},
 }
 
@@ -118,7 +118,7 @@ var ltDisputeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id64, _ := strconv.ParseUint(args[0], 10, 32)
 		action := args[1]
-		mgr := core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator())
+		mgr := core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator(core.DefaultGasPrice))
 		if action == "start" {
 			return mgr.LegalStartDispute(core.TokenID(id64))
 		}

--- a/synnergy-network/cmd/cli/syn10.go
+++ b/synnergy-network/cmd/cli/syn10.go
@@ -17,7 +17,7 @@ func ensureSYN10(cmd *cobra.Command, _ []string) error {
 	if led == nil {
 		return fmt.Errorf("ledger not initialised")
 	}
-	gas := core.NewFlatGasCalculator()
+	gas := core.NewFlatGasCalculator(core.DefaultGasPrice)
 	core.InitSYN10(led, gas, "USD", "CentralBank")
 	return nil
 }

--- a/synnergy-network/cmd/cli/syn1000.go
+++ b/synnergy-network/cmd/cli/syn1000.go
@@ -28,7 +28,7 @@ func syn1000Init(cmd *cobra.Command, _ []string) error {
 			err = e
 			return
 		}
-		gas := core.NewFlatGasCalculator()
+		gas := core.NewFlatGasCalculator(core.DefaultGasPrice)
 		syn1000Mgr = core.NewTokenManager(led, gas)
 	})
 	return err

--- a/synnergy-network/cmd/cli/syn1155.go
+++ b/synnergy-network/cmd/cli/syn1155.go
@@ -32,7 +32,7 @@ func syn1155Init(cmd *cobra.Command, _ []string) error {
 			err = e
 			return
 		}
-		gas := core.NewFlatGasCalculator()
+		gas := core.NewFlatGasCalculator(core.DefaultGasPrice)
 		syn1155Mgr = core.NewTokenManager(led, gas)
 	})
 	return err

--- a/synnergy-network/cmd/cli/syn131.go
+++ b/synnergy-network/cmd/cli/syn131.go
@@ -32,7 +32,7 @@ func synInit(cmd *cobra.Command, _ []string) error {
 			err = e
 			return
 		}
-		gas := core.NewFlatGasCalculator()
+		gas := core.NewFlatGasCalculator(core.DefaultGasPrice)
 		synMgr = core.NewTokenManager(led, gas)
 	})
 	return err

--- a/synnergy-network/cmd/cli/syn1900.go
+++ b/synnergy-network/cmd/cli/syn1900.go
@@ -33,7 +33,7 @@ func eduInit(cmd *cobra.Command, _ []string) error {
 			err = e
 			return
 		}
-		gas := core.NewFlatGasCalculator()
+		gas := core.NewFlatGasCalculator(core.DefaultGasPrice)
 		eduMgr = core.NewTokenManager(led, gas)
 	})
 	return err

--- a/synnergy-network/cmd/cli/syn1967.go
+++ b/synnergy-network/cmd/cli/syn1967.go
@@ -34,7 +34,7 @@ func syn1967Init(cmd *cobra.Command, _ []string) error {
 			err = e
 			return
 		}
-		gas := core.NewFlatGasCalculator()
+		gas := core.NewFlatGasCalculator(core.DefaultGasPrice)
 		syn1967Mgr = core.NewTokenManager(led, gas)
 	})
 	return err

--- a/synnergy-network/cmd/cli/syn2200.go
+++ b/synnergy-network/cmd/cli/syn2200.go
@@ -33,7 +33,7 @@ func syn2200Init(cmd *cobra.Command, _ []string) error {
 			err = e
 			return
 		}
-		gas := core.NewFlatGasCalculator()
+		gas := core.NewFlatGasCalculator(core.DefaultGasPrice)
 		syn2200Mgr = core.NewTokenManager(led, gas)
 	})
 	return err

--- a/synnergy-network/cmd/cli/syn2400.go
+++ b/synnergy-network/cmd/cli/syn2400.go
@@ -30,7 +30,7 @@ func syn2400Init(cmd *cobra.Command, _ []string) error {
 	if e != nil {
 		return e
 	}
-	dtMgr = core.NewTokenManager(led, core.NewFlatGasCalculator())
+	dtMgr = core.NewTokenManager(led, core.NewFlatGasCalculator(core.DefaultGasPrice))
 	return nil
 }
 

--- a/synnergy-network/cmd/cli/syn3500.go
+++ b/synnergy-network/cmd/cli/syn3500.go
@@ -18,7 +18,7 @@ func ensureSYN3500(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 	meta := core.Metadata{Name: "Currency Token", Symbol: "SYNCUR", Decimals: 2, Standard: core.StdSYN3500}
-	tok := core.NewSYN3500Token(meta, "USD", "Issuer", 1.0, led, core.NewFlatGasCalculator())
+	tok := core.NewSYN3500Token(meta, "USD", "Issuer", 1.0, led, core.NewFlatGasCalculator(core.DefaultGasPrice))
 	if tok == nil {
 		return fmt.Errorf("init failed")
 	}

--- a/synnergy-network/cmd/cli/syn500.go
+++ b/synnergy-network/cmd/cli/syn500.go
@@ -58,7 +58,7 @@ func syn500HandleCreate(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	meta := core.Metadata{Name: name, Symbol: symbol, Decimals: dec, Standard: core.StdSYN500}
-	mgr := core.NewTokenManager(syn500Ledger, core.NewFlatGasCalculator())
+	mgr := core.NewTokenManager(syn500Ledger, core.NewFlatGasCalculator(core.DefaultGasPrice))
 	tok, err := mgr.CreateSYN500(meta, map[core.Address]uint64{owner: supply})
 	if err != nil {
 		return err

--- a/synnergy-network/cmd/cli/syn5000.go
+++ b/synnergy-network/cmd/cli/syn5000.go
@@ -28,7 +28,7 @@ func syn5000Init(cmd *cobra.Command, _ []string) error {
 			err = e
 			return
 		}
-		gas := core.NewFlatGasCalculator()
+		gas := core.NewFlatGasCalculator(core.DefaultGasPrice)
 		syn5000Mgr = core.NewTokenManager(led, gas)
 	})
 	return err

--- a/synnergy-network/cmd/cli/syn721.go
+++ b/synnergy-network/cmd/cli/syn721.go
@@ -32,7 +32,7 @@ func syn721Init(cmd *cobra.Command, _ []string) error {
 			err = e
 			return
 		}
-		gas := core.NewFlatGasCalculator()
+		gas := core.NewFlatGasCalculator(core.DefaultGasPrice)
 		syn721Mgr = core.NewTokenManager(led, gas)
 	})
 	return err

--- a/synnergy-network/cmd/cli/syn845.go
+++ b/synnergy-network/cmd/cli/syn845.go
@@ -37,7 +37,7 @@ var syn845CreateCmd = &cobra.Command{
 			return err
 		}
 		meta := core.Metadata{Name: name, Symbol: symbol, Decimals: 0}
-		id, err := core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator()).CreateDebtToken(meta, map[core.Address]uint64{owner: supply})
+		id, err := core.NewTokenManager(core.CurrentLedger(), core.NewFlatGasCalculator(core.DefaultGasPrice)).CreateDebtToken(meta, map[core.Address]uint64{owner: supply})
 		if err != nil {
 			return err
 		}

--- a/synnergy-network/cmd/cli/token_management.go
+++ b/synnergy-network/cmd/cli/token_management.go
@@ -33,7 +33,7 @@ func tmInit(cmd *cobra.Command, _ []string) error {
 			err = e
 			return
 		}
-		gas := core.NewFlatGasCalculator()
+		gas := core.NewFlatGasCalculator(core.DefaultGasPrice)
 		tmMgr = core.NewTokenManager(led, gas)
 	})
 	return err

--- a/synnergy-network/core/helpers.go
+++ b/synnergy-network/core/helpers.go
@@ -75,8 +75,16 @@ func (tfStubClient) Analyse(_ context.Context, _ *TFRequest) (*TFResponse, error
 // Simple flat gas calculator used by CLI stubs
 // ------------------------------------------------------------------
 
+// DefaultGasPrice defines the flat price used when estimating or calculating
+// gas for token operations. Exported so other packages can reuse a consistent
+// base price when constructing a FlatGasCalculator.
+const DefaultGasPrice uint64 = 1
+
+// FlatGasCalculator implements a trivial GasCalculator that multiplies a
+// constant price by the provided amount.
 type FlatGasCalculator struct{ Price uint64 }
 
+// NewFlatGasCalculator returns a FlatGasCalculator with the supplied price.
 func NewFlatGasCalculator(p uint64) *FlatGasCalculator { return &FlatGasCalculator{Price: p} }
 
 func (f *FlatGasCalculator) Estimate(_ []byte) (uint64, error)     { return 0, nil }

--- a/synnergy-network/core/time_locked_node.go
+++ b/synnergy-network/core/time_locked_node.go
@@ -7,9 +7,6 @@ import (
 	"time"
 )
 
-// defaultGasPrice defines the flat gas cost used for queued transfers.
-const defaultGasPrice uint64 = 1
-
 // TimeLockRecord represents a pending transfer with a release time.
 type TimeLockRecord struct {
 	ID        string
@@ -88,7 +85,7 @@ func (t *TimeLockedNode) ExecuteDue() []string {
 	}
 	t.mu.Unlock()
 
-	tm := NewTokenManager(t.ledger, NewFlatGasCalculator(defaultGasPrice))
+	tm := NewTokenManager(t.ledger, NewFlatGasCalculator(DefaultGasPrice))
 	var executed []string
 	for _, rec := range due {
 		_ = tm.Transfer(rec.TokenID, rec.From, rec.To, rec.Amount)

--- a/synnergy-network/core/tokens_syn1000_helpers.go
+++ b/synnergy-network/core/tokens_syn1000_helpers.go
@@ -7,25 +7,25 @@ import Tokens "synnergy-network/core/Tokens"
 
 // TokensCreateSYN1000 is a VM helper to create a stablecoin.
 func TokensCreateSYN1000(meta Metadata, init map[Address]uint64) (TokenID, error) {
-	tm := NewTokenManager(CurrentLedger(), NewFlatGasCalculator())
+	tm := NewTokenManager(CurrentLedger(), NewFlatGasCalculator(DefaultGasPrice))
 	return tm.CreateSYN1000(meta, init)
 }
 
 // TokensAddStableReserve adds collateral to a SYN1000 token.
 func TokensAddStableReserve(id TokenID, asset string, amt uint64) error {
-	tm := NewTokenManager(CurrentLedger(), NewFlatGasCalculator())
+	tm := NewTokenManager(CurrentLedger(), NewFlatGasCalculator(DefaultGasPrice))
 	return tm.AddStableReserve(id, asset, amt)
 }
 
 // TokensSetStablePrice updates the oracle price for a SYN1000 token.
 func TokensSetStablePrice(id TokenID, asset string, price float64) error {
-	tm := NewTokenManager(CurrentLedger(), NewFlatGasCalculator())
+	tm := NewTokenManager(CurrentLedger(), NewFlatGasCalculator(DefaultGasPrice))
 	return tm.SetStablePrice(id, asset, price)
 }
 
 // TokensStableReserveValue returns the reserve value.
 func TokensStableReserveValue(id TokenID) (float64, error) {
-	tm := NewTokenManager(CurrentLedger(), NewFlatGasCalculator())
+	tm := NewTokenManager(CurrentLedger(), NewFlatGasCalculator(DefaultGasPrice))
 	return tm.StableReserveValue(id)
 }
 


### PR DESCRIPTION
## Summary
- add `DefaultGasPrice` constant for flat gas calculator
- use `DefaultGasPrice` when instantiating flat gas calculators across core and CLI

## Testing
- `go build ./synnergy-network/core/time_locked_node.go` *(fails: undefined types in other packages)*
- `go build ./synnergy-network/cmd/cli/syn2200.go` *(fails: remaining core package redeclarations)*

------
https://chatgpt.com/codex/tasks/task_e_688f5cc5b34083208a7d6b740d2c1605