### PR TITLE
refactor: clean network types and improve resource CLI

### DIFF
--- a/synnergy-network/cmd/cli/resource_management.go
+++ b/synnergy-network/cmd/cli/resource_management.go
@@ -29,7 +29,7 @@ func rmParseAddr(h string) (core.Address, error) {
 	var a core.Address
 	b, err := hex.DecodeString(strings.TrimPrefix(h, "0x"))
 	if err != nil || len(b) != len(a) {
-		return a, fmt.Errorf("bad address")
+		return a, fmt.Errorf("invalid address %q", h)
 	}
 	copy(a[:], b)
 	return a, nil

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,79 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/sirupsen/logrus"
 )
-
-// NodeID uniquely identifies a network peer.
-type NodeID string
-
-// Peer stores information about a connected peer.
-type Peer struct {
-	ID      NodeID
-	Addr    string
-	Latency time.Duration
-	Conn    net.Conn
-}
-
-// Message represents a pubsub message.
-type Message struct {
-	From  NodeID
-	Topic string
-	Data  []byte
-}
-
-// Config holds basic networking configuration.
-type Config struct {
-	ListenAddr     string
-	BootstrapPeers []string
-	DiscoveryTag   string
-}
-
-// NetworkMessage is used for optional replication hooks.
-type NetworkMessage struct {
-	Topic   string
-	Content []byte
-}
-
-// Block is a minimal placeholder for broadcast tests.
-type Block struct{}
-
-// NATManager manages external port mappings.
-type NATManager struct{}
-
-// NewNATManager returns a no-op NAT manager implementation.
-func NewNATManager() (*NATManager, error) { return &NATManager{}, nil }
-
-// Map reserves the given port; in this stub it is a no-op.
-func (m *NATManager) Map(port int) error { return nil }
-
-// Unmap releases any mapped port; in this stub it is a no-op.
-func (m *NATManager) Unmap() error { return nil }
-
-// parsePort extracts the TCP port from a multiaddress string.
-func parsePort(addr string) (int, error) {
-	parts := strings.Split(addr, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "tcp" {
-			return strconv.Atoi(parts[i+1])
-		}
-	}
-	return 0, fmt.Errorf("no tcp port in %s", addr)
-}
-
-// Node represents a Synnergy P2P node.
-type Node struct {
-	host      host.Host
-	pubsub    *pubsub.PubSub
-	topics    map[string]*pubsub.Topic
-	subs      map[string]*pubsub.Subscription
-	topicLock sync.RWMutex
-	subLock   sync.RWMutex
-	peerLock  sync.RWMutex
-	peers     map[NodeID]*Peer
-	nat       *NATManager
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cfg       Config
-}
 
 func NewNode(cfg Config) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- improve resource management address validation with clearer error reporting
- deduplicate network type declarations to avoid core package redeclarations

## Testing
- `go test ./cmd/cli -run TestNonExistent` *(fails: undefined: shuffleAddresses, sc.p2p.Broadcast, sc.auth.ValidatorPubKey, sc.crypto.Sign, sc.auth.ListAuthorities, sc.auth.LoanPoolAddress, tx.VerifySig)*

------
https://chatgpt.com/codex/tasks/task_e_688fca7b001c8320ae86074b49436718