### PR TITLE
core: expose tx validation via consensus pool

### DIFF
--- a/synnergy-network/core/consensus.go
+++ b/synnergy-network/core/consensus.go
@@ -142,6 +142,14 @@ func NewConsensus(
 	}, nil
 }
 
+// ValidateTx delegates transaction validation to the underlying pool.
+func (sc *SynnergyConsensus) ValidateTx(tx *Transaction) error {
+	if sc.pool == nil {
+		return errors.New("tx pool not initialised")
+	}
+	return sc.pool.ValidateTx(tx)
+}
+
 // Sub‑block proposer loop (PoH + immediate PoS self‑sign)
 //---------------------------------------------------------------------
 

--- a/synnergy-network/core/validator_node.go
+++ b/synnergy-network/core/validator_node.go
@@ -105,7 +105,7 @@ func (vn *ValidatorNode) ValidateTx(txBytes []byte) error {
 	if err != nil {
 		return err
 	}
-	return vn.cons.pool.ValidateTx(tx)
+	return vn.cons.ValidateTx(tx)
 }
 
 // ProposeBlock triggers block proposal according to the enabled mechanisms.


### PR DESCRIPTION
## Summary
- delegate transaction validation from SynnergyConsensus to its tx pool
- use consensus wrapper in ValidatorNode

## Testing
- `go build synnergy-network/core/validator_node.go synnergy-network/core/consensus.go synnergy-network/core/consensus_start.go synnergy-network/core/consensus_constructor.go synnergy-network/core/transactions.go synnergy-network/core/common_structs.go` *(fails: undefined types such as BaseNode)*

------
https://chatgpt.com/codex/tasks/task_e_688f7c829f388320826625b2c1ec1b17