### PR TITLE
fix: prevent overflow in fee distribution

### DIFF
--- a/synnergy-network/core/transaction_distribution.go
+++ b/synnergy-network/core/transaction_distribution.go
@@ -50,9 +50,11 @@ func (d *TxDistributor) DistributeFees(from Address, minerPk []byte, fee uint64)
 		return fmt.Errorf("decode miner: %w", err)
 	}
 
-	minerShare := fee / 2
-	loanShare := fee * 30 / 100
-	charityShare := fee - minerShare - loanShare
+	// Avoid potential overflow when computing percentages by dividing before
+	// multiplying. This keeps the calculation safe even for very large fees.
+	minerShare := fee / 2                        // 50%
+	loanShare := (fee / 10) * 3                  // 30%
+	charityShare := fee - minerShare - loanShare // remainder (20%)
 
 	d.mu.Lock()
 	defer d.mu.Unlock()


### PR DESCRIPTION
## Summary
- avoid overflow when splitting transaction fees by dividing before multiplying

## Testing
- `go test ./synnergy-network/...` *(fails: aborted after extensive module downloads)*

------
https://chatgpt.com/codex/tasks/task_e_688f6a3d1f10832085e8c601232abd44