### PR TITLE
core: add flat gas price for time-locked execution

### DIFF
--- a/synnergy-network/core/time_locked_node.go
+++ b/synnergy-network/core/time_locked_node.go
@@ -7,6 +7,9 @@ import (
 	"time"
 )
 
+// timeLockGasPrice is the flat gas cost used for queued transfers.
+const timeLockGasPrice uint64 = 1
+
 // TimeLockRecord represents a pending transfer with a release time.
 type TimeLockRecord struct {
 	ID        string
@@ -85,7 +88,7 @@ func (t *TimeLockedNode) ExecuteDue() []string {
 	}
 	t.mu.Unlock()
 
-	tm := NewTokenManager(t.ledger, NewFlatGasCalculator())
+	tm := NewTokenManager(t.ledger, NewFlatGasCalculator(timeLockGasPrice))
 	var executed []string
 	for _, rec := range due {
 		_ = tm.Transfer(rec.TokenID, rec.From, rec.To, rec.Amount)


### PR DESCRIPTION
## Summary
- provide default gas price constant for time-locked node
- supply gas price to `NewFlatGasCalculator` when executing queued transfers

## Testing
- `gofmt -w synnergy-network/core/time_locked_node.go`
- `go build synnergy-network/core/time_locked_node.go` *(fails: undefined TokenID, Address, Node, Ledger, etc. – other package issues)*

------
https://chatgpt.com/codex/tasks/task_e_688edb2b18fc8320bc4ad8f49ec77c3b