### PR TITLE
feat: harden relayer handling and DAO backend logs

### DIFF
--- a/synnergy-network/GUI/cross-chain-management/components/RelayerForm.js
+++ b/synnergy-network/GUI/cross-chain-management/components/RelayerForm.js
@@ -1,8 +1,11 @@
-export function attachRelayerForm(container, { onAuthorize, onRevoke }) {
+export function attachRelayerForm(
+  container,
+  { onAuthorize = async () => {}, onRevoke = async () => {} } = {},
+) {
   container.innerHTML = `
         <form id="relayerForm" class="row gy-2 gx-2 align-items-center">
             <div class="col-auto">
-                <input type="text" class="form-control" id="relayerAddr" placeholder="Relayer Address" required>
+                <input type="text" class="form-control" id="relayerAddr" placeholder="Relayer Address" required pattern="^0x[a-fA-F0-9]{40}$">
             </div>
             <div class="col-auto">
                 <button class="btn btn-success" id="authBtn">Authorize</button>
@@ -14,14 +17,27 @@ export function attachRelayerForm(container, { onAuthorize, onRevoke }) {
 
   const form = container.querySelector("#relayerForm");
   const addrInput = form.querySelector("#relayerAddr");
+  const isValidAddress = (addr) => /^0x[a-fA-F0-9]{40}$/.test(addr);
+
   form.querySelector("#authBtn").addEventListener("click", async (e) => {
     e.preventDefault();
-    await onAuthorize({ addr: addrInput.value });
+    const addr = addrInput.value.trim();
+    if (!isValidAddress(addr)) {
+      alert("Invalid address");
+      return;
+    }
+    await onAuthorize({ addr });
     addrInput.value = "";
   });
+
   form.querySelector("#revokeBtn").addEventListener("click", async (e) => {
     e.preventDefault();
-    await onRevoke({ addr: addrInput.value });
+    const addr = addrInput.value.trim();
+    if (!isValidAddress(addr)) {
+      alert("Invalid address");
+      return;
+    }
+    await onRevoke({ addr });
     addrInput.value = "";
   });
 }

--- a/synnergy-network/GUI/cross-chain-management/services/api.js
+++ b/synnergy-network/GUI/cross-chain-management/services/api.js
@@ -1,46 +1,35 @@
 const base = "/api";
 
-export async function listBridges() {
-  const r = await fetch(`${base}/bridges`);
-  return r.json();
+async function request(endpoint, options = {}) {
+  const res = await fetch(`${base}${endpoint}`, {
+    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
+    ...options,
+  });
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(`Request failed with ${res.status}: ${message}`);
+  }
+  const contentType = res.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    return res.json();
+  }
+  return res.text();
 }
 
-export async function createBridge(data) {
-  await fetch(`${base}/bridges`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
-}
+export const listBridges = () => request("/bridges");
 
-export async function authorizeRelayer(data) {
-  await fetch(`${base}/relayer/authorize`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
-}
+export const createBridge = (data) =>
+  request("/bridges", { method: "POST", body: JSON.stringify(data) });
 
-export async function revokeRelayer(data) {
-  await fetch(`${base}/relayer/revoke`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
-}
+export const authorizeRelayer = (data) =>
+  request("/relayer/authorize", { method: "POST", body: JSON.stringify(data) });
 
-export async function lockAndMint(data) {
-  await fetch(`${base}/lockmint`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
-}
+export const revokeRelayer = (data) =>
+  request("/relayer/revoke", { method: "POST", body: JSON.stringify(data) });
 
-export async function burnAndRelease(data) {
-  await fetch(`${base}/burnrelease`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
-}
+export const lockAndMint = (data) =>
+  request("/lockmint", { method: "POST", body: JSON.stringify(data) });
+
+export const burnAndRelease = (data) =>
+  request("/burnrelease", { method: "POST", body: JSON.stringify(data) });
+

--- a/synnergy-network/GUI/dao-explorer/backend/middleware/errorHandler.js
+++ b/synnergy-network/GUI/dao-explorer/backend/middleware/errorHandler.js
@@ -1,5 +1,9 @@
+const { env } = require("../config/config");
+
 function errorHandler(err, req, res, next) {
-  console.error(err.stack);
+  if (env !== "production") {
+    console.error(err.stack);
+  }
   res
     .status(err.status || 500)
     .json({ message: err.message || "Internal Server Error" });


### PR DESCRIPTION
## Summary
- centralize cross-chain API requests with error handling
- validate relayer addresses and provide default callbacks
- limit DAO backend error logging in production

## Testing
- `node --check synnergy-network/GUI/cross-chain-management/services/api.js`
- `node --check synnergy-network/GUI/cross-chain-management/components/RelayerForm.js`
- `node --check synnergy-network/GUI/dao-explorer/backend/middleware/errorHandler.js`
- `npm install`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688fb79066ec832098a24f8a8be63fb1