### PR TITLE
Fix governance scripts to handle tilde commands

### DIFF
--- a/synnergy-network/cmd/scripts/dao_vote.sh
+++ b/synnergy-network/cmd/scripts/dao_vote.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 ID=${1:?"proposal"}
 APPROVE=${2:-true}
-./synnergy ~gov vote "$ID" --approve="$APPROVE"
+./synnergy '~gov' vote "$ID" --approve="$APPROVE"

--- a/synnergy-network/cmd/scripts/fault_check.sh
+++ b/synnergy-network/cmd/scripts/fault_check.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-./synnergy ~fault snapshot
+./synnergy '~fault' snapshot

--- a/synnergy-network/cmd/scripts/governance_propose.sh
+++ b/synnergy-network/cmd/scripts/governance_propose.sh
@@ -2,5 +2,5 @@
 # Enterprise governance proposal creation
 set -euo pipefail
 TITLE=${1:-"Upgrade"}
-BODY=${2:-proposal.md}
-./synnergy ~gov propose --title "$TITLE" --body "$BODY"
+BODY=${2:-"proposal.md"}
+./synnergy '~gov' propose --title "$TITLE" --body "$BODY"


### PR DESCRIPTION
## Summary
- quote CLI command groups beginning with `~` so shells don't expand them
- ensure governance propose default body path is quoted for safe word splitting

## Testing
- `shellcheck synnergy-network/cmd/scripts/authority_apply.sh synnergy-network/cmd/scripts/build_cli.sh synnergy-network/cmd/scripts/coin_mint.sh synnergy-network/cmd/scripts/consensus_start.sh synnergy-network/cmd/scripts/contracts_deploy.sh synnergy-network/cmd/scripts/cross_chain_register.sh synnergy-network/cmd/scripts/dao_vote.sh synnergy-network/cmd/scripts/faucet_fund.sh synnergy-network/cmd/scripts/fault_check.sh synnergy-network/cmd/scripts/governance_propose.sh synnergy-network/cmd/scripts/loanpool_apply.sh`

------
https://chatgpt.com/codex/tasks/task_e_688fcaddce8c83208801ccb48db6d9a8