### PR TITLE
fix: use central stack push

### DIFF
--- a/synnergy-network/core/utility_functions.go
+++ b/synnergy-network/core/utility_functions.go
@@ -32,28 +32,6 @@ func BytesToAddress(b []byte) Address {
 	return a
 }
 
-
-// Push adds a *big.Int value onto the top of the stack.
-// It panics if a nil value is provided to prevent ambiguous stack entries.
-func (s *Stack) Push(v *big.Int) {
-	if v == nil {
-		panic("nil value pushed to stack")
-	}
-	s.data = append(s.data, v)
-}
-
-// Pop removes and returns the top element of the stack.
-// It panics if the stack is empty.
-func (s *Stack) Pop() *big.Int {
-	if len(s.data) == 0 {
-		panic("stack underflow")
-	}
-	idx := len(s.data) - 1
-	val := s.data[idx]
-	s.data = s.data[:idx]
-	return val
-}
-
 // Constants for 256-bit modular arithmetic.
 var (
 	two256  = new(big.Int).Lsh(big.NewInt(1), 256)


### PR DESCRIPTION
## Summary
- remove redundant stack push/pop implementations
- rely on shared `Stack.Push` in utility functions

## Testing
- `go build ./synnergy-network/core` *(fails: process interrupted after dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_e_688f7c498f40832080a1d4347bc39e08