### PR TITLE
fix: improve state channel and storage CLI setup

### DIFF
--- a/synnergy-network/cmd/cli/state_channel.go
+++ b/synnergy-network/cmd/cli/state_channel.go
@@ -37,11 +37,11 @@ func channelMiddleware(cmd *cobra.Command, args []string) {
 		ledgerPath = env
 	} else {
 		exe, _ := os.Executable()
-		ledgerPath = filepath.Join(filepath.Dir(exe), "state.db")
+		ledgerPath = filepath.Join(filepath.Dir(exe), "ledger")
 	}
 
 	// init ledger + engine singleton (idempotent)
-	led, err := ledger.NewBadgerLedger(ledgerPath)
+	led, err := core.OpenLedger(ledgerPath)
 	if err != nil {
 		log.Fatalf("failed to open ledger at %s: %v", ledgerPath, err)
 	}

--- a/synnergy-network/cmd/cli/storage.go
+++ b/synnergy-network/cmd/cli/storage.go
@@ -10,6 +10,7 @@ package cli
 // ----------------------------------------------------------------------------
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -60,7 +61,11 @@ func initStorageMiddleware(cmd *cobra.Command, args []string) {
 	}
 
 	// 2) ledger setup (optional, but recommended)
-	led, err := ledger.NewBadgerLedger(storageFlags.ledgerPath)
+	if storageFlags.ledgerPath == "" {
+		exe, _ := os.Executable()
+		storageFlags.ledgerPath = filepath.Join(filepath.Dir(exe), "ledger")
+	}
+	led, err := core.OpenLedger(storageFlags.ledgerPath)
 	if err != nil {
 		log.Fatalf("ledger open: %v", err)
 	}

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,79 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/sirupsen/logrus"
 )
-
-// NodeID uniquely identifies a network peer.
-type NodeID string
-
-// Peer stores information about a connected peer.
-type Peer struct {
-	ID      NodeID
-	Addr    string
-	Latency time.Duration
-	Conn    net.Conn
-}
-
-// Message represents a pubsub message.
-type Message struct {
-	From  NodeID
-	Topic string
-	Data  []byte
-}
-
-// Config holds basic networking configuration.
-type Config struct {
-	ListenAddr     string
-	BootstrapPeers []string
-	DiscoveryTag   string
-}
-
-// NetworkMessage is used for optional replication hooks.
-type NetworkMessage struct {
-	Topic   string
-	Content []byte
-}
-
-// Block is a minimal placeholder for broadcast tests.
-type Block struct{}
-
-// NATManager manages external port mappings.
-type NATManager struct{}
-
-// NewNATManager returns a no-op NAT manager implementation.
-func NewNATManager() (*NATManager, error) { return &NATManager{}, nil }
-
-// Map reserves the given port; in this stub it is a no-op.
-func (m *NATManager) Map(port int) error { return nil }
-
-// Unmap releases any mapped port; in this stub it is a no-op.
-func (m *NATManager) Unmap() error { return nil }
-
-// parsePort extracts the TCP port from a multiaddress string.
-func parsePort(addr string) (int, error) {
-	parts := strings.Split(addr, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "tcp" {
-			return strconv.Atoi(parts[i+1])
-		}
-	}
-	return 0, fmt.Errorf("no tcp port in %s", addr)
-}
-
-// Node represents a Synnergy P2P node.
-type Node struct {
-	host      host.Host
-	pubsub    *pubsub.PubSub
-	topics    map[string]*pubsub.Topic
-	subs      map[string]*pubsub.Subscription
-	topicLock sync.RWMutex
-	subLock   sync.RWMutex
-	peerLock  sync.RWMutex
-	peers     map[NodeID]*Peer
-	nat       *NATManager
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cfg       Config
-}
 
 func NewNode(cfg Config) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- use core.OpenLedger and a default ledger directory for state channel CLI
- wire storage CLI to core.OpenLedger and default ledger path, importing bytes for streaming
- drop duplicate network type declarations and rely on shared core definitions

## Testing
- `go build ./synnergy-network/cmd/cli` *(fails: undefined: shuffleAddresses, sc.p2p.Broadcast ...)*

------
https://chatgpt.com/codex/tasks/task_e_688fca87d2388320a2dac246b50d8067