### PR TITLE
fix: correct smart contract opcode calls

### DIFF
--- a/synnergy-network/cmd/smart_contracts/ledger_inspector.sol
+++ b/synnergy-network/cmd/smart_contracts/ledger_inspector.sol
@@ -4,24 +4,26 @@ pragma solidity ^0.8.20;
 /// @title LedgerInspector showcases additional Synnergy opcodes
 ///        allowing contracts to query ledger state.
 contract LedgerInspector {
-    bytes3 private constant LAST_HASH = hex"0E0003";  // LastBlockHash
-    bytes3 private constant BALANCE   = hex"0E0012";  // Ledger_BalanceOf
+    // Addresses of custom Synnergy VM opcodes
+    uint256 private constant LAST_HASH = 0x0E0003;  // LastBlockHash
+    uint256 private constant BALANCE   = 0x0E0012;  // Ledger_BalanceOf
 
-    /// Returns the hash of the latest block recorded by the ledger
-    function lastBlockHash() public returns (bytes32 hash) {
+    /// @notice Returns the hash of the latest block recorded by the ledger
+    /// @return hash Latest block hash
+    function lastBlockHash() external view returns (bytes32 hash) {
         assembly {
-            let success := call(gas(), 0, LAST_HASH, 0, 0, 0, 32)
-            if iszero(success) { revert(0, 0) }
+            if iszero(staticcall(gas(), LAST_HASH, 0, 0, 0, 32)) { revert(0, 0) }
             hash := mload(0)
         }
     }
 
-    /// Returns the SYNN token balance of an address
-    function balanceOf(bytes20 addr) public returns (uint64 bal) {
+    /// @notice Returns the SYNN token balance of an address
+    /// @param addr Address to query
+    /// @return bal Token balance
+    function balanceOf(address addr) external view returns (uint64 bal) {
         assembly {
             mstore(0, addr)
-            let success := call(gas(), 0, BALANCE, 0, 20, 0, 32)
-            if iszero(success) { revert(0, 0) }
+            if iszero(staticcall(gas(), BALANCE, 0, 20, 0, 32)) { revert(0, 0) }
             bal := mload(0)
         }
     }

--- a/synnergy-network/cmd/smart_contracts/liquidity_adder.sol
+++ b/synnergy-network/cmd/smart_contracts/liquidity_adder.sol
@@ -5,16 +5,17 @@ pragma solidity ^0.8.20;
 ///        using opcode 0x0F0004 (Liquidity_AddLiquidity).
 /// @notice The gas table assigns 5,000 gas to this opcode.
 contract LiquidityAdder {
-    /// Add liquidity to a pool via a custom VM opcode.
+    // Address of Liquidity_AddLiquidity opcode
+    uint256 private constant LIQUIDITY_ADD = 0x0F0004;
+
+    /// @notice Add liquidity to a pool via a custom VM opcode
     /// @param poolId Identifier of the pool
     /// @param amount Amount of base asset provided
     function add(uint32 poolId, uint64 amount) external {
-        bytes4 opcode = 0x0F0004; // Liquidity_AddLiquidity
         assembly {
             mstore(0x0, poolId)
             mstore(0x20, amount)
-            let success := call(gas(), 0, opcode, 0x0, 0x40, 0, 0)
-            if iszero(success) { revert(0, 0) }
+            if iszero(call(gas(), LIQUIDITY_ADD, 0, 0x0, 0x40, 0, 0)) { revert(0, 0) }
         }
     }
 }

--- a/synnergy-network/cmd/smart_contracts/marketplace.sol
+++ b/synnergy-network/cmd/smart_contracts/marketplace.sol
@@ -13,32 +13,41 @@ contract Marketplace {
     mapping(uint256 => Listing) public listings;
     uint256 public nextId;
 
-    /// Deploy a WASM contract using Synnergy opcode 0x080004 (Deploy)
-    function list(bytes calldata wasm, uint256 price) external returns (uint256) {
-        uint256 id = nextId++;
+    /// @notice Deploy a WASM contract using Synnergy opcode 0x080004 (Deploy)
+    /// @param wasm WASM bytecode of the contract
+    /// @param price Asking price in SYNN tokens
+    /// @return id Identifier of the newly created listing
+    function list(bytes calldata wasm, uint256 price) external returns (uint256 id) {
+        id = nextId++;
         listings[id] = Listing(msg.sender, price, wasm);
-        return id;
     }
 
-    /// Purchase and deploy the contract using Synnergy opcodes
+    /// @notice Purchase and deploy the contract using Synnergy opcodes
+    /// @param id Listing identifier
     function purchase(uint256 id) external {
         Listing storage l = listings[id];
         require(l.price > 0, "invalid listing");
+
+        address seller = l.seller;
+        uint256 price = l.price;
+        bytes memory code = l.wasm;
+
         assembly {
             // transfer SYNN tokens from buyer to seller
             let transfer := 0x190004 // Tokens_Transfer
             mstore(0x0, caller())
-            mstore(0x20, l.seller)
-            mstore(0x40, l.price)
-            if iszero(call(gas(), 0, transfer, 0x0, 0x60, 0, 0)) { revert(0,0) }
+            mstore(0x20, seller)
+            mstore(0x40, price)
+            if iszero(call(gas(), transfer, 0, 0x0, 0x60, 0, 0)) { revert(0, 0) }
 
             // deploy WASM contract
             let deploy := 0x080004 // Deploy
-            let ptr := add(l, 0x40)
+            let ptr := add(code, 0x20)
             mstore(0x0, ptr)
-            mstore(0x20, mload(ptr))
-            if iszero(call(gas(), 0, deploy, 0x0, 0x40, 0, 0)) { revert(0,0) }
+            mstore(0x20, mload(code))
+            if iszero(call(gas(), deploy, 0, 0x0, 0x40, 0, 0)) { revert(0, 0) }
         }
+
         delete listings[id];
     }
 }


### PR DESCRIPTION
## Summary
- fix ledger inspector to use staticcall with opcode constants
- ensure liquidity adder calls custom opcode address correctly
- streamline marketplace purchase flow and proper assembly arguments

## Testing
- `npx solc@0.8.20 --bin synnergy-network/cmd/smart_contracts/ledger_inspector.sol -o /tmp`
- `npx solc@0.8.20 --bin synnergy-network/cmd/smart_contracts/liquidity_adder.sol -o /tmp`
- `npx solc@0.8.20 --bin synnergy-network/cmd/smart_contracts/marketplace.sol -o /tmp`


------
https://chatgpt.com/codex/tasks/task_e_688fcb3e94048320bbe573c629a85ffa