### PR TITLE
Add mutex to DataMarketplaceToken

### DIFF
--- a/synnergy-network/core/syn2400.go
+++ b/synnergy-network/core/syn2400.go
@@ -1,10 +1,14 @@
 package core
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // DataMarketplaceToken implements the SYN2400 standard.
 type DataMarketplaceToken struct {
 	BaseToken
+	mu           sync.RWMutex
 	DataHash     string
 	Description  string
 	AccessRights map[Address]string
@@ -36,50 +40,52 @@ func NewDataMarketplaceToken(meta Metadata, hash, desc string, price uint64, ini
 
 // UpdateMetadata modifies the token data hash and description.
 func (d *DataMarketplaceToken) UpdateMetadata(hash, desc string) {
-	d.lock.Lock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	d.DataHash = hash
 	d.Description = desc
 	d.UpdatedAt = time.Now().UTC()
-	d.lock.Unlock()
 }
 
 // SetPrice updates the token price.
 func (d *DataMarketplaceToken) SetPrice(p uint64) {
-	d.lock.Lock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	d.Price = p
 	d.UpdatedAt = time.Now().UTC()
-	d.lock.Unlock()
 }
 
 // SetStatus changes the token status string.
 func (d *DataMarketplaceToken) SetStatus(s string) {
-	d.lock.Lock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	d.Status = s
 	d.UpdatedAt = time.Now().UTC()
-	d.lock.Unlock()
 }
 
 // GrantAccess gives access rights to an address.
 func (d *DataMarketplaceToken) GrantAccess(a Address, rights string) {
-	d.lock.Lock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.AccessRights == nil {
 		d.AccessRights = make(map[Address]string)
 	}
 	d.AccessRights[a] = rights
-	d.lock.Unlock()
+	d.UpdatedAt = time.Now().UTC()
 }
 
 // RevokeAccess removes access for an address.
 func (d *DataMarketplaceToken) RevokeAccess(a Address) {
-	d.lock.Lock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	delete(d.AccessRights, a)
-	d.lock.Unlock()
+	d.UpdatedAt = time.Now().UTC()
 }
 
 // HasAccess checks whether an address has rights.
 func (d *DataMarketplaceToken) HasAccess(a Address) bool {
-	d.lock.RLock()
+	d.mu.RLock()
+	defer d.mu.RUnlock()
 	_, ok := d.AccessRights[a]
-	d.lock.RUnlock()
 	return ok
 }


### PR DESCRIPTION
## Summary
- add RWMutex field to DataMarketplaceToken
- guard metadata, pricing, status, and access-control operations with mutex locks and timestamp updates

## Testing
- `gofmt -w synnergy-network/core/syn2400.go`
- `go vet synnergy-network/core/syn2400.go synnergy-network/core/syn2400_stub.go`
- `go build synnergy-network/core/syn2400.go synnergy-network/core/syn2400_stub.go`


------
https://chatgpt.com/codex/tasks/task_e_688edb1d01e08320a89198123c4301be