### PR TITLE
feat: require wallet for authority registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ The Dockerfile can build a containerised node which runs the networking, consens
 
 The CLI exposes dozens of commands grouped by module: AI management, token operations, governance tools, cross‑chain utilities and many more. Each file under `cmd/cli` registers a command group. Refer to [`synnergy-network/README.md`](synnergy-network/README.md) and `cmd/cli/cli_guide.md` for the full catalogue and examples.
 
+## Authority Node Policies
+
+Authority nodes participate in governance and sensitive financial operations. Each
+authority node must register with a dedicated wallet address which receives any
+rewards or fee distributions. Candidate nodes are activated only after gathering
+the required public and authority votes. Their signatures are also required for
+transaction reversals and other critical actions. Specific roles such as
+`CentralBankNode` or `GovernmentNode` gate privileged functionality like issuing
+SYN‑10/11/12 tokens or authorising regulated financial instruments.
+
 ## Core Modules
 
 The Go packages in `core/` implement the blockchain runtime. Important modules include consensus, ledger storage, networking layers, data replication, sharding and the virtual machine. Development helpers in `core/helpers.go` allow the CLI to run without a full node. A summary of every file lives in [`core/module_guide.md`](synnergy-network/core/module_guide.md).

--- a/synnergy-network/README.md
+++ b/synnergy-network/README.md
@@ -97,7 +97,8 @@ all modules from the core library. Highlights include:
 - `ai_mgmt` – manage AI model marketplace listings
 - `ai_infer` – advanced inference and transaction analysis
 - `amm` – swap tokens and manage liquidity pools
-- `authority_node` – validator registration and voting
+- `authority_node` – validator registration and voting; each authority registers
+  with a dedicated wallet address and activates after meeting voting thresholds
 - `access` – manage role based access permissions
 - `authority_apply` – submit and approve authority node applications
 - `charity_pool` – query and disburse community funds
@@ -207,6 +208,17 @@ all modules from the core library. Highlights include:
 - `finalization_management` – finalize blocks, rollup batches and channels
 - `quorum` – simple quorum tracker management
 - `virtual_machine` – run the on‑chain VM service
+
+### Authority Node Policy
+
+Authority nodes are specialised participants that oversee sensitive network
+operations. When registering, each node must provide a wallet address for
+payments and fees. Approval requires both public and authority votes to reach
+configured thresholds. Their multi-signature approval is required for actions
+like transaction reversals, loan pool authorisation and regulated token
+issuance. Privileged roles – Government, Regulator, Creditor Bank and Central
+Bank – restrict deployment of certain financial instruments and SYN‑10/11/12
+tokens.
 - `sandbox` – manage VM sandboxes
 - `workflow` – automate multi-step tasks with triggers and webhooks
 - `supply` – manage supply chain assets on chain

--- a/synnergy-network/cmd/cli/authority_node.go
+++ b/synnergy-network/cmd/cli/authority_node.go
@@ -56,13 +56,14 @@ func ensureAuthInitialised(cmd *cobra.Command, _ []string) error {
 
 type AuthController struct{}
 
-// RegisterCandidate wraps AuthoritySet.RegisterCandidate
+// RegisterCandidate wraps AuthoritySet.RegisterCandidate. The wallet defaults to
+// the node's address when invoked via the CLI.
 func (c *AuthController) RegisterCandidate(addr core.Address, roleStr string) error {
 	role, err := parseRole(roleStr)
 	if err != nil {
 		return err
 	}
-	return authSet.RegisterCandidate(addr, role)
+	return authSet.RegisterCandidate(addr, role, addr)
 }
 
 // RecordVote wraps AuthoritySet.RecordVote

--- a/synnergy-network/core/Nodes/authority_nodes/Authority_node_typr_manual.md
+++ b/synnergy-network/core/Nodes/authority_nodes/Authority_node_typr_manual.md
@@ -1,1 +1,23 @@
 # Authority Node Type Manual
+
+Authority nodes oversee sensitive operations within the Synnergy network. Every
+authority node **must** register with a dedicated wallet address used for fee
+distribution and grant payouts. Registration without a wallet is rejected.
+
+## Roles and Capabilities
+
+- **GovernmentNode** – may issue benefit tokens and apply monetary or fiscal
+  policy to SYN‑10/11/12 tokens.
+- **CentralBankNode** – the only role permitted to deploy the SYN‑10/11/12 token
+  standard.
+- **RegulatorNode** – can propose security upgrades which must then pass a
+  community vote.
+- **CreditorBankNode** – authorised to originate bill tokens and other regulated
+  financial instruments.
+- **StandardAuthorityNode** – participates in governance and validation but
+  cannot perform the specialised actions above.
+
+Disbursed grants pay participating authority nodes a 5% fee and require approval
+from at least five authority nodes plus a broader set of normal nodes. All
+authority nodes except the elected authority may validate ID tokens; identities
+remain invalid until verification to prevent double voting.

--- a/synnergy-network/core/authority_apply.go
+++ b/synnergy-network/core/authority_apply.go
@@ -170,7 +170,7 @@ func (ap *AuthorityApplier) FinalizeApplication(id Hash) error {
 	}
 	total := int(app.VotesFor + app.VotesAgainst)
 	if total >= rule.Quorum && int(app.VotesFor)*100/total >= rule.Majority {
-		if err := ap.auth.RegisterCandidate(app.Candidate, app.Role); err != nil {
+		if err := ap.auth.RegisterCandidate(app.Candidate, app.Role, app.Candidate); err != nil {
 			return err
 		}
 		app.Status = AuthApproved

--- a/synnergy-network/core/authority_nodes.go
+++ b/synnergy-network/core/authority_nodes.go
@@ -130,16 +130,24 @@ func hashFromAddress(addr Address) Hash {
 // RegisterCandidate – owner submits node for role.
 //---------------------------------------------------------------------
 
-func (as *AuthoritySet) RegisterCandidate(addr Address, role AuthorityRole) error {
+// RegisterCandidate registers a new authority node and attaches a wallet
+// address used for rewards or fee distribution. All authority nodes must
+// provide a non-zero wallet so payouts can be directed appropriately.
+func (as *AuthoritySet) RegisterCandidate(addr Address, role AuthorityRole, wallet Address) error {
 	if role < GovernmentNode || role > LargeCommerceNode {
 		return errors.New("invalid role")
 	}
 	if exists, _ := as.led.HasState(nodeKey(addr)); exists {
 		return errors.New("already registered")
 	}
-	n := AuthorityNode{Addr: addr, Role: role, CreatedAt: time.Now().Unix()}
+	if wallet == AddressZero {
+		return errors.New("wallet required")
+	}
+	n := AuthorityNode{Addr: addr, Wallet: wallet, Role: role, CreatedAt: time.Now().Unix()}
 	as.led.SetState(nodeKey(addr), mustJSON(n))
-	as.logger.Printf("authority candidate %s registered for role %s", addr.Short(), role)
+	if as.logger != nil {
+		as.logger.Printf("authority candidate %s registered for role %s", addr.Short(), role)
+	}
 	return nil
 }
 

--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -76,12 +76,16 @@ type edge struct {
 //---------------------------------------------------------------------
 
 type AuthorityNode struct {
-	Addr        Address       `json:"addr"`
-	Role        AuthorityRole `json:"role"`
-	Active      bool          `json:"active"`
-	PublicVotes uint32        `json:"pv"`
-	AuthVotes   uint32        `json:"av"`
-	CreatedAt   int64         `json:"since"`
+        Addr        Address       `json:"addr"`
+        // Wallet holds the payment address associated with the authority
+        // node. It may differ from the node's network address and is used
+        // when distributing fees or processing on-chain payments.
+        Wallet      Address       `json:"wallet"`
+        Role        AuthorityRole `json:"role"`
+        Active      bool          `json:"active"`
+        PublicVotes uint32        `json:"pv"`
+        AuthVotes   uint32        `json:"av"`
+        CreatedAt   int64         `json:"since"`
 }
 
 type AuthoritySet struct {

--- a/synnergy-network/tests/authority_nodes_test.go
+++ b/synnergy-network/tests/authority_nodes_test.go
@@ -66,17 +66,17 @@ func TestRegisterCandidate(t *testing.T) {
 	as := NewAuthoritySet(nil, led)
 	addr := Address{0x01}
 
-	err := as.RegisterCandidate(addr, GovernmentNode)
+	err := as.RegisterCandidate(addr, GovernmentNode, addr)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	err = as.RegisterCandidate(addr, GovernmentNode)
+	err = as.RegisterCandidate(addr, GovernmentNode, addr)
 	if err == nil {
 		t.Fatal("expected error on duplicate registration")
 	}
 
-	err = as.RegisterCandidate(Address{0x02}, AuthorityRole(99))
+	err = as.RegisterCandidate(Address{0x02}, AuthorityRole(99), Address{0x02})
 	if err == nil {
 		t.Fatal("expected error on invalid role")
 	}


### PR DESCRIPTION
## Summary
- require non-zero wallet address when registering authority nodes
- default CLI registration uses node address and document roles/policies
- update authority node manual and tests for wallet parameter

## Testing
- `go fmt core/authority_nodes.go core/authority_apply.go`
- `go fmt cmd/cli/authority_node.go`
- `go fmt tests/authority_nodes_test.go`
- `go test ./...` *(fails: build failed in multiple packages)*

------
https://chatgpt.com/codex/tasks/task_e_688f6276c01883209373ffc7821a669c