### PR TITLE
Refactor core network and polish CLI commands

### DIFF
--- a/synnergy-network/cmd/cli/master_node.go
+++ b/synnergy-network/cmd/cli/master_node.go
@@ -27,6 +27,7 @@ var masterCmd = &cobra.Command{
 var masterStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start master node services",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		master.Start()
 		fmt.Println("master node started")
@@ -37,6 +38,7 @@ var masterStartCmd = &cobra.Command{
 var masterStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop master node services",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := master.Stop(); err != nil {
 			return err
@@ -51,4 +53,8 @@ func init() {
 	masterCmd.AddCommand(masterStopCmd)
 }
 
+// MasterCmd exposes master node CLI operations.
 var MasterCmd = masterCmd
+
+// RegisterMaster adds master node commands to the root CLI.
+func RegisterMaster(root *cobra.Command) { root.AddCommand(MasterCmd) }

--- a/synnergy-network/cmd/cli/messages.go
+++ b/synnergy-network/cmd/cli/messages.go
@@ -11,9 +11,6 @@ import (
 var msgQueue = core.NewMessageQueue()
 
 func msgEnqueue(cmd *cobra.Command, args []string) error {
-	if len(args) != 5 {
-		return fmt.Errorf("usage: enqueue <src> <dst> <topic> <type> <payload>")
-	}
 	src, err := core.ParseAddress(args[0])
 	if err != nil {
 		return err
@@ -52,13 +49,14 @@ func msgBroadcast(cmd *cobra.Command, _ []string) error {
 }
 
 var msgRootCmd = &cobra.Command{Use: "messages", Short: "Message queue"}
-var msgEnqCmd = &cobra.Command{Use: "enqueue <src> <dst> <topic> <type> <payload>", Short: "Queue a message", RunE: msgEnqueue}
-var msgProcCmd = &cobra.Command{Use: "process", Short: "Process next", RunE: msgProcess}
-var msgBroadCmd = &cobra.Command{Use: "broadcast", Short: "Broadcast next", RunE: msgBroadcast}
+var msgEnqCmd = &cobra.Command{Use: "enqueue <src> <dst> <topic> <type> <payload>", Short: "Queue a message", Args: cobra.ExactArgs(5), RunE: msgEnqueue}
+var msgProcCmd = &cobra.Command{Use: "process", Short: "Process next", Args: cobra.NoArgs, RunE: msgProcess}
+var msgBroadCmd = &cobra.Command{Use: "broadcast", Short: "Broadcast next", Args: cobra.NoArgs, RunE: msgBroadcast}
 
 func init() { msgRootCmd.AddCommand(msgEnqCmd, msgProcCmd, msgBroadCmd) }
 
 // MessagesCmd exposes the command tree for registration in the root CLI.
 var MessagesCmd = msgRootCmd
 
+// RegisterMessages adds the message queue commands to the root CLI.
 func RegisterMessages(root *cobra.Command) { root.AddCommand(MessagesCmd) }

--- a/synnergy-network/cmd/cli/military_node.go
+++ b/synnergy-network/cmd/cli/military_node.go
@@ -85,13 +85,15 @@ func warLog(cmd *cobra.Command, args []string) error {
 }
 
 var warCmd = &cobra.Command{Use: "warfare", Short: "Warfare node", PersistentPreRunE: warInit}
-var warStartCmd = &cobra.Command{Use: "start", Short: "Start node", RunE: warStart}
-var warStopCmd = &cobra.Command{Use: "stop", Short: "Stop node", RunE: warStop}
+var warStartCmd = &cobra.Command{Use: "start", Short: "Start node", Args: cobra.NoArgs, RunE: warStart}
+var warStopCmd = &cobra.Command{Use: "stop", Short: "Stop node", Args: cobra.NoArgs, RunE: warStop}
 var warSecureCmd = &cobra.Command{Use: "command <payload>", Short: "Send secure command", Args: cobra.ExactArgs(1), RunE: warCommand}
 var warLogCmd = &cobra.Command{Use: "logistic <item> <status>", Short: "Record logistics", Args: cobra.ExactArgs(2), RunE: warLog}
 
 func init() { warCmd.AddCommand(warStartCmd, warStopCmd, warSecureCmd, warLogCmd) }
 
+// WarfareCmd exposes warfare node CLI commands.
 var WarfareCmd = warCmd
 
+// RegisterWarfare adds warfare node commands to the root CLI.
 func RegisterWarfare(root *cobra.Command) { root.AddCommand(WarfareCmd) }

--- a/synnergy-network/cmd/cli/mining_node.go
+++ b/synnergy-network/cmd/cli/mining_node.go
@@ -84,9 +84,13 @@ func minerStop(cmd *cobra.Command, _ []string) error {
 }
 
 var minerCmd = &cobra.Command{Use: "mining", Short: "Mining node operations", PersistentPreRunE: minerInit}
-var minerStartCmd = &cobra.Command{Use: "start", Short: "Start mining", RunE: minerStart}
-var minerStopCmd = &cobra.Command{Use: "stop", Short: "Stop mining", RunE: minerStop}
+var minerStartCmd = &cobra.Command{Use: "start", Short: "Start mining", Args: cobra.NoArgs, RunE: minerStart}
+var minerStopCmd = &cobra.Command{Use: "stop", Short: "Stop mining", Args: cobra.NoArgs, RunE: minerStop}
 
 func init() { minerCmd.AddCommand(minerStartCmd, minerStopCmd) }
 
+// MiningNodeCmd exposes mining node operations.
 var MiningNodeCmd = minerCmd
+
+// RegisterMiningNode adds the mining node commands to the root CLI.
+func RegisterMiningNode(root *cobra.Command) { root.AddCommand(MiningNodeCmd) }

--- a/synnergy-network/cmd/cli/mobile_mining_node.go
+++ b/synnergy-network/cmd/cli/mobile_mining_node.go
@@ -117,13 +117,17 @@ func mobileIntensity(cmd *cobra.Command, args []string) error {
 }
 
 var mobileRootCmd = &cobra.Command{Use: "mobileminer", Short: "Mobile mining node", PersistentPreRunE: mobileInit}
-var mobileStartCmd = &cobra.Command{Use: "start", Short: "Start miner", RunE: mobileStart}
-var mobileStopCmd = &cobra.Command{Use: "stop", Short: "Stop miner", RunE: mobileStop}
-var mobileStatusCmd = &cobra.Command{Use: "status", Short: "Show stats", RunE: mobileStatus}
+var mobileStartCmd = &cobra.Command{Use: "start", Short: "Start miner", Args: cobra.NoArgs, RunE: mobileStart}
+var mobileStopCmd = &cobra.Command{Use: "stop", Short: "Stop miner", Args: cobra.NoArgs, RunE: mobileStop}
+var mobileStatusCmd = &cobra.Command{Use: "status", Short: "Show stats", Args: cobra.NoArgs, RunE: mobileStatus}
 var mobileIntensityCmd = &cobra.Command{Use: "intensity <1-100>", Short: "Set intensity", Args: cobra.ExactArgs(1), RunE: mobileIntensity}
 
 func init() {
 	mobileRootCmd.AddCommand(mobileStartCmd, mobileStopCmd, mobileStatusCmd, mobileIntensityCmd)
 }
 
+// MobileMinerCmd exposes the mobile mining node CLI commands.
 var MobileMinerCmd = mobileRootCmd
+
+// RegisterMobileMiner adds the mobile mining commands to the root CLI.
+func RegisterMobileMiner(root *cobra.Command) { root.AddCommand(MobileMinerCmd) }

--- a/synnergy-network/cmd/cli/mobile_node.go
+++ b/synnergy-network/cmd/cli/mobile_node.go
@@ -89,12 +89,14 @@ func mobileFlush(cmd *cobra.Command, _ []string) error {
 }
 
 var mobileRootCmd = &cobra.Command{Use: "mobile", Short: "Mobile node", PersistentPreRunE: mobileInit}
-var mobileStartCmd = &cobra.Command{Use: "start", Short: "Start", RunE: mobileStart}
-var mobileStopCmd = &cobra.Command{Use: "stop", Short: "Stop", RunE: mobileStop}
-var mobileFlushCmd = &cobra.Command{Use: "flush", Short: "Flush queued tx", RunE: mobileFlush}
+var mobileStartCmd = &cobra.Command{Use: "start", Short: "Start", Args: cobra.NoArgs, RunE: mobileStart}
+var mobileStopCmd = &cobra.Command{Use: "stop", Short: "Stop", Args: cobra.NoArgs, RunE: mobileStop}
+var mobileFlushCmd = &cobra.Command{Use: "flush", Short: "Flush queued tx", Args: cobra.NoArgs, RunE: mobileFlush}
 
 func init() { mobileRootCmd.AddCommand(mobileStartCmd, mobileStopCmd, mobileFlushCmd) }
 
+// MobileCmd exposes mobile node CLI commands.
 var MobileCmd = mobileRootCmd
 
+// RegisterMobile adds mobile node commands to the root CLI.
 func RegisterMobile(root *cobra.Command) { root.AddCommand(MobileCmd) }

--- a/synnergy-network/cmd/cli/molecular_node.go
+++ b/synnergy-network/cmd/cli/molecular_node.go
@@ -90,11 +90,13 @@ func molStop(cmd *cobra.Command, _ []string) error {
 }
 
 var molCmd = &cobra.Command{Use: "molecular", Short: "Run molecular node", PersistentPreRunE: molInit}
-var molStartCmd = &cobra.Command{Use: "start", Short: "Start molecular node", RunE: molStart}
-var molStopCmd = &cobra.Command{Use: "stop", Short: "Stop molecular node", RunE: molStop}
+var molStartCmd = &cobra.Command{Use: "start", Short: "Start molecular node", Args: cobra.NoArgs, RunE: molStart}
+var molStopCmd = &cobra.Command{Use: "stop", Short: "Stop molecular node", Args: cobra.NoArgs, RunE: molStop}
 
 func init() { molCmd.AddCommand(molStartCmd, molStopCmd) }
 
+// MolecularCmd exposes molecular node CLI commands.
 var MolecularCmd = molCmd
 
+// RegisterMolecular adds molecular node commands to the root CLI.
 func RegisterMolecular(root *cobra.Command) { root.AddCommand(MolecularCmd) }

--- a/synnergy-network/cmd/cli/monomaniac_recovery.go
+++ b/synnergy-network/cmd/cli/monomaniac_recovery.go
@@ -25,6 +25,7 @@ type recoveryFlags struct {
 var registerRecCmd = &cobra.Command{
 	Use:   "register",
 	Short: "Register recovery credentials",
+	Args:  cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, _ []string) error {
 		ownerStr, _ := cmd.Flags().GetString("owner")
 		recStr, _ := cmd.Flags().GetString("recovery")
@@ -60,6 +61,7 @@ var registerRecCmd = &cobra.Command{
 var recoverCmd = &cobra.Command{
 	Use:   "recover",
 	Short: "Recover an account using credentials",
+	Args:  cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, _ []string) error {
 		ownerStr, _ := cmd.Flags().GetString("owner")
 		recStr, _ := cmd.Flags().GetString("recovery")
@@ -114,6 +116,8 @@ func init() {
 	recoveryCmd.AddCommand(registerRecCmd, recoverCmd)
 }
 
+// RecoveryCmd exposes account recovery operations.
 var RecoveryCmd = recoveryCmd
 
+// RegisterRecovery adds recovery commands to the root CLI.
 func RegisterRecovery(root *cobra.Command) { root.AddCommand(RecoveryCmd) }

--- a/synnergy-network/cmd/cli/nat.go
+++ b/synnergy-network/cmd/cli/nat.go
@@ -57,6 +57,8 @@ var natIPCmd = &cobra.Command{Use: "ip", Short: "Show external IP", Args: cobra.
 
 func init() { natRootCmd.AddCommand(natMapCmd, natUnmapCmd, natIPCmd) }
 
+// NatCmd exposes the NAT traversal commands.
 var NatCmd = natRootCmd
 
+// RegisterNAT adds NAT traversal commands to the root CLI.
 func RegisterNAT(root *cobra.Command) { root.AddCommand(NatCmd) }

--- a/synnergy-network/cmd/cli/network.go
+++ b/synnergy-network/cmd/cli/network.go
@@ -195,6 +195,8 @@ func init() { netRootCmd.AddCommand(netStartCmd, netStopCmd, netPeersCmd, netBro
 // Export
 // -----------------------------------------------------------------------------
 
+// NetworkCmd exposes P2P networking commands.
 var NetworkCmd = netRootCmd
 
+// RegisterNetwork adds the networking commands to the root CLI.
 func RegisterNetwork(root *cobra.Command) { root.AddCommand(NetworkCmd) }

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,79 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/sirupsen/logrus"
 )
-
-// NodeID uniquely identifies a network peer.
-type NodeID string
-
-// Peer stores information about a connected peer.
-type Peer struct {
-	ID      NodeID
-	Addr    string
-	Latency time.Duration
-	Conn    net.Conn
-}
-
-// Message represents a pubsub message.
-type Message struct {
-	From  NodeID
-	Topic string
-	Data  []byte
-}
-
-// Config holds basic networking configuration.
-type Config struct {
-	ListenAddr     string
-	BootstrapPeers []string
-	DiscoveryTag   string
-}
-
-// NetworkMessage is used for optional replication hooks.
-type NetworkMessage struct {
-	Topic   string
-	Content []byte
-}
-
-// Block is a minimal placeholder for broadcast tests.
-type Block struct{}
-
-// NATManager manages external port mappings.
-type NATManager struct{}
-
-// NewNATManager returns a no-op NAT manager implementation.
-func NewNATManager() (*NATManager, error) { return &NATManager{}, nil }
-
-// Map reserves the given port; in this stub it is a no-op.
-func (m *NATManager) Map(port int) error { return nil }
-
-// Unmap releases any mapped port; in this stub it is a no-op.
-func (m *NATManager) Unmap() error { return nil }
-
-// parsePort extracts the TCP port from a multiaddress string.
-func parsePort(addr string) (int, error) {
-	parts := strings.Split(addr, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "tcp" {
-			return strconv.Atoi(parts[i+1])
-		}
-	}
-	return 0, fmt.Errorf("no tcp port in %s", addr)
-}
-
-// Node represents a Synnergy P2P node.
-type Node struct {
-	host      host.Host
-	pubsub    *pubsub.PubSub
-	topics    map[string]*pubsub.Topic
-	subs      map[string]*pubsub.Subscription
-	topicLock sync.RWMutex
-	subLock   sync.RWMutex
-	peerLock  sync.RWMutex
-	peers     map[NodeID]*Peer
-	nat       *NATManager
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cfg       Config
-}
 
 func NewNode(cfg Config) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- streamline core network implementation by removing duplicate types and using shared NAT utilities
- add argument validation, registration helpers and documentation across stage-27 CLI commands

## Testing
- `go vet synnergy-network/cmd/cli/master_node.go` *(fails: undefined interface fields in other core packages)*


------
https://chatgpt.com/codex/tasks/task_e_688fca4a970083208688242dc987847b