### PR TITLE
refactor: clean up DAO access CLI and network definitions

### DIFF
--- a/synnergy-network/cmd/cli/dao_access_control.go
+++ b/synnergy-network/cmd/cli/dao_access_control.go
@@ -29,7 +29,10 @@ func initDAOMiddleware(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-var daoCmd = &cobra.Command{
+// daoAccessCmd groups subcommands for DAO access control operations. A unique
+// variable name is used to avoid colliding with the "daoCmd" defined in
+// dao.go, which represents a different command in the CLI package.
+var daoAccessCmd = &cobra.Command{
 	Use:               "dao_access",
 	Short:             "Manage DAO access control",
 	PersistentPreRunE: initDAOMiddleware,
@@ -89,7 +92,8 @@ var daoRoleCmd = &cobra.Command{
 	},
 }
 
-var daoListCmd = &cobra.Command{
+// daoAccessListCmd lists current DAO members and their roles.
+var daoAccessListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List DAO members",
 	Args:  cobra.NoArgs,
@@ -106,8 +110,8 @@ var daoListCmd = &cobra.Command{
 }
 
 func init() {
-	daoCmd.AddCommand(daoAddCmd, daoRemoveCmd, daoRoleCmd, daoListCmd)
+	daoAccessCmd.AddCommand(daoAddCmd, daoRemoveCmd, daoRoleCmd, daoAccessListCmd)
 }
 
 // DAOAccessCmd is the exported command for index.go
-var DAOAccessCmd = daoCmd
+var DAOAccessCmd = daoAccessCmd

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,79 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/sirupsen/logrus"
 )
-
-// NodeID uniquely identifies a network peer.
-type NodeID string
-
-// Peer stores information about a connected peer.
-type Peer struct {
-	ID      NodeID
-	Addr    string
-	Latency time.Duration
-	Conn    net.Conn
-}
-
-// Message represents a pubsub message.
-type Message struct {
-	From  NodeID
-	Topic string
-	Data  []byte
-}
-
-// Config holds basic networking configuration.
-type Config struct {
-	ListenAddr     string
-	BootstrapPeers []string
-	DiscoveryTag   string
-}
-
-// NetworkMessage is used for optional replication hooks.
-type NetworkMessage struct {
-	Topic   string
-	Content []byte
-}
-
-// Block is a minimal placeholder for broadcast tests.
-type Block struct{}
-
-// NATManager manages external port mappings.
-type NATManager struct{}
-
-// NewNATManager returns a no-op NAT manager implementation.
-func NewNATManager() (*NATManager, error) { return &NATManager{}, nil }
-
-// Map reserves the given port; in this stub it is a no-op.
-func (m *NATManager) Map(port int) error { return nil }
-
-// Unmap releases any mapped port; in this stub it is a no-op.
-func (m *NATManager) Unmap() error { return nil }
-
-// parsePort extracts the TCP port from a multiaddress string.
-func parsePort(addr string) (int, error) {
-	parts := strings.Split(addr, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "tcp" {
-			return strconv.Atoi(parts[i+1])
-		}
-	}
-	return 0, fmt.Errorf("no tcp port in %s", addr)
-}
-
-// Node represents a Synnergy P2P node.
-type Node struct {
-	host      host.Host
-	pubsub    *pubsub.PubSub
-	topics    map[string]*pubsub.Topic
-	subs      map[string]*pubsub.Subscription
-	topicLock sync.RWMutex
-	subLock   sync.RWMutex
-	peerLock  sync.RWMutex
-	peers     map[NodeID]*Peer
-	nat       *NATManager
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cfg       Config
-}
 
 func NewNode(cfg Config) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- avoid name conflicts in `dao_access_control` by renaming root command and list subcommand
- remove duplicate type declarations in `core/network` and rely on shared structures

## Testing
- `go build cmd/cli/cross_chain.go cmd/cli/cross_chain_contracts.go cmd/cli/cross_chain_transactions.go cmd/cli/cross_consensus_scaling_networks.go cmd/cli/custodial_node.go cmd/cli/dao.go cmd/cli/dao_access_control.go cmd/cli/dao_proposal.go cmd/cli/dao_staking.go cmd/cli/dao_token.go cmd/cli/data.go cmd/cli/data_distribution.go` *(fails: undefined shuffleAddresses; sc.p2p.Broadcast undefined; sc.auth.ValidatorPubKey undefined; sc.crypto.Sign undefined; sc.auth.ListAuthorities undefined; sc.p2p.Broadcast undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688fb85237f08320908f77f0088b5d49