### PR TITLE
Expand AGENTS stages to ninety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,10 @@
 # Error Fix Stages
 
-To bring the repository to production-grade quality, all files have been divided into 30 stages. For each file in a stage:
+To bring the repository to production-grade quality, all files have been divided into 90 stages. For each file in a stage:
 
 - Fix syntax, logic, runtime, configuration, dependency, and documentation errors.
 - If a problem originates outside the file but causes an error within it, fix the external source as part of the stage.
+
 
 
 ## Stage 1
@@ -19,6 +20,8 @@ To bring the repository to production-grade quality, all files have been divided
 - Dockerfile
 - Makefile
 - SECURITY.md
+
+## Stage 2
 - Synnergy.env.sh
 - __MACOSX/synnergy-network/._.DS_Store
 - __MACOSX/synnergy-network/cmd/._.DS_Store
@@ -31,6 +34,8 @@ To bring the repository to production-grade quality, all files have been divided
 - docs/gui-user-guide.md
 - go.work
 - go.work.sum
+
+## Stage 3
 - scripts/build_matrix.sh
 - scripts/check_circular_imports.sh
 - scripts/devnet_start.sh
@@ -42,7 +47,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/.DS_Store
 - synnergy-network/.env
 
-## Stage 2
+
+## Stage 4
 
 - synnergy-network/GUI/ai-marketplace/app.js
 - synnergy-network/GUI/ai-marketplace/index.html
@@ -55,6 +61,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/GUI/cross-chain-management/components/BridgeList.js
 - synnergy-network/GUI/cross-chain-management/components/BurnReleaseForm.js
 - synnergy-network/GUI/cross-chain-management/components/LockMintForm.js
+
+## Stage 5
 - synnergy-network/GUI/cross-chain-management/components/RelayerForm.js
 - synnergy-network/GUI/cross-chain-management/index.html
 - synnergy-network/GUI/cross-chain-management/services/api.js
@@ -67,6 +75,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/GUI/dao-explorer/backend/controllers/proposalController.js
 - synnergy-network/GUI/dao-explorer/backend/middleware/errorHandler.js
 - synnergy-network/GUI/dao-explorer/backend/package-lock.json
+
+## Stage 6
 - synnergy-network/GUI/dao-explorer/backend/package.json
 - synnergy-network/GUI/dao-explorer/backend/routes/proposalRoutes.js
 - synnergy-network/GUI/dao-explorer/backend/server.js
@@ -78,7 +88,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/GUI/dao-explorer/components/VoteForm.js
 - synnergy-network/GUI/dao-explorer/styles/main.css
 
-## Stage 3
+
+## Stage 7
 
 - synnergy-network/GUI/dao-explorer/views/index.html
 - synnergy-network/GUI/dex-screener/app.js
@@ -91,6 +102,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/GUI/explorer/components/blocks.js
 - synnergy-network/GUI/explorer/components/tx.js
 - synnergy-network/GUI/explorer/index.html
+
+## Stage 8
 - synnergy-network/GUI/explorer/styles.css
 - synnergy-network/GUI/nft_marketplace/app.js
 - synnergy-network/GUI/nft_marketplace/assets/logo.png
@@ -103,6 +116,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/GUI/nft_marketplace/backend/routes/nftRoutes.js
 - synnergy-network/GUI/nft_marketplace/backend/server.js
 - synnergy-network/GUI/nft_marketplace/backend/services/marketplaceService.js
+
+## Stage 9
 - synnergy-network/GUI/nft_marketplace/index.html
 - synnergy-network/GUI/nft_marketplace/style.css
 - synnergy-network/GUI/smart-contract-marketplace/.env
@@ -114,7 +129,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/GUI/smart-contract-marketplace/eslint.config.js
 - synnergy-network/GUI/smart-contract-marketplace/index.html
 
-## Stage 4
+
+## Stage 10
 
 - synnergy-network/GUI/smart-contract-marketplace/package-lock.json
 - synnergy-network/GUI/smart-contract-marketplace/package.json
@@ -127,6 +143,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/GUI/smart-contract-marketplace/server/services/contractService.js
 - synnergy-network/GUI/smart-contract-marketplace/styles.css
 - synnergy-network/GUI/smart-contract-marketplace/views/deploy.html
+
+## Stage 11
 - synnergy-network/GUI/smart-contract-marketplace/views/detail.html
 - synnergy-network/GUI/smart-contract-marketplace/views/listings.html
 - synnergy-network/GUI/storage-marketplace/app.js
@@ -139,6 +157,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/GUI/storage-marketplace/backend/middleware/errorHandler.js
 - synnergy-network/GUI/storage-marketplace/backend/package-lock.json
 - synnergy-network/GUI/storage-marketplace/backend/package.json
+
+## Stage 12
 - synnergy-network/GUI/storage-marketplace/backend/routes/deals.js
 - synnergy-network/GUI/storage-marketplace/backend/routes/listings.js
 - synnergy-network/GUI/storage-marketplace/backend/routes/storage.js
@@ -150,7 +170,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/GUI/storage-marketplace/components/storage.js
 - synnergy-network/GUI/storage-marketplace/index.html
 
-## Stage 5
+
+## Stage 13
 
 - synnergy-network/GUI/storage-marketplace/styles/style.css
 - synnergy-network/GUI/token-creation-tool/app.js
@@ -163,6 +184,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/GUI/token-creation-tool/server/.env
 - synnergy-network/GUI/token-creation-tool/server/config/default.json
 - synnergy-network/GUI/token-creation-tool/server/controllers/tokenController.js
+
+## Stage 14
 - synnergy-network/GUI/token-creation-tool/server/middleware/errorHandler.js
 - synnergy-network/GUI/token-creation-tool/server/middleware/logger.js
 - synnergy-network/GUI/token-creation-tool/server/package-lock.json
@@ -175,6 +198,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/GUI/token-creation-tool/views/create.html
 - synnergy-network/GUI/wallet/app.js
 - synnergy-network/GUI/wallet/assets/.gitkeep
+
+## Stage 15
 - synnergy-network/GUI/wallet/components/wallet.js
 - synnergy-network/GUI/wallet/index.html
 - synnergy-network/GUI/wallet/styles/style.css
@@ -186,7 +211,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/access_control.go
 - synnergy-network/cmd/cli/account_and_balance_operations.go
 
-## Stage 6
+
+## Stage 16
 
 - synnergy-network/cmd/cli/agriculture.go
 - synnergy-network/cmd/cli/ai.go
@@ -199,6 +225,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/anomaly_detection.go
 - synnergy-network/cmd/cli/api_node.go
 - synnergy-network/cmd/cli/archival_witness_node.go
+
+## Stage 17
 - synnergy-network/cmd/cli/audit_management.go
 - synnergy-network/cmd/cli/audit_node.go
 - synnergy-network/cmd/cli/authority_apply.go
@@ -211,6 +239,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/blockchain_compression.go
 - synnergy-network/cmd/cli/blockchain_synchronization.go
 - synnergy-network/cmd/cli/bootstrap_node.go
+
+## Stage 18
 - synnergy-network/cmd/cli/carbon_credit_system.go
 - synnergy-network/cmd/cli/central_banking_node.go
 - synnergy-network/cmd/cli/chain_fork_manager.go
@@ -222,7 +252,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/compliance.go
 - synnergy-network/cmd/cli/compliance_management.go
 
-## Stage 7
+
+## Stage 19
 
 - synnergy-network/cmd/cli/connection_pool.go
 - synnergy-network/cmd/cli/consensus.go
@@ -235,6 +266,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/cross_chain_agnostic_protocols.go
 - synnergy-network/cmd/cli/cross_chain_bridge.go
 - synnergy-network/cmd/cli/cross_chain_connection.go
+
+## Stage 20
 - synnergy-network/cmd/cli/cross_chain_contracts.go
 - synnergy-network/cmd/cli/cross_chain_transactions.go
 - synnergy-network/cmd/cli/cross_consensus_scaling_networks.go
@@ -246,6 +279,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/dao_token.go
 - synnergy-network/cmd/cli/data.go
 - synnergy-network/cmd/cli/data_distribution.go
+
+## Stage 21
 - synnergy-network/cmd/cli/data_operations.go
 - synnergy-network/cmd/cli/data_resource_management.go
 - synnergy-network/cmd/cli/defi.go
@@ -257,7 +292,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/ecommerce.go
 - synnergy-network/cmd/cli/elected_authority_node.go
 
-## Stage 8
+
+## Stage 22
 
 - synnergy-network/cmd/cli/employment.go
 - synnergy-network/cmd/cli/employment_token.go
@@ -270,6 +306,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/event_ticket.go
 - synnergy-network/cmd/cli/execution_management.go
 - synnergy-network/cmd/cli/experimental_node.go
+
+## Stage 23
 - synnergy-network/cmd/cli/failover_recovery.go
 - synnergy-network/cmd/cli/faucet.go
 - synnergy-network/cmd/cli/fault_tolerance.go
@@ -281,6 +319,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/gaming.go
 - synnergy-network/cmd/cli/gateway_node.go
 - synnergy-network/cmd/cli/geolocation_network.go
+
+## Stage 24
 - synnergy-network/cmd/cli/geospatial_node.go
 - synnergy-network/cmd/cli/governance.go
 - synnergy-network/cmd/cli/governance_management.go
@@ -292,7 +332,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/high_availability.go
 - synnergy-network/cmd/cli/historical_node.go
 
-## Stage 9
+
+## Stage 25
 
 - synnergy-network/cmd/cli/holographic_node.go
 - synnergy-network/cmd/cli/identity_token.go
@@ -305,6 +346,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/insurance_token.go
 - synnergy-network/cmd/cli/integration_node.go
 - synnergy-network/cmd/cli/ipfs.go
+
+## Stage 26
 - synnergy-network/cmd/cli/iptoken.go
 - synnergy-network/cmd/cli/kademlia.go
 - synnergy-network/cmd/cli/ledger.go
@@ -316,6 +359,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/loanpool_apply.go
 - synnergy-network/cmd/cli/loanpool_management.go
 - synnergy-network/cmd/cli/marketplace.go
+
+## Stage 27
 - synnergy-network/cmd/cli/master_node.go
 - synnergy-network/cmd/cli/messages.go
 - synnergy-network/cmd/cli/military_node.go
@@ -327,7 +372,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/nat.go
 - synnergy-network/cmd/cli/network.go
 
-## Stage 10
+
+## Stage 28
 
 - synnergy-network/cmd/cli/offchain_wallet.go
 - synnergy-network/cmd/cli/optimization.go
@@ -340,6 +386,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/plasma_management.go
 - synnergy-network/cmd/cli/plasma_operations.go
 - synnergy-network/cmd/cli/polls_management.go
+
+## Stage 29
 - synnergy-network/cmd/cli/private_transactions.go
 - synnergy-network/cmd/cli/quadratic_voting.go
 - synnergy-network/cmd/cli/quantum_resistant_node.go
@@ -351,6 +399,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/replication.go
 - synnergy-network/cmd/cli/reputation_tokens.go
 - synnergy-network/cmd/cli/resource_allocation.go
+
+## Stage 30
 - synnergy-network/cmd/cli/resource_management.go
 - synnergy-network/cmd/cli/resource_marketplace.go
 - synnergy-network/cmd/cli/rollups.go
@@ -362,7 +412,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/stake_penalty.go
 - synnergy-network/cmd/cli/staking_node.go
 
-## Stage 11
+
+## Stage 31
 
 - synnergy-network/cmd/cli/state_channel.go
 - synnergy-network/cmd/cli/state_channel_management.go
@@ -375,6 +426,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/syn11.go
 - synnergy-network/cmd/cli/syn1100.go
 - synnergy-network/cmd/cli/syn1155.go
+
+## Stage 32
 - synnergy-network/cmd/cli/syn1200.go
 - synnergy-network/cmd/cli/syn130.go
 - synnergy-network/cmd/cli/syn1300_token.go
@@ -386,6 +439,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/syn1967.go
 - synnergy-network/cmd/cli/syn200.go
 - synnergy-network/cmd/cli/syn2100.go
+
+## Stage 33
 - synnergy-network/cmd/cli/syn2200.go
 - synnergy-network/cmd/cli/syn223.go
 - synnergy-network/cmd/cli/syn2400.go
@@ -397,7 +452,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/syn5000.go
 - synnergy-network/cmd/cli/syn600.go
 
-## Stage 12
+
+## Stage 34
 
 - synnergy-network/cmd/cli/syn70.go
 - synnergy-network/cmd/cli/syn721.go
@@ -410,6 +466,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/token_management.go
 - synnergy-network/cmd/cli/token_vote.go
 - synnergy-network/cmd/cli/tokens.go
+
+## Stage 35
 - synnergy-network/cmd/cli/transaction_distribution.go
 - synnergy-network/cmd/cli/transactionreversal.go
 - synnergy-network/cmd/cli/transactions.go
@@ -421,6 +479,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/cli/wallet.go
 - synnergy-network/cmd/cli/wallet_management.go
 - synnergy-network/cmd/cli/warehouse.go
+
+## Stage 36
 - synnergy-network/cmd/cli/watchtower_node.go
 - synnergy-network/cmd/cli/workflow_integrations.go
 - synnergy-network/cmd/cli/zero_trust_data_channels.go
@@ -432,7 +492,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/config/default.yaml
 - synnergy-network/cmd/config/explorer.yaml
 
-## Stage 13
+
+## Stage 37
 
 - synnergy-network/cmd/config/genesis.json
 - synnergy-network/cmd/config/prod.yaml
@@ -445,6 +506,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/explorer/server_test.go
 - synnergy-network/cmd/explorer/service.go
 - synnergy-network/cmd/opcode-lint/main.go
+
+## Stage 38
 - synnergy-network/cmd/scripts/authority_apply.sh
 - synnergy-network/cmd/scripts/build_cli.sh
 - synnergy-network/cmd/scripts/coin_mint.sh
@@ -456,6 +519,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/scripts/fault_check.sh
 - synnergy-network/cmd/scripts/governance_propose.sh
 - synnergy-network/cmd/scripts/loanpool_apply.sh
+
+## Stage 39
 - synnergy-network/cmd/scripts/marketplace_list.sh
 - synnergy-network/cmd/scripts/network_peers.sh
 - synnergy-network/cmd/scripts/network_start.sh
@@ -467,7 +532,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/scripts/sidechain_sync.sh
 - synnergy-network/cmd/scripts/start_synnergy_network.sh
 
-## Stage 14
+
+## Stage 40
 
 - synnergy-network/cmd/scripts/state_channel_open.sh
 - synnergy-network/cmd/scripts/storage_marketplace_pin.sh
@@ -480,6 +546,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/smart_contracts/ai_marketplace.sol
 - synnergy-network/cmd/smart_contracts/ai_model_registry.sol
 - synnergy-network/cmd/smart_contracts/ai_optimizer.sol
+
+## Stage 41
 - synnergy-network/cmd/smart_contracts/ai_predictor.sol
 - synnergy-network/cmd/smart_contracts/amm_pool_manager.sol
 - synnergy-network/cmd/smart_contracts/authority_applier.sol
@@ -491,6 +559,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/smart_contracts/cross_chain_eth.sol
 - synnergy-network/cmd/smart_contracts/cross_chain_manager.sol
 - synnergy-network/cmd/smart_contracts/cross_chain_protocol.sol
+
+## Stage 42
 - synnergy-network/cmd/smart_contracts/dao_explorer.json
 - synnergy-network/cmd/smart_contracts/dao_explorer.sol
 - synnergy-network/cmd/smart_contracts/data_feed_oracle.sol
@@ -502,7 +572,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/smart_contracts/faucet.sol
 - synnergy-network/cmd/smart_contracts/fault_tolerance_checker.sol
 
-## Stage 15
+
+## Stage 43
 
 - synnergy-network/cmd/smart_contracts/gov_quorum.sol
 - synnergy-network/cmd/smart_contracts/green_certifier.sol
@@ -515,6 +586,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/smart_contracts/marketplace.sol
 - synnergy-network/cmd/smart_contracts/message_queue.sol
 - synnergy-network/cmd/smart_contracts/mobile_miner.sol
+
+## Stage 44
 - synnergy-network/cmd/smart_contracts/multi_sig_wallet.sol
 - synnergy-network/cmd/smart_contracts/network_bootstrap.sol
 - synnergy-network/cmd/smart_contracts/nft_marketplace.sol
@@ -526,6 +599,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/smart_contracts/rust/ai_model_registry.rs
 - synnergy-network/cmd/smart_contracts/rust/ai_optimizer.rs
 - synnergy-network/cmd/smart_contracts/rust/ai_predictor.rs
+
+## Stage 45
 - synnergy-network/cmd/smart_contracts/rust/amm_pool_manager.rs
 - synnergy-network/cmd/smart_contracts/rust/authority_applier.rs
 - synnergy-network/cmd/smart_contracts/rust/bank_node_bridge.rs
@@ -537,7 +612,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/smart_contracts/rust/data_feed_oracle.rs
 - synnergy-network/cmd/smart_contracts/rust/data_marketplace.rs
 
-## Stage 16
+
+## Stage 46
 
 - synnergy-network/cmd/smart_contracts/rust/fault_tolerance_checker.rs
 - synnergy-network/cmd/smart_contracts/rust/gov_quorum.rs
@@ -550,6 +626,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/smart_contracts/rust/mobile_miner.rs
 - synnergy-network/cmd/smart_contracts/rust/network_bootstrap.rs
 - synnergy-network/cmd/smart_contracts/rust/node_firewall.rs
+
+## Stage 47
 - synnergy-network/cmd/smart_contracts/rust/oracle_updater.rs
 - synnergy-network/cmd/smart_contracts/rust/pension_plan.rs
 - synnergy-network/cmd/smart_contracts/rust/replication_service.rs
@@ -561,6 +639,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/cmd/smart_contracts/storage_marketplace.sol
 - synnergy-network/cmd/smart_contracts/time_locked_wallet.sol
 - synnergy-network/cmd/smart_contracts/token_creator.sol
+
+## Stage 48
 - synnergy-network/cmd/smart_contracts/token_factory.sol
 - synnergy-network/cmd/smart_contracts/token_minter.sol
 - synnergy-network/cmd/synnergy/main.go
@@ -572,7 +652,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/Nodes/Nodes_Type_manual.md
 - synnergy-network/core/Nodes/authority_nodes/Authority_node_typr_manual.md
 
-## Stage 17
+
+## Stage 49
 
 - synnergy-network/core/Nodes/authority_nodes/index.go
 - synnergy-network/core/Nodes/bank_nodes/index.go
@@ -585,6 +666,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/Nodes/holographic_node.go
 - synnergy-network/core/Nodes/index.go
 - synnergy-network/core/Nodes/light_node.go
+
+## Stage 50
 - synnergy-network/core/Nodes/military_nodes/index.go
 - synnergy-network/core/Nodes/molecular_node.go
 - synnergy-network/core/Nodes/optimization_nodes/index.go
@@ -596,6 +679,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/Nodes/watchtower/index.go
 - synnergy-network/core/Nodes/witness/archival_witness_node.go
 - synnergy-network/core/SYN1967.go
+
+## Stage 51
 - synnergy-network/core/SYN2369.go
 - synnergy-network/core/Tokens/SYN1000.go
 - synnergy-network/core/Tokens/SYN3000.go
@@ -607,7 +692,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/Tokens/syn10.go
 - synnergy-network/core/Tokens/syn1000_index.go
 
-## Stage 18
+
+## Stage 52
 
 - synnergy-network/core/Tokens/syn1100.go
 - synnergy-network/core/Tokens/syn12.go
@@ -620,6 +706,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/Tokens/syn70.go
 - synnergy-network/core/Tokens/syn845.go
 - synnergy-network/core/access_control.go
+
+## Stage 53
 - synnergy-network/core/access_control_test.go
 - synnergy-network/core/account_and_balance_operations.go
 - synnergy-network/core/account_and_balance_operations_test.go
@@ -631,6 +719,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/ai_enhanced_node.go
 - synnergy-network/core/ai_inference_analysis.go
 - synnergy-network/core/ai_model_management.go
+
+## Stage 54
 - synnergy-network/core/ai_secure_storage.go
 - synnergy-network/core/ai_training.go
 - synnergy-network/core/amm.go
@@ -642,7 +732,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/authority_apply.go
 - synnergy-network/core/authority_nodes.go
 
-## Stage 19
+
+## Stage 55
 
 - synnergy-network/core/authority_penalty_test.go
 - synnergy-network/core/autonomous_agent_node.go
@@ -655,6 +746,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/biometrics_auth.go
 - synnergy-network/core/blockchain_compression.go
 - synnergy-network/core/blockchain_synchronization.go
+
+## Stage 56
 - synnergy-network/core/bootstrap_node.go
 - synnergy-network/core/carbon_credit_system.go
 - synnergy-network/core/central_banking_node.go
@@ -666,6 +759,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/compliance.go
 - synnergy-network/core/compliance_management.go
 - synnergy-network/core/connection_pool.go
+
+## Stage 57
 - synnergy-network/core/connection_pool_test.go
 - synnergy-network/core/consensus.go
 - synnergy-network/core/consensus_adaptive_management.go
@@ -677,7 +772,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/consensus_validator_management.go
 - synnergy-network/core/content_node.go
 
-## Stage 20
+
+## Stage 58
 
 - synnergy-network/core/content_node_impl.go
 - synnergy-network/core/content_types.go
@@ -690,6 +786,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/cross_chain_bridge.go
 - synnergy-network/core/cross_chain_connection.go
 - synnergy-network/core/cross_chain_contracts.go
+
+## Stage 59
 - synnergy-network/core/cross_chain_transactions.go
 - synnergy-network/core/cross_consensus_scaling_networks.go
 - synnergy-network/core/custodial_node.go
@@ -701,6 +799,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/dao_token.go
 - synnergy-network/core/data.go
 - synnergy-network/core/data_distribution.go
+
+## Stage 60
 - synnergy-network/core/data_operations.go
 - synnergy-network/core/data_resource_management.go
 - synnergy-network/core/defi.go
@@ -712,7 +812,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/ecommerce.go
 - synnergy-network/core/education_token.go
 
-## Stage 21
+
+## Stage 61
 
 - synnergy-network/core/elected_authority_node.go
 - synnergy-network/core/employment.go
@@ -725,6 +826,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/execution_management.go
 - synnergy-network/core/experimental_node.go
 - synnergy-network/core/external_sensor.go
+
+## Stage 62
 - synnergy-network/core/failover_recovery.go
 - synnergy-network/core/faucet.go
 - synnergy-network/core/fault_tolerance.go
@@ -736,6 +839,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/gas_table.go
 - synnergy-network/core/gateway_node.go
 - synnergy-network/core/geolocation_network.go
+
+## Stage 63
 - synnergy-network/core/geospatial_node.go
 - synnergy-network/core/governance.go
 - synnergy-network/core/governance_execution.go
@@ -747,7 +852,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/green_technology.go
 - synnergy-network/core/healthcare.go
 
-## Stage 22
+
+## Stage 64
 
 - synnergy-network/core/helpers.go
 - synnergy-network/core/high_availability.go
@@ -760,6 +866,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/initialization_replication.go
 - synnergy-network/core/intangible_assets.go
 - synnergy-network/core/integration_node.go
+
+## Stage 65
 - synnergy-network/core/integration_registry.go
 - synnergy-network/core/ip_management.go
 - synnergy-network/core/ipfs.go
@@ -771,6 +879,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/liquidity_views.go
 - synnergy-network/core/loanpool.go
 - synnergy-network/core/loanpool_apply.go
+
+## Stage 66
 - synnergy-network/core/loanpool_approval_process.go
 - synnergy-network/core/loanpool_config.go
 - synnergy-network/core/loanpool_grant_disbursement.go
@@ -782,7 +892,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/messages.go
 - synnergy-network/core/mining_node.go
 
-## Stage 23
+
+## Stage 67
 
 - synnergy-network/core/mobile_mining_node.go
 - synnergy-network/core/mobile_node.go
@@ -795,6 +906,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/network.go
 - synnergy-network/core/network_test.go
 - synnergy-network/core/node.go
+
+## Stage 68
 - synnergy-network/core/offchain_wallet.go
 - synnergy-network/core/opcode_and_gas_guide.md
 - synnergy-network/core/opcode_dispatcher.go
@@ -806,6 +919,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/plasma_management.go
 - synnergy-network/core/plasma_operations.go
 - synnergy-network/core/polls_management.go
+
+## Stage 69
 - synnergy-network/core/private_transactions.go
 - synnergy-network/core/quantum_resistant_node.go
 - synnergy-network/core/quorum_tracker.go
@@ -817,7 +932,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/resource_allocation_management.go
 - synnergy-network/core/resource_allocator.go
 
-## Stage 24
+
+## Stage 70
 
 - synnergy-network/core/resource_management.go
 - synnergy-network/core/resource_marketplace.go
@@ -830,6 +946,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/sidechains.go
 - synnergy-network/core/smart_legal_contracts.go
 - synnergy-network/core/stake_penalty.go
+
+## Stage 71
 - synnergy-network/core/staking_node.go
 - synnergy-network/core/state_channel.go
 - synnergy-network/core/state_channel_management.go
@@ -841,6 +959,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/syn1155.go
 - synnergy-network/core/syn11_token.go
 - synnergy-network/core/syn1300.go
+
+## Stage 72
 - synnergy-network/core/syn131_token.go
 - synnergy-network/core/syn1401.go
 - synnergy-network/core/syn1500.go
@@ -852,7 +972,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/syn2400.go
 - synnergy-network/core/syn2500_token.go
 
-## Stage 25
+
+## Stage 73
 
 - synnergy-network/core/syn2700.go
 - synnergy-network/core/syn2900.go
@@ -865,6 +986,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/syn3600.go
 - synnergy-network/core/syn3700_token.go
 - synnergy-network/core/syn3800.go
+
+## Stage 74
 - synnergy-network/core/syn3900.go
 - synnergy-network/core/syn4200_token.go
 - synnergy-network/core/syn4700.go
@@ -876,6 +999,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/syn800_token.go
 - synnergy-network/core/system_health_logging.go
 - synnergy-network/core/tangible_assets.go
+
+## Stage 75
 - synnergy-network/core/time_locked_node.go
 - synnergy-network/core/token_management.go
 - synnergy-network/core/token_management_syn1000.go
@@ -887,7 +1012,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/tokens_syn1000_helpers.go
 - synnergy-network/core/tokens_syn1000_opcodes.go
 
-## Stage 26
+
+## Stage 76
 
 - synnergy-network/core/tokens_syn1200.go
 - synnergy-network/core/tokens_syn900.go
@@ -900,6 +1026,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/txpool_addtx.go
 - synnergy-network/core/txpool_snapshot.go
 - synnergy-network/core/txpool_stub.go
+
+## Stage 77
 - synnergy-network/core/user_feedback_system.go
 - synnergy-network/core/utility_functions.go
 - synnergy-network/core/validator_node.go
@@ -911,6 +1039,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/core/warfare_node.go
 - synnergy-network/core/watchtower_node.go
 - synnergy-network/core/workflow_integrations.go
+
+## Stage 78
 - synnergy-network/core/zero_trust_data_channels.go
 - synnergy-network/core/zkp_node.go
 - synnergy-network/go.mod
@@ -922,7 +1052,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/internal/testutil/sandbox.go
 - synnergy-network/internal/testutil/sandbox_fuzz_test.go
 
-## Stage 27
+
+## Stage 79
 
 - synnergy-network/internal/testutil/sandbox_test.go
 - synnergy-network/monitoring/grafana/dashboard-cli.json
@@ -935,6 +1066,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/pkg/utils/env_test.go
 - synnergy-network/pkg/utils/errors.go
 - synnergy-network/pkg/utils/version.go
+
+## Stage 80
 - synnergy-network/smart_contract_guide.md
 - synnergy-network/tests/ai_test.go
 - synnergy-network/tests/amm_test.go
@@ -946,6 +1079,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/tests/dao_proposal_test.go
 - synnergy-network/tests/dao_test.go
 - synnergy-network/tests/fault_tolerance_test.go
+
+## Stage 81
 - synnergy-network/tests/governance_test.go
 - synnergy-network/tests/green_technology_test.go
 - synnergy-network/tests/identity_verification_test.go
@@ -957,7 +1092,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/tests/security_test.go
 - synnergy-network/tests/sharding_test.go
 
-## Stage 28
+
+## Stage 82
 
 - synnergy-network/tests/sidechain_test.go
 - synnergy-network/tests/state_channel_test.go
@@ -970,6 +1106,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/third_party/go-libp2p-core/.github/workflows/go-compat.yml
 - synnergy-network/third_party/go-libp2p-core/.github/workflows/go-test.yml
 - synnergy-network/third_party/go-libp2p-core/.github/workflows/release-check.yml
+
+## Stage 83
 - synnergy-network/third_party/go-libp2p-core/.github/workflows/releaser.yml
 - synnergy-network/third_party/go-libp2p-core/.github/workflows/tagpush.yml
 - synnergy-network/third_party/go-libp2p-core/.gitignore
@@ -981,6 +1119,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/third_party/go-libp2p-core/connmgr/decay.go
 - synnergy-network/third_party/go-libp2p-core/connmgr/gater.go
 - synnergy-network/third_party/go-libp2p-core/connmgr/manager.go
+
+## Stage 84
 - synnergy-network/third_party/go-libp2p-core/connmgr/null.go
 - synnergy-network/third_party/go-libp2p-core/connmgr/presets.go
 - synnergy-network/third_party/go-libp2p-core/control/disconnect.go
@@ -992,7 +1132,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/third_party/go-libp2p-core/crypto/pb/forward.go
 - synnergy-network/third_party/go-libp2p-core/crypto/rsa_common.go
 
-## Stage 29
+
+## Stage 85
 
 - synnergy-network/third_party/go-libp2p-core/crypto/rsa_go.go
 - synnergy-network/third_party/go-libp2p-core/crypto/rsa_openssl.go
@@ -1005,6 +1146,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/third_party/go-libp2p-core/event/doc.go
 - synnergy-network/third_party/go-libp2p-core/event/identify.go
 - synnergy-network/third_party/go-libp2p-core/event/nattype.go
+
+## Stage 86
 - synnergy-network/third_party/go-libp2p-core/event/network.go
 - synnergy-network/third_party/go-libp2p-core/event/protocol.go
 - synnergy-network/third_party/go-libp2p-core/event/reachability.go
@@ -1016,6 +1159,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/third_party/go-libp2p-core/introspection/endpoint.go
 - synnergy-network/third_party/go-libp2p-core/introspection/introspector.go
 - synnergy-network/third_party/go-libp2p-core/metrics/bandwidth.go
+
+## Stage 87
 - synnergy-network/third_party/go-libp2p-core/metrics/reporter.go
 - synnergy-network/third_party/go-libp2p-core/network/conn.go
 - synnergy-network/third_party/go-libp2p-core/network/context.go
@@ -1027,7 +1172,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/third_party/go-libp2p-core/network/rcmgr.go
 - synnergy-network/third_party/go-libp2p-core/network/stream.go
 
-## Stage 30
+
+## Stage 88
 
 - synnergy-network/third_party/go-libp2p-core/peer/addrinfo.go
 - synnergy-network/third_party/go-libp2p-core/peer/peer.go
@@ -1039,6 +1185,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/third_party/go-libp2p-core/pnet/error.go
 - synnergy-network/third_party/go-libp2p-core/pnet/protector.go
 - synnergy-network/third_party/go-libp2p-core/protocol/id.go
+
+## Stage 89
 - synnergy-network/third_party/go-libp2p-core/protocol/switch.go
 - synnergy-network/third_party/go-libp2p-core/record/envelope.go
 - synnergy-network/third_party/go-libp2p-core/record/record.go
@@ -1050,6 +1198,8 @@ To bring the repository to production-grade quality, all files have been divided
 - synnergy-network/third_party/go-libp2p-core/test/addrs.go
 - synnergy-network/third_party/go-libp2p-core/test/crypto.go
 - synnergy-network/third_party/go-libp2p-core/test/errors.go
+
+## Stage 90
 - synnergy-network/third_party/go-libp2p-core/test/peer.go
 - synnergy-network/third_party/go-libp2p-core/transport/transport.go
 - synnergy-network/third_party/go-libp2p-core/version.json


### PR DESCRIPTION
## Summary
- Reorganize AGENTS.md to break repository tasks into 90 stages instead of 30 for finer granularity.

## Testing
- `./scripts/run_tests.sh` *(fails: go: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f99fd42f48320b49920f072a22ae0