### PR TITLE
refactor: modernize biometrics file handling

### DIFF
--- a/synnergy-network/cmd/cli/biometric_security_node.go
+++ b/synnergy-network/cmd/cli/biometric_security_node.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -60,7 +60,7 @@ func bioNodeStop(cmd *cobra.Command, _ []string) error {
 func bioEnrollNode(cmd *cobra.Command, args []string) error {
 	addr, _ := cmd.Flags().GetString("address")
 	file, _ := cmd.Flags().GetString("file")
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/synnergy-network/cmd/cli/biometrics.go
+++ b/synnergy-network/cmd/cli/biometrics.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	core "synnergy-network/core"
@@ -15,7 +15,7 @@ var biometrics = core.NewBiometricsAuth()
 func bioEnroll(cmd *cobra.Command, args []string) error {
 	addr, _ := cmd.Flags().GetString("address")
 	file, _ := cmd.Flags().GetString("file")
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}
@@ -25,7 +25,7 @@ func bioEnroll(cmd *cobra.Command, args []string) error {
 func bioVerify(cmd *cobra.Command, args []string) error {
 	addr, _ := cmd.Flags().GetString("address")
 	file, _ := cmd.Flags().GetString("file")
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- use `os.ReadFile` instead of deprecated `ioutil.ReadFile` in biometric CLI
- use `os.ReadFile` for biometrics enrollment and verification

## Testing
- `go build synnergy-network/cmd/cli/biometric_security_node.go` *(fails: process stalled on dependency downloads; aborted)*
- `go vet synnergy-network/cmd/cli/biometric_security_node.go synnergy-network/cmd/cli/biometrics.go` *(fails: process stalled on dependency downloads; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_688fb82baddc83208adeb8fd8803b557