### PR TITLE
Fix consensus pool interface for transaction validation

### DIFF
--- a/synnergy-network/core/consensus.go
+++ b/synnergy-network/core/consensus.go
@@ -60,6 +60,9 @@ const (
 // Wire‑up interfaces (keeps core independent of concrete impls)
 //---------------------------------------------------------------------
 
+// txPool defines the minimal transaction pool capabilities required by the
+// consensus engine. In addition to selecting transactions for new sub-blocks,
+// the pool must be able to validate incoming transactions.
 type txPool interface {
 	Pick(max int) [][]byte
 	ValidateTx(tx *Transaction) error

--- a/synnergy-network/core/consensus_constructor.go
+++ b/synnergy-network/core/consensus_constructor.go
@@ -14,7 +14,7 @@ func NewConsensus(
 	led *Ledger,
 	p2p interface{},
 	crypt interface{},
-	pool interface{},
+	pool txPool,
 	auth interface{},
 ) (*SynnergyConsensus, error) {
 	if lg == nil {


### PR DESCRIPTION
## Summary
- type the consensus constructor's pool parameter as `txPool`
- document the txPool interface, including its `ValidateTx` method

## Testing
- `go test ./core -run TestTxPoolValidateReversal -tags tokens -count=1` *(fails: NewConsensus redeclared, duplicate definitions)*

------
https://chatgpt.com/codex/tasks/task_e_688f5d2a67f08320a94616f907c0d498