### PR TITLE
fix: specify gas price for time-locked transfers

### DIFF
--- a/synnergy-network/core/time_locked_node.go
+++ b/synnergy-network/core/time_locked_node.go
@@ -7,9 +7,6 @@ import (
 	"time"
 )
 
-// timeLockGasPrice is the flat gas cost used for queued transfers.
-const timeLockGasPrice uint64 = 1
-
 // TimeLockRecord represents a pending transfer with a release time.
 type TimeLockRecord struct {
 	ID        string
@@ -88,7 +85,7 @@ func (t *TimeLockedNode) ExecuteDue() []string {
 	}
 	t.mu.Unlock()
 
-	tm := NewTokenManager(t.ledger, NewFlatGasCalculator(timeLockGasPrice))
+	tm := NewTokenManager(t.ledger, NewFlatGasCalculator(DefaultGasPrice))
 	var executed []string
 	for _, rec := range due {
 		_ = tm.Transfer(rec.TokenID, rec.From, rec.To, rec.Amount)


### PR DESCRIPTION
## Summary
- use DefaultGasPrice when creating NewFlatGasCalculator in time-locked node

## Testing
- `go build ./synnergy-network/core/time_locked_node.go` *(fails: undefined: TokenID)*

------
https://chatgpt.com/codex/tasks/task_e_688f7bfaf7508320be5c82f8a75f1398