### PR TITLE
refactor: convert smart contract marketplace server to esm

### DIFF
--- a/synnergy-network/GUI/smart-contract-marketplace/server/controllers/contractController.js
+++ b/synnergy-network/GUI/smart-contract-marketplace/server/controllers/contractController.js
@@ -1,11 +1,11 @@
-const service = require("../services/contractService");
+import * as service from "../services/contractService.js";
 
-exports.list = async (req, res) => {
+export async function list(req, res) {
   const listings = await service.listContracts();
   res.json(listings);
-};
+}
 
-exports.deploy = async (req, res) => {
+export async function deploy(req, res) {
   try {
     const { name, wasm } = req.body;
     const contract = await service.deployContract(name, wasm);
@@ -13,21 +13,21 @@ exports.deploy = async (req, res) => {
   } catch (e) {
     res.status(500).json({ error: e.message });
   }
-};
+}
 
-exports.get = async (req, res) => {
+export async function get(req, res) {
   const contract = await service.getContract(req.params.id);
   if (!contract) return res.status(404).end();
   res.json(contract);
-};
+}
 
-exports.remove = async (req, res) => {
+export async function remove(req, res) {
   await service.deleteContract(req.params.id);
   res.status(204).end();
-};
+}
 
-exports.wasm = async (req, res) => {
+export async function wasm(req, res) {
   const file = await service.getWasm(req.params.id);
   if (!file) return res.status(404).end();
   res.type("application/wasm").send(file);
-};
+}

--- a/synnergy-network/GUI/smart-contract-marketplace/server/middleware/logger.js
+++ b/synnergy-network/GUI/smart-contract-marketplace/server/middleware/logger.js
@@ -1,4 +1,4 @@
-module.exports = function (req, res, next) {
+export default function (req, res, next) {
   console.log(`${req.method} ${req.originalUrl}`);
   next();
-};
+}

--- a/synnergy-network/GUI/smart-contract-marketplace/server/routes/contracts.js
+++ b/synnergy-network/GUI/smart-contract-marketplace/server/routes/contracts.js
@@ -1,6 +1,7 @@
-const express = require("express");
-const router = express.Router();
-const ctrl = require("../controllers/contractController");
+import { Router } from "express";
+import * as ctrl from "../controllers/contractController.js";
+
+const router = Router();
 
 router.get("/", ctrl.list);
 router.post("/", ctrl.deploy);
@@ -8,4 +9,4 @@ router.get("/:id", ctrl.get);
 router.delete("/:id", ctrl.remove);
 router.get("/:id/wasm", ctrl.wasm);
 
-module.exports = router;
+export default router;

--- a/synnergy-network/GUI/smart-contract-marketplace/server/server.js
+++ b/synnergy-network/GUI/smart-contract-marketplace/server/server.js
@@ -1,9 +1,15 @@
-const express = require("express");
-const morgan = require("morgan");
-const contractsRouter = require("./routes/contracts");
-const logger = require("./middleware/logger");
-const path = require("path");
-require("dotenv").config();
+import express from "express";
+import morgan from "morgan";
+import contractsRouter from "./routes/contracts.js";
+import logger from "./middleware/logger.js";
+import path from "path";
+import dotenv from "dotenv";
+import { fileURLToPath } from "url";
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 app.use(express.json());

--- a/synnergy-network/GUI/smart-contract-marketplace/server/services/contractService.js
+++ b/synnergy-network/GUI/smart-contract-marketplace/server/services/contractService.js
@@ -1,6 +1,10 @@
-const fs = require("fs");
-const path = require("path");
-const { exec } = require("child_process");
+import fs from "fs";
+import path from "path";
+import { exec } from "child_process";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const DB_PATH =
   process.env.DB_FILE || path.join(__dirname, "../data/contracts.json");
@@ -19,11 +23,11 @@ function save(data) {
   fs.writeFileSync(DB_PATH, JSON.stringify(data, null, 2));
 }
 
-exports.listContracts = async () => {
+export async function listContracts() {
   return load();
-};
+}
 
-exports.deployContract = async (name, wasm) => {
+export async function deployContract(name, wasm) {
   const contracts = load();
   const id = `c${Date.now()}`;
   const filename = path.join(__dirname, `${id}.wasm`);
@@ -41,21 +45,21 @@ exports.deployContract = async (name, wasm) => {
   contracts.push(contract);
   save(contracts);
   return contract;
-};
+}
 
-exports.getContract = async (id) => {
+export async function getContract(id) {
   const contracts = load();
   return contracts.find((c) => c.id === id);
-};
+}
 
-exports.deleteContract = async (id) => {
+export async function deleteContract(id) {
   let contracts = load();
   contracts = contracts.filter((c) => c.id !== id);
   save(contracts);
-};
+}
 
-exports.getWasm = async (id) => {
+export async function getWasm(id) {
   const file = path.join(__dirname, `${id}.wasm`);
   if (!fs.existsSync(file)) return null;
   return fs.readFileSync(file);
-};
+}


### PR DESCRIPTION
## Summary
- migrate smart contract marketplace backend from CommonJS to ES modules for consistency with `type: module`
- add URL-derived `__dirname` handling and module imports across server, routes, controllers and services

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test")*
- `node server/server.js`

------
https://chatgpt.com/codex/tasks/task_e_688fb7cc7e288320adb0be0b1572d573