### PR TITLE
Define minimal consensus constructor

### DIFF
--- a/synnergy-network/core/consensus_constructor.go
+++ b/synnergy-network/core/consensus_constructor.go
@@ -1,0 +1,39 @@
+//go:build !tokens
+// +build !tokens
+
+package core
+
+import (
+	"math/big"
+
+	"github.com/sirupsen/logrus"
+)
+
+// NewConsensus constructs a minimal SynnergyConsensus engine wiring the
+// provided components. It initialises block heights from the ledger and sets a
+// zero difficulty value so that other components can safely build upon it.
+func NewConsensus(
+	lg *logrus.Logger,
+	led *Ledger,
+	p2p interface{},
+	crypt interface{},
+	pool interface{},
+	auth interface{},
+) (*SynnergyConsensus, error) {
+	if lg == nil {
+		lg = logrus.StandardLogger()
+	}
+
+	return &SynnergyConsensus{
+		logger:        lg,
+		ledger:        led,
+		p2p:           p2p,
+		crypto:        crypt,
+		pool:          pool,
+		auth:          auth,
+		nextSubHeight: led.LastSubBlockHeight() + 1,
+		nextBlkHeight: led.LastBlockHeight() + 1,
+		curDifficulty: big.NewInt(0),
+		blkTimes:      make([]int64, 0, 100),
+	}, nil
+}


### PR DESCRIPTION
## Summary
- implement minimal `NewConsensus` for wiring ledger, network, crypto, pool and auth components
- gate constructor behind `!tokens` build tag to avoid conflicts with full consensus implementation

## Testing
- `go vet synnergy-network/core/consensus_constructor.go synnergy-network/core/ledger.go synnergy-network/core/common_structs.go synnergy-network/core/tokens.go synnergy-network/core/authority_nodes.go synnergy-network/core/virtual_machine.go` *(fails: `undefined: PoolID`)*

------
https://chatgpt.com/codex/tasks/task_e_688edb86ea908320b3fe0d70754a1eb6