### PR TITLE
core: add AddressZero constant

### DIFF
--- a/synnergy-network/core/Tokens/index.go
+++ b/synnergy-network/core/Tokens/index.go
@@ -11,6 +11,9 @@ import "time"
 // of direct core dependencies.
 type Address [20]byte
 
+// AddressZero is the zero-value address (all bytes zero).
+var AddressZero = Address{}
+
 // TokenStandard mirrors core.TokenStandard.  It enumerates every supported token
 // specification within the Synnergy ecosystem.  Each constant corresponds to a
 // dedicated file containing the token's implementation (e.g. syn10.go,

--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -683,6 +683,10 @@ type HDWallet struct {
 // Address represents a 20‑byte account identifier.
 type Address [20]byte
 
+// AddressZero represents the zero-value address (all bytes zero).
+// It is used as a sentinel in token and ledger operations.
+var AddressZero = Address{}
+
 // Hash represents a 32‑byte cryptographic hash.
 type Hash [32]byte
 


### PR DESCRIPTION
## Summary
- add AddressZero variable in core to represent the zero address
- expose the same AddressZero in the Tokens helper package
- explicitly initialize the AddressZero sentinel for clarity

## Testing
- `go vet ./synnergy-network/core/Tokens`
- `go vet ./synnergy-network/core/common_structs.go` *(fails: undefined: TokenID)*

------
https://chatgpt.com/codex/tasks/task_e_688edb003b9c8320b7b8f5a826b90894