### PR TITLE
Handle JSON encoding errors in explorer and dexserver

### DIFF
--- a/synnergy-network/cmd/dexserver/main.go
+++ b/synnergy-network/cmd/dexserver/main.go
@@ -38,7 +38,9 @@ func poolsHandler(w http.ResponseWriter, _ *http.Request) {
 		out = append(out, pv)
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(out)
+	if err := json.NewEncoder(w).Encode(out); err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+	}
 }
 
 func main() {

--- a/synnergy-network/cmd/explorer/server.go
+++ b/synnergy-network/cmd/explorer/server.go
@@ -115,5 +115,7 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 func writeJSON(w http.ResponseWriter, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
-	_ = enc.Encode(v)
+	if err := enc.Encode(v); err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+	}
 }


### PR DESCRIPTION
## Summary
- add explicit error handling when encoding dex pool responses
- propagate encoding failures in explorer's JSON helper

## Testing
- `go test ./synnergy-network/cmd/explorer -run TestHandleInfo -count=1` *(fails: build dependencies did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_688fcad1a9048320bf08f8aa06c847e6