### PR TITLE
Refactor Stage 21 CLI utilities

### DIFF
--- a/synnergy-network/cmd/cli/data_resource_management.go
+++ b/synnergy-network/cmd/cli/data_resource_management.go
@@ -3,7 +3,8 @@ package cli
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -34,7 +35,7 @@ func (c *DataResourceController) store(owner, key, file string, gas uint64) erro
 	if err != nil {
 		return err
 	}
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}
@@ -54,7 +55,7 @@ func (c *DataResourceController) load(owner, key, out string) error {
 		fmt.Printf("%s", string(data))
 		return nil
 	}
-	return ioutil.WriteFile(out, data, 0o644)
+	return os.WriteFile(out, data, 0o644)
 }
 
 func (c *DataResourceController) del(owner, key string) error {
@@ -113,7 +114,5 @@ func init() {
 var ResourceCmd = resourceCmd
 
 func parseUint(s string) (uint64, error) {
-	var v uint64
-	_, err := fmt.Sscan(s, &v)
-	return v, err
+	return strconv.ParseUint(s, 10, 64)
 }

--- a/synnergy-network/cmd/cli/defi.go
+++ b/synnergy-network/cmd/cli/defi.go
@@ -9,6 +9,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
+
 	"github.com/spf13/cobra"
 	core "synnergy-network/core"
 )
@@ -73,9 +75,7 @@ func defiClaim(cmd *cobra.Command, args []string) error {
 
 // minimal helper to parse uint
 func parseUintArg(s string) (uint64, error) {
-	var v uint64
-	_, err := fmt.Sscanf(s, "%d", &v)
-	return v, err
+	return strconv.ParseUint(s, 10, 64)
 }
 
 var defiCmd = &cobra.Command{

--- a/synnergy-network/cmd/cli/distributed_network_coordination.go
+++ b/synnergy-network/cmd/cli/distributed_network_coordination.go
@@ -7,6 +7,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -104,8 +105,7 @@ var coordMintCmd = &cobra.Command{
 }
 
 func parseUint(s string) (uint64, error) {
-	var v uint64
-	_, err := fmt.Sscan(s, &v)
+	v, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("invalid number %q", s)
 	}

--- a/synnergy-network/cmd/cli/elected_authority_node.go
+++ b/synnergy-network/cmd/cli/elected_authority_node.go
@@ -23,22 +23,30 @@ func ensureElectedNode(cmd *cobra.Command, _ []string) error {
 
 type ElectedAuthController struct{}
 
-func (c *ElectedAuthController) vote(addr string) {
+func (c *ElectedAuthController) vote(addr string) error {
 	var a core.Address
-	b, _ := hex.DecodeString(strings.TrimPrefix(addr, "0x"))
+	b, err := hex.DecodeString(strings.TrimPrefix(addr, "0x"))
+	if err != nil || len(b) != len(a) {
+		return fmt.Errorf("invalid address")
+	}
 	copy(a[:], b)
 	var na Nodes.Address
 	copy(na[:], a[:])
 	electedNode.RecordVote(na)
+	return nil
 }
 
-func (c *ElectedAuthController) report(addr string) {
+func (c *ElectedAuthController) report(addr string) error {
 	var a core.Address
-	b, _ := hex.DecodeString(strings.TrimPrefix(addr, "0x"))
+	b, err := hex.DecodeString(strings.TrimPrefix(addr, "0x"))
+	if err != nil || len(b) != len(a) {
+		return fmt.Errorf("invalid address")
+	}
 	copy(a[:], b)
 	var na Nodes.Address
 	copy(na[:], a[:])
 	electedNode.ReportMisbehaviour(na)
+	return nil
 }
 
 //---------------------------------------------------------------------
@@ -55,10 +63,13 @@ var electedVoteCmd = &cobra.Command{
 	Use:   "vote <addr>",
 	Short: "Vote to elect the node",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctrl := &ElectedAuthController{}
-		ctrl.vote(args[0])
+		if err := ctrl.vote(args[0]); err != nil {
+			return err
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), "vote recorded")
+		return nil
 	},
 }
 
@@ -66,10 +77,13 @@ var electedReportCmd = &cobra.Command{
 	Use:   "report <addr>",
 	Short: "Report the node for misbehaviour",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctrl := &ElectedAuthController{}
-		ctrl.report(args[0])
+		if err := ctrl.report(args[0]); err != nil {
+			return err
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), "report recorded")
+		return nil
 	},
 }
 

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,79 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/sirupsen/logrus"
 )
-
-// NodeID uniquely identifies a network peer.
-type NodeID string
-
-// Peer stores information about a connected peer.
-type Peer struct {
-	ID      NodeID
-	Addr    string
-	Latency time.Duration
-	Conn    net.Conn
-}
-
-// Message represents a pubsub message.
-type Message struct {
-	From  NodeID
-	Topic string
-	Data  []byte
-}
-
-// Config holds basic networking configuration.
-type Config struct {
-	ListenAddr     string
-	BootstrapPeers []string
-	DiscoveryTag   string
-}
-
-// NetworkMessage is used for optional replication hooks.
-type NetworkMessage struct {
-	Topic   string
-	Content []byte
-}
-
-// Block is a minimal placeholder for broadcast tests.
-type Block struct{}
-
-// NATManager manages external port mappings.
-type NATManager struct{}
-
-// NewNATManager returns a no-op NAT manager implementation.
-func NewNATManager() (*NATManager, error) { return &NATManager{}, nil }
-
-// Map reserves the given port; in this stub it is a no-op.
-func (m *NATManager) Map(port int) error { return nil }
-
-// Unmap releases any mapped port; in this stub it is a no-op.
-func (m *NATManager) Unmap() error { return nil }
-
-// parsePort extracts the TCP port from a multiaddress string.
-func parsePort(addr string) (int, error) {
-	parts := strings.Split(addr, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "tcp" {
-			return strconv.Atoi(parts[i+1])
-		}
-	}
-	return 0, fmt.Errorf("no tcp port in %s", addr)
-}
-
-// Node represents a Synnergy P2P node.
-type Node struct {
-	host      host.Host
-	pubsub    *pubsub.PubSub
-	topics    map[string]*pubsub.Topic
-	subs      map[string]*pubsub.Subscription
-	topicLock sync.RWMutex
-	subLock   sync.RWMutex
-	peerLock  sync.RWMutex
-	peers     map[NodeID]*Peer
-	nat       *NATManager
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cfg       Config
-}
 
 func NewNode(cfg Config) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- replace deprecated ioutil usage with os equivalents and use strconv for uint parsing
- tighten DeFi and coordination CLIs with robust argument parsing
- add error handling to elected authority node CLI
- deduplicate networking type definitions in core

## Testing
- `go build synnergy-network/cmd/cli/data_operations.go` *(fails: undefined symbols in core)*

------
https://chatgpt.com/codex/tasks/task_e_688fc9fdc55083208253267440a230d9