### PR TITLE
fix: provide TxPayment type for wallet management

### DIFF
--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -622,22 +622,6 @@ type Storage struct {
 // TxPool & transaction structs (aggregated from transactions.go)
 //---------------------------------------------------------------------
 
-// TxType categorises transaction kinds. It mirrors the definition in
-// transactions.go but is repeated here to avoid build tag dependencies.
-type TxType uint8
-
-const (
-	// TxPayment transfers value between addresses.
-	TxPayment TxType = iota + 1
-	// TxContractCall executes a smart contract.
-	TxContractCall
-	// TxReversal denotes a reversal of a previous transaction. It requires
-	// multiple authority co‑signatures and refunds the original sender minus
-	// a protocol‑defined fee.
-	TxReversal
-)
-
-
 type Transaction struct {
 	// core fields
 	Type             TxType            `json:"type"`

--- a/synnergy-network/core/tx_types.go
+++ b/synnergy-network/core/tx_types.go
@@ -1,13 +1,21 @@
+//go:build tokens
+// +build tokens
+
 package core
 
 // TxType categorizes high-level transaction kinds used across the Synnergy core.
+//
+// The full token build exposes all transaction variants, so this file is only
+// compiled when the `tokens` build tag is supplied. Lightweight builds rely on
+// `tx_types_nontokens.go`, which defines the minimal subset required by the
+// wallet manager and other non-token modules.
 type TxType uint8
 
 const (
-	// TxPayment transfers value between addresses.
-	TxPayment TxType = iota + 1
-	// TxContractCall executes a smart contract.
-	TxContractCall
-	// TxReversal denotes a reversal of a previous transaction.
-	TxReversal
+        // TxPayment transfers value between addresses.
+        TxPayment TxType = iota + 1
+        // TxContractCall executes a smart contract.
+        TxContractCall
+        // TxReversal denotes a reversal of a previous transaction.
+        TxReversal
 )


### PR DESCRIPTION
## Summary
- add token-gated transaction type definitions
- centralize TxType to remove duplicate declarations

## Testing
- `go build -tags tokens synnergy-network/core/tx_types.go`
- `go build synnergy-network/core/tx_types_nontokens.go`
- `go build synnergy-network/core/common_structs.go` *(fails: undefined Log, TokenID, Token, PoolID, Location, TxType)*

------
https://chatgpt.com/codex/tasks/task_e_688f7c06b6608320a803150bbf7c451b