### PR TITLE
Stage 15: add Start lifecycle for SynnergyConsensus

### DIFF
--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -142,6 +142,7 @@ type SynnergyConsensus struct {
 	crypto interface{}
 	pool   txPool
 	auth   interface{}
+	cancel context.CancelFunc
 
 	mu            sync.Mutex
 	nextSubHeight uint64

--- a/synnergy-network/core/consensus_start.go
+++ b/synnergy-network/core/consensus_start.go
@@ -14,6 +14,17 @@ func (sc *SynnergyConsensus) Start(ctx context.Context) {
 		ctx = context.Background()
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
+
+	sc.mu.Lock()
+	if sc.cancel != nil {
+		sc.mu.Unlock()
+		cancel()
+		return
+	}
+	sc.cancel = cancel
+	sc.mu.Unlock()
+
 	// Launch sub‑block proposer and block sealing loops.
 	go sc.subBlockLoop(ctx)
 	go sc.blockLoop(ctx)
@@ -43,5 +54,20 @@ func (sc *SynnergyConsensus) Start(ctx context.Context) {
 			<-ctx.Done()
 			sc.logger.Println("consensus stopped")
 		}()
+	}
+}
+
+// Stop terminates the consensus engine started via Start. It is safe to call
+// multiple times.
+func (sc *SynnergyConsensus) Stop() {
+	if sc == nil {
+		return
+	}
+	sc.mu.Lock()
+	cancel := sc.cancel
+	sc.cancel = nil
+	sc.mu.Unlock()
+	if cancel != nil {
+		cancel()
 	}
 }


### PR DESCRIPTION
## Summary
- add context-driven Start method with cancel handling for consensus engine
- introduce cancel field and Stop method on SynnergyConsensus

## Testing
- `go test ./synnergy-network/core -run TestStart -count=1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f7c612f2883208b9661f76211e0ac