### PR TITLE
fix config loading

### DIFF
--- a/synnergy-network/cmd/config/config.go
+++ b/synnergy-network/cmd/config/config.go
@@ -1,0 +1,27 @@
+package config
+
+// Package config in cmd provides a thin wrapper around the shared
+// configuration loader found in pkg/config. It exposes the loaded
+// configuration via the AppConfig variable and mirrors the behaviour
+// used by the command line tests.
+
+import (
+	pkgconfig "synnergy-network/pkg/config"
+)
+
+// AppConfig holds the currently loaded configuration for command line
+// utilities. It mirrors pkg/config.AppConfig but is scoped to this
+// package for convenience when writing CLI tools and tests.
+var AppConfig pkgconfig.Config
+
+// LoadConfig loads the configuration for the given environment name and
+// stores it in AppConfig. Any errors during loading cause a panic, which
+// is acceptable for command line initialisation where failure should
+// abort execution.
+func LoadConfig(env string) {
+	cfg, err := pkgconfig.Load(env)
+	if err != nil {
+		panic(err)
+	}
+	AppConfig = *cfg
+}

--- a/synnergy-network/pkg/config/config.go
+++ b/synnergy-network/pkg/config/config.go
@@ -65,6 +65,7 @@ var AppConfig Config
 func Load(env string) (*Config, error) {
 	viper.SetConfigName("default")
 	viper.AddConfigPath("cmd/config")
+	viper.AddConfigPath("config")
 	viper.SetConfigType("yaml")
 	if err := viper.ReadInConfig(); err != nil {
 		return nil, utils.Wrap(err, "load config")


### PR DESCRIPTION
## Summary
- allow config loader to search both cmd/config and config directories
- expose LoadConfig wrapper for command-line tools

## Testing
- `go test ./synnergy-network/cmd/config`
- `go test ./synnergy-network/pkg/config`
- `go build ./synnergy-network/cmd/cli/watchtower_node.go` *(fails: NodeID redeclared in core/common_structs.go)*

------
https://chatgpt.com/codex/tasks/task_e_688fcac60ac083209e0af22218fd3956