### PR TITLE
Harden governance and geospatial CLI validation

### DIFF
--- a/synnergy-network/cmd/cli/geospatial_node.go
+++ b/synnergy-network/cmd/cli/geospatial_node.go
@@ -91,10 +91,22 @@ func geoNodeQuery(cmd *cobra.Command, args []string) error {
 	if n == nil {
 		return fmt.Errorf("not running")
 	}
-	minLat, _ := strconv.ParseFloat(args[0], 64)
-	maxLat, _ := strconv.ParseFloat(args[1], 64)
-	minLon, _ := strconv.ParseFloat(args[2], 64)
-	maxLon, _ := strconv.ParseFloat(args[3], 64)
+	minLat, err := strconv.ParseFloat(args[0], 64)
+	if err != nil {
+		return err
+	}
+	maxLat, err := strconv.ParseFloat(args[1], 64)
+	if err != nil {
+		return err
+	}
+	minLon, err := strconv.ParseFloat(args[2], 64)
+	if err != nil {
+		return err
+	}
+	maxLon, err := strconv.ParseFloat(args[3], 64)
+	if err != nil {
+		return err
+	}
 	ids := n.QueryRegion(minLat, maxLat, minLon, maxLon)
 	for _, id := range ids {
 		fmt.Fprintln(cmd.OutOrStdout(), id)

--- a/synnergy-network/cmd/cli/governance_management.go
+++ b/synnergy-network/cmd/cli/governance_management.go
@@ -22,14 +22,14 @@ func ensureGovMgmt(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func addrFromHex(h string) core.Address {
+func addrFromHex(h string) (core.Address, error) {
 	var a core.Address
 	b, err := hex.DecodeString(h)
 	if err != nil || len(b) != len(a) {
-		return a
+		return a, fmt.Errorf("invalid address")
 	}
 	copy(a[:], b)
-	return a
+	return a, nil
 }
 
 var govMgmtCmd = &cobra.Command{Use: "govmgmt", Short: "Manage governance contracts", PersistentPreRunE: ensureGovMgmt}
@@ -39,7 +39,10 @@ var gmAddContractCmd = &cobra.Command{
 	Short: "Register a governance contract",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		addr := addrFromHex(args[0])
+		addr, err := addrFromHex(args[0])
+		if err != nil {
+			return err
+		}
 		return gm.RegisterGovContract(addr, args[1])
 	},
 }
@@ -49,7 +52,10 @@ var gmEnableContractCmd = &cobra.Command{
 	Short: "Enable a governance contract",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		addr := addrFromHex(args[0])
+		addr, err := addrFromHex(args[0])
+		if err != nil {
+			return err
+		}
 		return gm.EnableGovContract(addr, true)
 	},
 }
@@ -59,7 +65,10 @@ var gmDisableContractCmd = &cobra.Command{
 	Short: "Disable a governance contract",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		addr := addrFromHex(args[0])
+		addr, err := addrFromHex(args[0])
+		if err != nil {
+			return err
+		}
 		return gm.EnableGovContract(addr, false)
 	},
 }
@@ -69,7 +78,10 @@ var gmGetContractCmd = &cobra.Command{
 	Short: "Show contract details",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		addr := addrFromHex(args[0])
+		addr, err := addrFromHex(args[0])
+		if err != nil {
+			return err
+		}
 		c, err := gm.GetGovContract(addr)
 		if err != nil {
 			return err
@@ -99,7 +111,10 @@ var gmDelContractCmd = &cobra.Command{
 	Short: "Remove a governance contract",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		addr := addrFromHex(args[0])
+		addr, err := addrFromHex(args[0])
+		if err != nil {
+			return err
+		}
 		return gm.DeleteGovContract(addr)
 	},
 }

--- a/synnergy-network/cmd/cli/grant_tokens.go
+++ b/synnergy-network/cmd/cli/grant_tokens.go
@@ -32,7 +32,10 @@ var gtCreateCmd = &cobra.Command{
 	Short: "Create a new grant",
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		addr := mustHex(args[0])
+		addr, err := core.StringToAddress(args[0])
+		if err != nil {
+			return err
+		}
 		name := args[1]
 		amt, err := strconv.ParseUint(args[2], 10, 64)
 		if err != nil {


### PR DESCRIPTION
## Summary
- ensure geospatial queries validate all coordinate inputs
- add strict hex address parsing for governance contract commands
- validate beneficiary addresses when creating grant tokens

## Testing
- `go vet synnergy-network/cmd/cli/geospatial_node.go synnergy-network/cmd/cli/governance_management.go synnergy-network/cmd/cli/grant_tokens.go` *(fails: NodeID redeclared in synnergy-network/core/network.go)*

------
https://chatgpt.com/codex/tasks/task_e_688fca263c0483208069d1d451d627da