### PR TITLE
Stage17: implement sub-block proposer

### DIFF
--- a/synnergy-network/core/consensus.go
+++ b/synnergy-network/core/consensus.go
@@ -184,9 +184,29 @@ func (sc *SynnergyConsensus) subBlockLoop(ctx context.Context) {
 
 // ProposeSubBlock selects txs, computes PoH, signs with validator stake key.
 func (sc *SynnergyConsensus) ProposeSubBlock() (*SubBlock, error) {
-	txs := sc.pool.Pick(MaxTxPerSubBlock)
-	if len(txs) == 0 {
+	rawTxs := sc.pool.Pick(MaxTxPerSubBlock)
+	if len(rawTxs) == 0 {
 		return nil, errors.New("no txs")
+	}
+
+	// Filter and validate picked transactions.
+	validTxs := make([][]byte, 0, len(rawTxs))
+	for _, b := range rawTxs {
+		var tx Transaction
+		if err := json.Unmarshal(b, &tx); err != nil {
+			sc.logger.Printf("discarding malformed tx: %v", err)
+			continue
+		}
+		if sc.pool != nil {
+			if err := sc.pool.ValidateTx(&tx); err != nil {
+				sc.logger.Printf("discarding invalid tx: %v", err)
+				continue
+			}
+		}
+		validTxs = append(validTxs, b)
+	}
+	if len(validTxs) == 0 {
+		return nil, errors.New("no valid txs")
 	}
 
 	header := SubBlockHeader{
@@ -195,9 +215,9 @@ func (sc *SynnergyConsensus) ProposeSubBlock() (*SubBlock, error) {
 		Validator: sc.auth.ValidatorPubKey("pos"),
 	}
 
-	// PoH hash
+	// Build PoH hash over the valid transaction set and timestamp.
 	h := sha256.New()
-	for _, tx := range txs {
+	for _, tx := range validTxs {
 		h.Write(tx)
 	}
 	ts := make([]byte, 8)
@@ -211,11 +231,11 @@ func (sc *SynnergyConsensus) ProposeSubBlock() (*SubBlock, error) {
 	}
 	header.Sig = sig
 
-	sb := &SubBlock{Header: header, Body: SubBlockBody{Transactions: txs}}
+	sb := &SubBlock{Header: header, Body: SubBlockBody{Transactions: validTxs}}
 	if err := sc.ledger.AppendSubBlock(sb); err != nil {
 		return nil, err
 	}
-	sc.logger.Printf("sub‑block #%d proposed with %d txs", header.Height, len(txs))
+	sc.logger.Printf("sub‑block #%d proposed with %d txs", header.Height, len(validTxs))
 	return sb, nil
 }
 


### PR DESCRIPTION
## Summary
- extend SynnergyConsensus with a full-featured `ProposeSubBlock` method that filters and validates transactions before proposing a sub-block

## Testing
- `go vet core/validator_node.go core/consensus.go core/common_structs.go` *(fails: undefined BaseNode)*


------
https://chatgpt.com/codex/tasks/task_e_688f5d34b1d88320b2e776328e5c67e8