### PR TITLE
Define TxType and payment constant for non-token builds

### DIFF
--- a/synnergy-network/core/tx_types_nontokens.go
+++ b/synnergy-network/core/tx_types_nontokens.go
@@ -1,0 +1,24 @@
+//go:build !tokens
+
+package core
+
+// TxType identifiers for basic transaction categories.
+//
+// In builds that do not include the full token stack (the "tokens" build tag
+// is absent) the comprehensive transaction types defined in transactions.go are
+// not compiled.  This file provides the minimal subset of types required by
+// lightweight components such as wallet management so that code depending on a
+// basic payment transfer still compiles.
+
+// TxType enumerates high level transaction categories.
+// It mirrors the definition in transactions.go when the "tokens" tag is set.
+type TxType uint8
+
+const (
+	// TxPayment represents a standard currency transfer.
+	TxPayment TxType = iota + 1
+	// TxContractCall identifies a generic smart contract invocation.
+	TxContractCall
+	// TxReversal denotes an authority-approved transaction reversal.
+	TxReversal
+)


### PR DESCRIPTION
## Summary
- add minimal `TxType` enum and `TxPayment`/related constants for builds without the `tokens` tag
- document purpose of non-token transaction types to support wallet management

## Testing
- `gofmt -w synnergy-network/core/tx_types_nontokens.go`
- `go build wm_stubs.go wallet_management.go tx_types_nontokens.go` *(fails: undefined WalletFromMnemonic, BalanceOf)*

------
https://chatgpt.com/codex/tasks/task_e_688edb386ee88320a2c74d4d8346fa7f