### PR TITLE
Stage 13 fixes: enhance token tool reliability

### DIFF
--- a/synnergy-network/GUI/token-creation-tool/components/TokenList.js
+++ b/synnergy-network/GUI/token-creation-tool/components/TokenList.js
@@ -1,7 +1,11 @@
 export async function renderTokenList(container) {
-  const res = await fetch("/api/tokens");
-  const tokens = await res.json();
-  container.innerHTML = `
+  try {
+    const res = await fetch("/api/tokens");
+    if (!res.ok) {
+      throw new Error(`Request failed with status ${res.status}`);
+    }
+    const tokens = await res.json();
+    container.innerHTML = `
     <h2 class="h4 mt-5">Existing Tokens</h2>
     <table class="table table-striped">
       <thead><tr><th>ID</th><th>Name</th><th>Symbol</th><th>Supply</th></tr></thead>
@@ -9,8 +13,11 @@ export async function renderTokenList(container) {
         .map(
           (t) => `
         <tr><td>${t.id}</td><td>${t.name}</td><td>${t.symbol}</td><td>${t.supply}</td></tr>
-      `,
+      `
         )
         .join("")}</tbody>
     </table>`;
+  } catch (err) {
+    container.innerHTML = `<p class="text-danger">Failed to load tokens: ${err.message}</p>`;
+  }
 }

--- a/synnergy-network/GUI/token-creation-tool/server/services/tokenService.js
+++ b/synnergy-network/GUI/token-creation-tool/server/services/tokenService.js
@@ -2,14 +2,13 @@ import fs from "fs";
 import path from "path";
 import solc from "solc";
 import { ethers } from "ethers";
+import { fileURLToPath } from "url";
 
-const dbPath = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
-  "..",
-  "tokens.json",
-);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const dbPath = path.join(__dirname, "..", "tokens.json");
 const contractPath = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
+  __dirname,
   "..",
   "..",
   "..",


### PR DESCRIPTION
## Summary
- add resilient token list rendering and graceful fetch error handling
- correct token service imports and path resolution

## Testing
- `npx eslint -c synnergy-network/GUI/token-creation-tool/eslint.config.js synnergy-network/GUI/token-creation-tool/app.js synnergy-network/GUI/token-creation-tool/components/TokenForm.js synnergy-network/GUI/token-creation-tool/components/TokenList.js synnergy-network/GUI/token-creation-tool/server/controllers/tokenController.js synnergy-network/GUI/token-creation-tool/server/services/tokenService.js`
- `npx prettier --check synnergy-network/GUI/storage-marketplace/styles/style.css synnergy-network/GUI/token-creation-tool/index.html`
- `jq empty synnergy-network/GUI/token-creation-tool/server/config/default.json`
- `xmllint --noout synnergy-network/GUI/token-creation-tool/assets/banner.svg synnergy-network/GUI/token-creation-tool/assets/logo.svg`
- `node --check synnergy-network/GUI/token-creation-tool/components/TokenList.js`
- `node --check synnergy-network/GUI/token-creation-tool/server/services/tokenService.js`


------
https://chatgpt.com/codex/tasks/task_e_688fb7ef269c832096f1b72fc64d77b2