### PR TITLE
Fix CLI wiring for Stage 16

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1,3 +1,4 @@
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -15,6 +16,7 @@ github.com/multiformats/go-base32 v0.0.3/go.mod h1:pLiuGC8y0QR3Ue4Zug5UzK9LjgbkL
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
 github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
 github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
+github.com/pion/mdns v0.0.12 h1:CiMYlY+O0azojWDmxdNr7ADGrnZ+V6Ilfner+6mSVK8=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=

--- a/synnergy-network/cmd/cli/ai_contract.go
+++ b/synnergy-network/cmd/cli/ai_contract.go
@@ -28,7 +28,7 @@ func parseAddressAddr(h string) (core.Address, error) {
 // Controller wraps the core functions
 type AIContractController struct{}
 
-func (c *AIContractController) Deploy(wasm string, ric string, cid string, royalty uint16, gas uint64) (*core.AIEnhancedContract, error) {
+func (c *AIContractController) Deploy(wasm, ric, cid string, royalty uint16, gas uint64) (*core.AIEnhancedContract, error) {
 	code, err := ioutil.ReadFile(wasm)
 	if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (c *AIContractController) Deploy(wasm string, ric string, cid string, royal
 	return core.DeployAIContract(code, ricData, cid, royalty, creator, gas)
 }
 
-func (c *AIContractController) Invoke(addr core.Address, method string, argHex string, txPath string, threshold float32, gas uint64) ([]byte, error) {
+func (c *AIContractController) Invoke(addr core.Address, method, argHex, txPath string, threshold float32, gas uint64) ([]byte, error) {
 	args, err := hex.DecodeString(strings.TrimPrefix(argHex, "0x"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid args hex: %w", err)

--- a/synnergy-network/cmd/cli/ai_enhanced_node.go
+++ b/synnergy-network/cmd/cli/ai_enhanced_node.go
@@ -75,7 +75,12 @@ func aiPredictLoad(cmd *cobra.Command, args []string) error {
 var aiNodeCmd = &cobra.Command{Use: "ainode", Short: "AI enhanced node", PersistentPreRunE: aiNodeInit}
 var aiNodeStartCmd = &cobra.Command{Use: "start", Short: "Start AI node", RunE: aiNodeStart}
 var aiNodeStopCmd = &cobra.Command{Use: "stop", Short: "Stop AI node", RunE: aiNodeStop}
-var aiNodePredictCmd = &cobra.Command{Use: "predict <file>", Short: "Predict tx volume", Args: cobra.ExactArgs(1), RunE: aiPredictLoad}
+var aiNodePredictCmd = &cobra.Command{
+	Use:   "predict <file>",
+	Short: "Predict tx volume",
+	Args:  cobra.ExactArgs(1),
+	RunE:  aiPredictLoad,
+}
 
 func init() {
 	aiNodeCmd.AddCommand(aiNodeStartCmd, aiNodeStopCmd, aiNodePredictCmd)

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,79 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/sirupsen/logrus"
 )
-
-// NodeID uniquely identifies a network peer.
-type NodeID string
-
-// Peer stores information about a connected peer.
-type Peer struct {
-	ID      NodeID
-	Addr    string
-	Latency time.Duration
-	Conn    net.Conn
-}
-
-// Message represents a pubsub message.
-type Message struct {
-	From  NodeID
-	Topic string
-	Data  []byte
-}
-
-// Config holds basic networking configuration.
-type Config struct {
-	ListenAddr     string
-	BootstrapPeers []string
-	DiscoveryTag   string
-}
-
-// NetworkMessage is used for optional replication hooks.
-type NetworkMessage struct {
-	Topic   string
-	Content []byte
-}
-
-// Block is a minimal placeholder for broadcast tests.
-type Block struct{}
-
-// NATManager manages external port mappings.
-type NATManager struct{}
-
-// NewNATManager returns a no-op NAT manager implementation.
-func NewNATManager() (*NATManager, error) { return &NATManager{}, nil }
-
-// Map reserves the given port; in this stub it is a no-op.
-func (m *NATManager) Map(port int) error { return nil }
-
-// Unmap releases any mapped port; in this stub it is a no-op.
-func (m *NATManager) Unmap() error { return nil }
-
-// parsePort extracts the TCP port from a multiaddress string.
-func parsePort(addr string) (int, error) {
-	parts := strings.Split(addr, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "tcp" {
-			return strconv.Atoi(parts[i+1])
-		}
-	}
-	return 0, fmt.Errorf("no tcp port in %s", addr)
-}
-
-// Node represents a Synnergy P2P node.
-type Node struct {
-	host      host.Host
-	pubsub    *pubsub.PubSub
-	topics    map[string]*pubsub.Topic
-	subs      map[string]*pubsub.Subscription
-	topicLock sync.RWMutex
-	subLock   sync.RWMutex
-	peerLock  sync.RWMutex
-	peers     map[NodeID]*Peer
-	nat       *NATManager
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cfg       Config
-}
 
 func NewNode(cfg Config) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- streamline AI contract deploy/invoke parameters and adjust signatures
- clean up AI enhanced node CLI and expose predict subcommand
- remove duplicate type definitions from core network module to resolve redeclarations

## Testing
- `go vet ./cmd/cli/ai_contract.go` *(fails: undefined references in core package)*

------
https://chatgpt.com/codex/tasks/task_e_688fb811d87883208a78fde6d15a0013