### PR TITLE
feat(core): add FromCommon for tokens build

### DIFF
--- a/synnergy-network/core/address_from_common_tokens.go
+++ b/synnergy-network/core/address_from_common_tokens.go
@@ -1,0 +1,14 @@
+//go:build tokens
+// +build tokens
+
+package core
+
+import "github.com/ethereum/go-ethereum/common"
+
+// FromCommon converts a go-ethereum common.Address into the core Address type.
+// It copies the 20-byte address into our Address array.
+func FromCommon(a common.Address) Address {
+	var out Address
+	copy(out[:], a.Bytes())
+	return out
+}


### PR DESCRIPTION
## Summary
- implement FromCommon for the tokens build tag so transaction fee distribution can convert Ethereum addresses into the core Address type

## Testing
- `go build -tags tokens synnergy-network/core/transaction_distribution.go` *(fails: undefined Address etc)*

------
https://chatgpt.com/codex/tasks/task_e_688f7c17816483208a401e62618aff91