### PR TITLE
feat: track wallet for authority nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ The Dockerfile can build a containerised node which runs the networking, consens
 
 The CLI exposes dozens of commands grouped by module: AI management, token operations, governance tools, cross‑chain utilities and many more. Each file under `cmd/cli` registers a command group. Refer to [`synnergy-network/README.md`](synnergy-network/README.md) and `cmd/cli/cli_guide.md` for the full catalogue and examples.
 
+## Authority Node Policies
+
+Authority nodes participate in governance and sensitive financial operations. Each
+authority node must register with a dedicated wallet address which receives any
+rewards or fee distributions. Candidate nodes are activated only after gathering
+the required public and authority votes. Their signatures are also required for
+transaction reversals and other critical actions. Specific roles such as
+`CentralBankNode` or `GovernmentNode` gate privileged functionality like issuing
+SYN‑10/11/12 tokens or authorising regulated financial instruments.
+
 ## Core Modules
 
 The Go packages in `core/` implement the blockchain runtime. Important modules include consensus, ledger storage, networking layers, data replication, sharding and the virtual machine. Development helpers in `core/helpers.go` allow the CLI to run without a full node. A summary of every file lives in [`core/module_guide.md`](synnergy-network/core/module_guide.md).

--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -97,7 +97,8 @@ all modules from the core library. Highlights include:
 - `ai_mgmt` – manage AI model marketplace listings
 - `ai_infer` – advanced inference and transaction analysis
 - `amm` – swap tokens and manage liquidity pools
-- `authority_node` – validator registration and voting
+- `authority_node` – validator registration and voting; each authority registers
+  with a dedicated wallet address and activates after meeting voting thresholds
 - `access` – manage role based access permissions
 - `authority_apply` – submit and approve authority node applications
 - `charity_pool` – query and disburse community funds
@@ -207,6 +208,17 @@ all modules from the core library. Highlights include:
 - `finalization_management` – finalize blocks, rollup batches and channels
 - `quorum` – simple quorum tracker management
 - `virtual_machine` – run the on‑chain VM service
+
+### Authority Node Policy
+
+Authority nodes are specialised participants that oversee sensitive network
+operations. When registering, each node must provide a wallet address for
+payments and fees. Approval requires both public and authority votes to reach
+configured thresholds. Their multi-signature approval is required for actions
+like transaction reversals, loan pool authorisation and regulated token
+issuance. Privileged roles – Government, Regulator, Creditor Bank and Central
+Bank – restrict deployment of certain financial instruments and SYN‑10/11/12
+tokens.
 - `sandbox` – manage VM sandboxes
 - `workflow` – automate multi-step tasks with triggers and webhooks
 - `supply` – manage supply chain assets on chain

--- a/synnergy-network/core/authority_nodes.go
+++ b/synnergy-network/core/authority_nodes.go
@@ -130,17 +130,31 @@ func hashFromAddress(addr Address) Hash {
 // RegisterCandidate – owner submits node for role.
 //---------------------------------------------------------------------
 
+// RegisterCandidate registers a new authority node using the same address for
+// both node identity and wallet. It is kept for backwards compatibility. New
+// code should call RegisterCandidateWithWallet to explicitly set the wallet.
 func (as *AuthoritySet) RegisterCandidate(addr Address, role AuthorityRole) error {
-	if role < GovernmentNode || role > LargeCommerceNode {
-		return errors.New("invalid role")
-	}
-	if exists, _ := as.led.HasState(nodeKey(addr)); exists {
-		return errors.New("already registered")
-	}
-	n := AuthorityNode{Addr: addr, Role: role, CreatedAt: time.Now().Unix()}
-	as.led.SetState(nodeKey(addr), mustJSON(n))
-	as.logger.Printf("authority candidate %s registered for role %s", addr.Short(), role)
-	return nil
+        return as.RegisterCandidateWithWallet(addr, role, addr)
+}
+
+// RegisterCandidateWithWallet registers a new authority node and attaches a
+// wallet address used for rewards or fee distribution.
+func (as *AuthoritySet) RegisterCandidateWithWallet(addr Address, role AuthorityRole, wallet Address) error {
+        if role < GovernmentNode || role > LargeCommerceNode {
+                return errors.New("invalid role")
+        }
+        if exists, _ := as.led.HasState(nodeKey(addr)); exists {
+                return errors.New("already registered")
+        }
+        if wallet == AddressZero {
+                return errors.New("wallet required")
+        }
+        n := AuthorityNode{Addr: addr, Wallet: wallet, Role: role, CreatedAt: time.Now().Unix()}
+        as.led.SetState(nodeKey(addr), mustJSON(n))
+        if as.logger != nil {
+                as.logger.Printf("authority candidate %s registered for role %s", addr.Short(), role)
+        }
+        return nil
 }
 
 //---------------------------------------------------------------------

--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -76,12 +76,16 @@ type edge struct {
 //---------------------------------------------------------------------
 
 type AuthorityNode struct {
-	Addr        Address       `json:"addr"`
-	Role        AuthorityRole `json:"role"`
-	Active      bool          `json:"active"`
-	PublicVotes uint32        `json:"pv"`
-	AuthVotes   uint32        `json:"av"`
-	CreatedAt   int64         `json:"since"`
+        Addr        Address       `json:"addr"`
+        // Wallet holds the payment address associated with the authority
+        // node. It may differ from the node's network address and is used
+        // when distributing fees or processing on-chain payments.
+        Wallet      Address       `json:"wallet"`
+        Role        AuthorityRole `json:"role"`
+        Active      bool          `json:"active"`
+        PublicVotes uint32        `json:"pv"`
+        AuthVotes   uint32        `json:"av"`
+        CreatedAt   int64         `json:"since"`
 }
 
 type AuthoritySet struct {


### PR DESCRIPTION
## Summary
- track wallet address for authority nodes and add registration helper requiring wallet
- document authority node policies and wallet requirements

## Testing
- `go fmt synnergy-network/core/common_structs.go synnergy-network/core/authority_nodes.go` *(fails: command not found)*
- `go test ./...` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f6276c01883209373ffc7821a669c