### PR TITLE
Stage 18: consolidate network types and tidy CLI docs

### DIFF
--- a/synnergy-network/cmd/cli/cli_guide.md
+++ b/synnergy-network/cmd/cli/cli_guide.md
@@ -21,7 +21,7 @@ The following command groups expose the same functionality available in the core
 - **charity_mgmt** – Donate to and withdraw from the charity pool.
 - **identity** – Register and verify user identities.
 - **coin** – Mint the base coin, transfer balances and inspect supply metrics.
- - **compliance_management** – Manage suspensions and whitelists for addresses.
+- **compliance_management** – Manage suspensions and whitelists for addresses.
 - **compliance** – Run KYC/AML checks on addresses and export audit reports.
 - **audit** – Manage on-chain audit logs.
 - **consensus_hop** – Switch between consensus modes based on network metrics.
@@ -68,13 +68,13 @@ The following command groups expose the same functionality available in the core
 - **connpool** – Manage reusable outbound connections.
 - **nat** – Manage router port mappings for inbound connectivity.
 - **peer** – Discover peers, connect to them and advertise this node.
- - **replication** – Trigger snapshot creation and replicate the ledger to new nodes.
- - **high_availability** – Manage standby nodes and promote backups.
- - **rollups** – Create rollup batches or inspect existing ones.
+- **replication** – Trigger snapshot creation and replicate the ledger to new nodes.
+- **high_availability** – Manage standby nodes and promote backups.
+- **rollups** – Create rollup batches or inspect existing ones.
 - **plasma** – Deposit into and withdraw from the Plasma chain.
 - **replication** – Trigger snapshot creation and replicate the ledger to new nodes.
 - **coordination** – Coordinate distributed nodes and broadcast ledger state.
- - **rollups** – Create rollup batches, inspect existing ones and control the aggregator state.
+- **rollups** – Create rollup batches, inspect existing ones and control the aggregator state.
 - **initrep** – Bootstrap a ledger via peer replication.
 - **synchronization** – Coordinate block download and verification.
 - **rollups** – Create rollup batches or inspect existing ones.
@@ -83,7 +83,7 @@ The following command groups expose the same functionality available in the core
 - **firewall** – Manage address, token and IP block lists.
 - **biometrics** – Manage biometric authentication templates.
 - **sharding** – Migrate data between shards and check shard status.
- - **sidechain** – Launch, manage and interact with remote side‑chain nodes.
+- **sidechain** – Launch, manage and interact with remote side‑chain nodes.
 - **state_channel** – Open, close and settle payment channels.
 - **loanpool** – Submit loan proposals and manage disbursements.
 - **grant** – Create and release grants from the loan pool.
@@ -131,7 +131,7 @@ The following command groups expose the same functionality available in the core
 - **testnet** – Start an ephemeral test network from a YAML config.
 - **faucet** – Dispense test funds with rate limiting.
 
-# Newly Added Command Groups
+## Newly Added Command Groups
 
 The CLI has grown considerably. The modules below expose functionality found in
 recently added Go files under `cmd/cli`.

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -1,4 +1,3 @@
-// Package core implements P2P networking for Synnergy nodes.
 package core
 
 import (
@@ -6,92 +5,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/libp2p/go-libp2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/sirupsen/logrus"
 )
 
-// NodeID uniquely identifies a network peer.
-type NodeID string
-
-// Peer stores information about a connected peer.
-type Peer struct {
-	ID      NodeID
-	Addr    string
-	Latency time.Duration
-	Conn    net.Conn
-}
-
-// Message represents a pubsub message.
-type Message struct {
-	From  NodeID
-	Topic string
-	Data  []byte
-}
-
-// Config holds basic networking configuration.
-type Config struct {
-	ListenAddr     string
-	BootstrapPeers []string
-	DiscoveryTag   string
-}
-
-// NetworkMessage is used for optional replication hooks.
-type NetworkMessage struct {
-	Topic   string
-	Content []byte
-}
-
-// Block is a minimal placeholder for broadcast tests.
-type Block struct{}
-
-// NATManager manages external port mappings.
-type NATManager struct{}
-
-// NewNATManager returns a no-op NAT manager implementation.
-func NewNATManager() (*NATManager, error) { return &NATManager{}, nil }
-
-// Map reserves the given port; in this stub it is a no-op.
-func (m *NATManager) Map(port int) error { return nil }
-
-// Unmap releases any mapped port; in this stub it is a no-op.
-func (m *NATManager) Unmap() error { return nil }
-
-// parsePort extracts the TCP port from a multiaddress string.
-func parsePort(addr string) (int, error) {
-	parts := strings.Split(addr, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "tcp" {
-			return strconv.Atoi(parts[i+1])
-		}
-	}
-	return 0, fmt.Errorf("no tcp port in %s", addr)
-}
-
-// Node represents a Synnergy P2P node.
-type Node struct {
-	host      host.Host
-	pubsub    *pubsub.PubSub
-	topics    map[string]*pubsub.Topic
-	subs      map[string]*pubsub.Subscription
-	topicLock sync.RWMutex
-	subLock   sync.RWMutex
-	peerLock  sync.RWMutex
-	peers     map[NodeID]*Peer
-	nat       *NATManager
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cfg       Config
-}
-
+// NewNode creates and bootstraps a Synnergy P2P node.  Core data types such as
+// NodeID, Peer, Message and Config are defined in `common_structs.go` and
+// reused here to avoid duplication.
 func NewNode(cfg Config) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
## Summary
- remove duplicated network structures, relying on common_structs for shared types
- clean up CLI guide formatting and demote extra top-level heading

## Testing
- `npx --yes markdownlint-cli synnergy-network/cmd/cli/cli_guide.md` *(fails: numerous line-length and formatting warnings)*
- `go vet ./synnergy-network/cmd/cli` *(fails: undefined references in core package)*

------
https://chatgpt.com/codex/tasks/task_e_688fb8383fd08320b3081afa3b0beaa8