### PR TITLE
core: add safe txpool snapshot method

### DIFF
--- a/synnergy-network/core/transactions.go
+++ b/synnergy-network/core/transactions.go
@@ -271,8 +271,17 @@ func (tp *TxPool) Pick(max int) [][]byte {
 
 // Snapshot returns a copy of all pending transactions for inspection.
 func (tp *TxPool) Snapshot() []*Transaction {
+	if tp == nil {
+		return nil
+	}
+
 	tp.mu.RLock()
 	defer tp.mu.RUnlock()
+
+	if len(tp.queue) == 0 {
+		return nil
+	}
+
 	list := make([]*Transaction, len(tp.queue))
 	copy(list, tp.queue)
 	return list

--- a/synnergy-network/core/txpool_snapshot.go
+++ b/synnergy-network/core/txpool_snapshot.go
@@ -5,8 +5,16 @@ package core
 // Snapshot returns a copy of all pending transactions in the pool.
 // It acquires a read lock to allow concurrent access while taking the snapshot.
 func (tp *TxPool) Snapshot() []*Transaction {
+	if tp == nil {
+		return nil
+	}
+
 	tp.mu.RLock()
 	defer tp.mu.RUnlock()
+
+	if len(tp.queue) == 0 {
+		return nil
+	}
 
 	// Make a copy to avoid exposing internal slice allowing callers to mutate state.
 	list := make([]*Transaction, len(tp.queue))


### PR DESCRIPTION
## Summary
- add a nil-safe TxPool.Snapshot implementation for non-token builds
- mirror Snapshot safety checks in the token build's transactions module

## Testing
- `go build synnergy-network/core/system_health_logging.go synnergy-network/core/txpool_snapshot.go synnergy-network/core/transactions.go synnergy-network/core/common_structs.go` *(fails: undefined: Log, TokenID, Token, PoolID, Location, NATManager, Broadcaster)*

------
https://chatgpt.com/codex/tasks/task_e_688f7bea69008320b58ae03aa37371a5