### PR TITLE
Add global AddressZero sentinel

### DIFF
--- a/synnergy-network/core/address_zero.go
+++ b/synnergy-network/core/address_zero.go
@@ -2,8 +2,7 @@ package core
 
 // AddressZero represents the zero-value address (all 20 bytes set to zero).
 //
-// The variable is intentionally declared at package level so that all token
-// modules can reference a single sentinel value when performing mint, burn or
-// escrow operations.  Treat it as a read-only value.
-var AddressZero Address
-
+// The variable is declared at package level so that all token modules can
+// reference a single sentinel value when performing mint, burn, or escrow
+// operations. It should be treated as read-only.
+var AddressZero = Address{}

--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -76,16 +76,16 @@ type edge struct {
 //---------------------------------------------------------------------
 
 type AuthorityNode struct {
-        Addr        Address       `json:"addr"`
-        // Wallet holds the payment address associated with the authority
-        // node. It may differ from the node's network address and is used
-        // when distributing fees or processing on-chain payments.
-        Wallet      Address       `json:"wallet"`
-        Role        AuthorityRole `json:"role"`
-        Active      bool          `json:"active"`
-        PublicVotes uint32        `json:"pv"`
-        AuthVotes   uint32        `json:"av"`
-        CreatedAt   int64         `json:"since"`
+	Addr Address `json:"addr"`
+	// Wallet holds the payment address associated with the authority
+	// node. It may differ from the node's network address and is used
+	// when distributing fees or processing on-chain payments.
+	Wallet      Address       `json:"wallet"`
+	Role        AuthorityRole `json:"role"`
+	Active      bool          `json:"active"`
+	PublicVotes uint32        `json:"pv"`
+	AuthVotes   uint32        `json:"av"`
+	CreatedAt   int64         `json:"since"`
 }
 
 type AuthoritySet struct {
@@ -637,7 +637,6 @@ const (
 	TxReversal
 )
 
-
 type Transaction struct {
 	// core fields
 	Type             TxType            `json:"type"`
@@ -714,10 +713,6 @@ type HDWallet struct {
 
 // Address represents a 20‑byte account identifier.
 type Address [20]byte
-
-// AddressZero represents the zero-value address (all bytes zero).
-// It is used as a sentinel in token and ledger operations.
-var AddressZero = Address{}
 
 // Hash represents a 32‑byte cryptographic hash.
 type Hash [32]byte


### PR DESCRIPTION
## Summary
- add AddressZero sentinel value for core token operations
- remove duplicate AddressZero definition from common_structs

## Testing
- `go vet synnergy-network/core/address_zero.go synnergy-network/core/common_structs.go synnergy-network/core/tokens.go` *(fails: undefined: Log)*

------
https://chatgpt.com/codex/tasks/task_e_688f7bb57dc083208c8c9dfc895f4948