### PR TITLE
refactor: harden DAO explorer services

### DIFF
--- a/synnergy-network/GUI/dao-explorer/backend/package-lock.json
+++ b/synnergy-network/GUI/dao-explorer/backend/package-lock.json
@@ -9,9 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "body-parser": "^1.20.3",
-        "cors": "2.8.5",
-        "dotenv": "16.3.1",
+        "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
         "ethers": "^6.15.0",
         "express": "^4.21.2"
       },
@@ -223,15 +222,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/synnergy-network/GUI/dao-explorer/backend/package.json
+++ b/synnergy-network/GUI/dao-explorer/backend/package.json
@@ -6,11 +6,14 @@
   "engines": {
     "node": ">=20"
   },
-  "packageManager": "npm@11.4.2",
+  "packageManager": "npm@10.8.2",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --check server.js && node --check routes/proposalRoutes.js && node --check services/contractService.js && node --check services/proposalService.js"
+  },
   "dependencies": {
-    "body-parser": "^1.20.3",
-    "cors": "2.8.5",
-    "dotenv": "16.3.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
     "ethers": "^6.15.0",
     "express": "^4.21.2"
   }

--- a/synnergy-network/GUI/dao-explorer/backend/server.js
+++ b/synnergy-network/GUI/dao-explorer/backend/server.js
@@ -1,5 +1,4 @@
 const express = require("express");
-const bodyParser = require("body-parser");
 const cors = require("cors");
 const config = require("./config/config");
 const proposalRoutes = require("./routes/proposalRoutes");
@@ -8,7 +7,7 @@ const path = require("path");
 
 const app = express();
 app.use(cors());
-app.use(bodyParser.json());
+app.use(express.json());
 
 // serve frontend files
 app.use(express.static(path.join(__dirname, "..", "views")));

--- a/synnergy-network/GUI/dao-explorer/components/ProposalDetail.js
+++ b/synnergy-network/GUI/dao-explorer/components/ProposalDetail.js
@@ -1,15 +1,46 @@
 export default function renderProposalDetail(proposal) {
   const container = document.getElementById("proposal-detail");
-  container.innerHTML = proposal
-    ? `
-    <h2 class="text-xl font-bold mb-2">${proposal.title}</h2>
-    <p class="mb-2">${proposal.description}</p>
-    <p>For: ${proposal.votesFor} | Against: ${proposal.votesAgainst}</p>
-    <form id="vote-form" class="mt-2">
-      <input type="hidden" name="id" value="${proposal.id}">
-      <button name="approve" value="true" class="bg-green-500 text-white px-2 py-1 mr-2 rounded">Approve</button>
-      <button name="approve" value="false" class="bg-red-500 text-white px-2 py-1 rounded">Reject</button>
-    </form>
-  `
-    : "<p>Select a proposal</p>";
+  container.innerHTML = "";
+
+  if (!proposal) {
+    const placeholder = document.createElement("p");
+    placeholder.textContent = "Select a proposal";
+    container.appendChild(placeholder);
+    return;
+  }
+
+  const title = document.createElement("h2");
+  title.className = "text-xl font-bold mb-2";
+  title.textContent = proposal.title;
+
+  const description = document.createElement("p");
+  description.className = "mb-2";
+  description.textContent = proposal.description;
+
+  const votes = document.createElement("p");
+  votes.textContent = `For: ${proposal.votesFor} | Against: ${proposal.votesAgainst}`;
+
+  const form = document.createElement("form");
+  form.id = "vote-form";
+  form.className = "mt-2";
+
+  const hiddenId = document.createElement("input");
+  hiddenId.type = "hidden";
+  hiddenId.name = "id";
+  hiddenId.value = proposal.id;
+
+  const approveBtn = document.createElement("button");
+  approveBtn.name = "approve";
+  approveBtn.value = "true";
+  approveBtn.className = "bg-green-500 text-white px-2 py-1 mr-2 rounded";
+  approveBtn.textContent = "Approve";
+
+  const rejectBtn = document.createElement("button");
+  rejectBtn.name = "approve";
+  rejectBtn.value = "false";
+  rejectBtn.className = "bg-red-500 text-white px-2 py-1 rounded";
+  rejectBtn.textContent = "Reject";
+
+  form.append(hiddenId, approveBtn, rejectBtn);
+  container.append(title, description, votes, form);
 }

--- a/synnergy-network/GUI/dao-explorer/components/ProposalList.js
+++ b/synnergy-network/GUI/dao-explorer/components/ProposalList.js
@@ -4,9 +4,20 @@ export default function renderProposalList(proposals) {
   proposals.forEach((p) => {
     const item = document.createElement("div");
     item.className = "border p-4 rounded mb-2 bg-white";
-    item.innerHTML = `<h3 class="text-lg font-semibold">${p.title}</h3>
-      <p>${p.description}</p>
-      <button class="text-blue-600 underline" data-id="${p.id}">View</button>`;
+
+    const title = document.createElement("h3");
+    title.className = "text-lg font-semibold";
+    title.textContent = p.title;
+
+    const description = document.createElement("p");
+    description.textContent = p.description;
+
+    const button = document.createElement("button");
+    button.className = "text-blue-600 underline";
+    button.dataset.id = p.id;
+    button.textContent = "View";
+
+    item.append(title, description, button);
     container.appendChild(item);
   });
 }


### PR DESCRIPTION
## Summary
- streamline DAO explorer backend with start/test scripts and express.json
- mitigate XSS by rendering proposal data with DOM APIs instead of innerHTML
- update lockfile to reflect dependency cleanup

## Testing
- `cd synnergy-network/GUI/dao-explorer/backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fb79be0988320a4c39b1df8656ea3