### PR TITLE
core: add address helper for tokens build

### DIFF
--- a/synnergy-network/core/address_from_common_tokens.go
+++ b/synnergy-network/core/address_from_common_tokens.go
@@ -1,0 +1,14 @@
+//go:build tokens
+// +build tokens
+
+package core
+
+import "github.com/ethereum/go-ethereum/common"
+
+// FromCommon converts a go-ethereum common.Address into the core Address type.
+// It copies the 20-byte address into our Address array.
+func FromCommon(a common.Address) Address {
+	var out Address
+	copy(out[:], a.Bytes())
+	return out
+}


### PR DESCRIPTION
## Summary
- add `FromCommon` helper for tokens builds so transaction reversal logic can convert Ethereum addresses to core Address type

## Testing
- `go test ./core -tags tokens` *(fails: AddressZero redeclared)*

------
https://chatgpt.com/codex/tasks/task_e_688f7c25c5788320be0cfaf44c7763bd