### PR TITLE
Refactor plasma CLI commands and modernize wallet utility

### DIFF
--- a/synnergy-network/cmd/cli/offchain_wallet.go
+++ b/synnergy-network/cmd/cli/offchain_wallet.go
@@ -1,10 +1,11 @@
 package cli
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	"synnergy-network/core"
@@ -23,7 +24,7 @@ func offwalletCreate(cmd *cobra.Command, _ []string) error {
 	seed := wallet.Seed()
 	ks := map[string]string{"seed": fmt.Sprintf("%x", seed)}
 	data, _ := json.MarshalIndent(ks, "", "  ")
-	if err := ioutil.WriteFile(out, data, 0o600); err != nil {
+	if err := os.WriteFile(out, data, 0o600); err != nil {
 		return err
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "mnemonic: %s\n", mnemonic)
@@ -40,7 +41,7 @@ func offwalletSign(cmd *cobra.Command, _ []string) error {
 	if walletFile == "" || inFile == "" {
 		return errors.New("--wallet and --in required")
 	}
-	data, err := ioutil.ReadFile(walletFile)
+	data, err := os.ReadFile(walletFile)
 	if err != nil {
 		return err
 	}
@@ -57,7 +58,7 @@ func offwalletSign(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	ow := &core.OffChainWallet{HDWallet: w}
-	raw, err := ioutil.ReadFile(inFile)
+	raw, err := os.ReadFile(inFile)
 	if err != nil {
 		return err
 	}
@@ -70,7 +71,7 @@ func offwalletSign(cmd *cobra.Command, _ []string) error {
 	}
 	out, _ := json.MarshalIndent(&tx, "", "  ")
 	if outFile != "" {
-		if err := ioutil.WriteFile(outFile, out, 0o600); err != nil {
+		if err := os.WriteFile(outFile, out, 0o600); err != nil {
 			return err
 		}
 	} else {
@@ -81,12 +82,7 @@ func offwalletSign(cmd *cobra.Command, _ []string) error {
 }
 
 func hexToBytes(s string) ([]byte, error) {
-	b := make([]byte, len(s)/2)
-	_, err := fmt.Sscanf(s, "%x", &b)
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
+	return hex.DecodeString(s)
 }
 
 var offWalletCmd = &cobra.Command{

--- a/synnergy-network/cmd/cli/plasma_management.go
+++ b/synnergy-network/cmd/cli/plasma_management.go
@@ -13,12 +13,12 @@ import (
 // plasma_management.go - CLI wrappers for the Plasma manager
 // -----------------------------------------------------------------------------
 
-var plasmaCmd = &cobra.Command{
-	Use:   "plasma",
-	Short: "Interact with the plasma chain",
+var plasmamgmtCmd = &cobra.Command{
+	Use:   "plasmamgmt",
+	Short: "Manage the plasma chain",
 }
 
-var plasmaDepositCmd = &cobra.Command{
+var plasmamgmtDepositCmd = &cobra.Command{
 	Use:   "deposit [from] [tokenID] [amount]",
 	Short: "Deposit tokens into the plasma chain",
 	Args:  cobra.ExactArgs(3),
@@ -46,7 +46,7 @@ var plasmaDepositCmd = &cobra.Command{
 	},
 }
 
-var plasmaWithdrawCmd = &cobra.Command{
+var plasmamgmtWithdrawCmd = &cobra.Command{
 	Use:   "withdraw [depositID] [to]",
 	Short: "Withdraw a plasma deposit",
 	Args:  cobra.ExactArgs(2),
@@ -65,7 +65,7 @@ var plasmaWithdrawCmd = &cobra.Command{
 	},
 }
 
-var plasmaSubmitCmd = &cobra.Command{
+var plasmamgmtSubmitCmd = &cobra.Command{
 	Use:   "submit [root]",
 	Short: "Submit a plasma block commitment",
 	Args:  cobra.ExactArgs(1),
@@ -84,10 +84,10 @@ var plasmaSubmitCmd = &cobra.Command{
 }
 
 func init() {
-	plasmaCmd.AddCommand(plasmaDepositCmd)
-	plasmaCmd.AddCommand(plasmaWithdrawCmd)
-	plasmaCmd.AddCommand(plasmaSubmitCmd)
+	plasmamgmtCmd.AddCommand(plasmamgmtDepositCmd)
+	plasmamgmtCmd.AddCommand(plasmamgmtWithdrawCmd)
+	plasmamgmtCmd.AddCommand(plasmamgmtSubmitCmd)
 }
 
-// PlasmaCmd is the exported command to mount on the root CLI.
-var PlasmaCmd = plasmaCmd
+// PlasmaMgmtCmd is the exported command to mount on the root CLI.
+var PlasmaMgmtCmd = plasmamgmtCmd

--- a/synnergy-network/cmd/cli/plasma_operations.go
+++ b/synnergy-network/cmd/cli/plasma_operations.go
@@ -40,13 +40,13 @@ func (p *PlasmaController) Finalize(n uint64) error { return core.Plasma().Final
 // CLI commands
 //---------------------------------------------------------------------
 
-var plasmaCmd = &cobra.Command{
-	Use:               "plasma",
+var plasmaOpsCmd = &cobra.Command{
+	Use:               "plasmaops",
 	Short:             "Interact with the plasma bridge",
 	PersistentPreRunE: ensurePlasma,
 }
 
-var plasmaDepositCmd = &cobra.Command{
+var plasmaOpsDepositCmd = &cobra.Command{
 	Use:   "deposit <from> <token> <amount>",
 	Short: "Deposit tokens into the plasma bridge",
 	Args:  cobra.ExactArgs(3),
@@ -68,7 +68,7 @@ var plasmaDepositCmd = &cobra.Command{
 	},
 }
 
-var plasmaExitCmd = &cobra.Command{
+var plasmaOpsExitCmd = &cobra.Command{
 	Use:   "exit <owner> <token> <amount>",
 	Short: "Start an exit from the plasma bridge",
 	Args:  cobra.ExactArgs(3),
@@ -90,7 +90,7 @@ var plasmaExitCmd = &cobra.Command{
 	},
 }
 
-var plasmaFinalizeCmd = &cobra.Command{
+var plasmaOpsFinalizeCmd = &cobra.Command{
 	Use:   "finalize <nonce>",
 	Short: "Finalize a pending exit",
 	Args:  cobra.ExactArgs(1),
@@ -104,7 +104,7 @@ var plasmaFinalizeCmd = &cobra.Command{
 	},
 }
 
-var plasmaGetCmd = &cobra.Command{
+var plasmaOpsGetCmd = &cobra.Command{
 	Use:   "get <nonce>",
 	Short: "Retrieve a plasma exit",
 	Args:  cobra.ExactArgs(1),
@@ -123,7 +123,7 @@ var plasmaGetCmd = &cobra.Command{
 	},
 }
 
-var plasmaListCmd = &cobra.Command{
+var plasmaOpsListCmd = &cobra.Command{
 	Use:   "list <owner>",
 	Short: "List exits for an address",
 	Args:  cobra.ExactArgs(1),
@@ -143,12 +143,12 @@ var plasmaListCmd = &cobra.Command{
 }
 
 func init() {
-	plasmaCmd.AddCommand(plasmaDepositCmd)
-	plasmaCmd.AddCommand(plasmaExitCmd)
-	plasmaCmd.AddCommand(plasmaFinalizeCmd)
-	plasmaCmd.AddCommand(plasmaGetCmd)
-	plasmaCmd.AddCommand(plasmaListCmd)
+	plasmaOpsCmd.AddCommand(plasmaOpsDepositCmd)
+	plasmaOpsCmd.AddCommand(plasmaOpsExitCmd)
+	plasmaOpsCmd.AddCommand(plasmaOpsFinalizeCmd)
+	plasmaOpsCmd.AddCommand(plasmaOpsGetCmd)
+	plasmaOpsCmd.AddCommand(plasmaOpsListCmd)
 }
 
 // PlasmaRoute exports the root command for registration in index.go
-var PlasmaRoute = plasmaCmd
+var PlasmaRoute = plasmaOpsCmd


### PR DESCRIPTION
## Summary
- modernize offline wallet CLI to use `os` APIs and safer hex decoding
- split plasma management and operations commands into distinct Cobra roots to avoid name collisions

## Testing
- `go build synnergy-network/cmd/cli/offchain_wallet.go` *(fails: NodeID redeclared in synnergy-network/core)*
- `go build synnergy-network/cmd/cli/plasma_operations.go` *(fails: NodeID redeclared in synnergy-network/core)*

------
https://chatgpt.com/codex/tasks/task_e_688fca55eba08320b2202cd19f56345c