### PR TITLE
feat: add opcode linting and plugin hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ Web front‑ends are provided under `GUI/`. Each directory contains a standalone
 
 Example contracts demonstrating Synnergy's opcode catalogue are located throughout `smart_contract_guide.md` and under various GUI directories. They illustrate token faucets, storage markets, DAO governance and more. Contracts are compiled to WebAssembly and deployed via the CLI. See [`synnergy-network/smart_contract_guide.md`](synnergy-network/smart_contract_guide.md) for a step‑by‑step tutorial.
 
+## Opcode Tooling and Plugins
+
+Run `go run ./cmd/opcode-lint` to verify that the opcode catalogue remains free of collisions. The linter imports the dispatcher and fails on duplicate names or values.
+
+External teams can extend the opcode set without modifying core files by implementing the `core.OpcodeModule` interface and loading it via `core.RegisterModule`. Modules receive a registrar callback for wiring new handlers, enabling a lightweight plugin model.
+
+Gas prices may be adjusted at runtime using `core.UpdateGasCost`, allowing governance or off-chain configuration to tune fees dynamically. The exported `core.Catalogue` and `core.GasTable` helpers provide capability discovery for tools and dashboards.
+
 ## Tests
 
 Unit tests reside in `synnergy-network/tests`. Execute them with:

--- a/synnergy-network/cmd/opcode-lint/main.go
+++ b/synnergy-network/cmd/opcode-lint/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	core "synnergy-network/core"
+)
+
+func main() {
+	ops := core.Catalogue()
+	seenOps := make(map[core.Opcode]struct{})
+	seenNames := make(map[string]struct{})
+	for _, info := range ops {
+		if _, ok := seenOps[info.Op]; ok {
+			log.Fatalf("duplicate opcode 0x%06X", info.Op)
+		}
+		seenOps[info.Op] = struct{}{}
+		if _, ok := seenNames[info.Name]; ok {
+			log.Fatalf("duplicate opcode name %s", info.Name)
+		}
+		seenNames[info.Name] = struct{}{}
+	}
+	fmt.Printf("checked %d opcodes, no collisions detected\n", len(ops))
+}

--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -61,3 +61,22 @@ func GasCost(op Opcode) uint64 {
 	log.Printf("gas_table: missing cost for opcode %d – charging default", op)
 	return DefaultGasCost
 }
+
+// UpdateGasCost overrides the gas price for a specific opcode at runtime. This
+// enables dynamic fee schedules driven by governance or off-chain configuration.
+func UpdateGasCost(op Opcode, cost uint64) {
+	if gasTable == nil {
+		gasTable = make(map[Opcode]uint64)
+	}
+	gasTable[op] = cost
+}
+
+// GasTable returns a copy of the current gas pricing table for capability
+// discovery and tooling integrations.
+func GasTable() map[Opcode]uint64 {
+	out := make(map[Opcode]uint64, len(gasTable))
+	for k, v := range gasTable {
+		out[k] = v
+	}
+	return out
+}

--- a/synnergy-network/core/module_plugin.go
+++ b/synnergy-network/core/module_plugin.go
@@ -1,0 +1,18 @@
+package core
+
+// OpcodeModule represents an external package that wishes to register additional
+// opcode handlers. Implementations call the provided registrar for each opcode
+// they expose.
+
+type OpcodeModule interface {
+	Register(func(Opcode, OpcodeFunc))
+}
+
+// RegisterModule loads a module into the dispatcher using the core Register
+// function. Nil modules are ignored to simplify optional wiring.
+func RegisterModule(m OpcodeModule) {
+	if m == nil {
+		return
+	}
+	m.Register(Register)
+}


### PR DESCRIPTION
## Summary
- add `cmd/opcode-lint` to detect duplicate opcodes
- expose `core.Catalogue` and plugin interface for external opcode modules
- allow runtime gas updates and document tooling in README

## Testing
- `go fmt synnergy-network/core/opcode_dispatcher.go synnergy-network/core/module_plugin.go synnergy-network/core/gas_table.go synnergy-network/cmd/opcode-lint/main.go`
- `go build ./cmd/opcode-lint` *(fails: undefined shuffleAddresses, broadcast methods, etc.)*
- `go test ./cmd/opcode-lint` *(fails: undefined shuffleAddresses, broadcast methods, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688f62993c8c8320934b380848e0106d