### PR TITLE
Add minimal Rust contract stubs for Stage 45

### DIFF
--- a/synnergy-network/cmd/smart_contracts/rust/amm_pool_manager.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/amm_pool_manager.rs
@@ -1,1 +1,45 @@
-// Placeholder for amm_pool_manager contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.
+//! Automated market maker pool management contract.
+//!
+//! This module provides a minimal stub of the AMM pool manager contract used by the
+//! Synnergy network. In the full system, opcodes are dispatched via the Go-based
+//! `opcode_dispatcher.go` with gas costs defined in `gas_table.go`. This Rust version
+//! focuses on basic validation and structure to ensure compile-time safety.
+
+/// Core AMM pool manager type.
+#[derive(Default)]
+pub struct AmmPoolManager;
+
+impl AmmPoolManager {
+    /// Creates a new [`AmmPoolManager`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Executes a generic opcode. Returns an error if provided gas is zero.
+    pub fn execute_opcode(&self, opcode: u8, gas: u64) -> Result<(), String> {
+        if gas == 0 {
+            return Err("insufficient gas".into());
+        }
+        // In production this would interface with opcode_dispatcher.go
+        // to execute the opcode using gas_table.go for gas calculations.
+        let _ = opcode; // placeholder usage
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_creates_manager() {
+        let mgr = AmmPoolManager::new();
+        assert!(mgr.execute_opcode(0, 1).is_ok());
+    }
+
+    #[test]
+    fn zero_gas_fails() {
+        let mgr = AmmPoolManager::new();
+        assert!(mgr.execute_opcode(0, 0).is_err());
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/rust/authority_applier.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/authority_applier.rs
@@ -1,1 +1,40 @@
-// Placeholder for authority_applier contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.
+//! Authority application contract stub.
+//!
+//! This module mirrors the behaviour of the authority applier smart contract within the
+//! Synnergy network. Opcode execution and gas accounting are delegated to Go components
+//! (`opcode_dispatcher.go` and `gas_table.go`). Here we provide a minimal Rust version for
+//! compilation and basic validation.
+
+#[derive(Default)]
+pub struct AuthorityApplier;
+
+impl AuthorityApplier {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn execute_opcode(&self, opcode: u8, gas: u64) -> Result<(), String> {
+        if gas == 0 {
+            return Err("insufficient gas".into());
+        }
+        let _ = opcode;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execute_with_gas() {
+        let contract = AuthorityApplier::new();
+        assert!(contract.execute_opcode(1, 10).is_ok());
+    }
+
+    #[test]
+    fn execute_without_gas() {
+        let contract = AuthorityApplier::new();
+        assert!(contract.execute_opcode(1, 0).is_err());
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/rust/bank_node_bridge.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/bank_node_bridge.rs
@@ -1,1 +1,40 @@
-// Placeholder for bank_node_bridge contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.
+//! Bank node bridge contract stub.
+//!
+//! In the complete Synnergy network this contract enables secure communication between
+//! bank nodes. Opcode dispatching and gas metering are handled externally in Go. This file
+//! offers a lightweight Rust version to guarantee compilation and provide basic gas
+//! validation.
+
+#[derive(Default)]
+pub struct BankNodeBridge;
+
+impl BankNodeBridge {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn execute_opcode(&self, opcode: u8, gas: u64) -> Result<(), String> {
+        if gas == 0 {
+            return Err("insufficient gas".into());
+        }
+        let _ = opcode;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bridge_with_gas() {
+        let bridge = BankNodeBridge::new();
+        assert!(bridge.execute_opcode(2, 5).is_ok());
+    }
+
+    #[test]
+    fn bridge_without_gas() {
+        let bridge = BankNodeBridge::new();
+        assert!(bridge.execute_opcode(2, 0).is_err());
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/rust/carbon_credit.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/carbon_credit.rs
@@ -1,1 +1,39 @@
-// Placeholder for carbon_credit contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.
+//! Carbon credit contract stub.
+//!
+//! Provides a minimal Rust implementation of the carbon credit smart contract used in
+//! Synnergy. Actual opcode dispatching and gas calculations occur within Go components. The
+//! Rust code verifies gas usage and supports basic compilation.
+
+#[derive(Default)]
+pub struct CarbonCredit;
+
+impl CarbonCredit {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn execute_opcode(&self, opcode: u8, gas: u64) -> Result<(), String> {
+        if gas == 0 {
+            return Err("insufficient gas".into());
+        }
+        let _ = opcode;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn executes_with_gas() {
+        let contract = CarbonCredit::new();
+        assert!(contract.execute_opcode(3, 4).is_ok());
+    }
+
+    #[test]
+    fn rejects_zero_gas() {
+        let contract = CarbonCredit::new();
+        assert!(contract.execute_opcode(3, 0).is_err());
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/rust/compliance_auditor.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/compliance_auditor.rs
@@ -1,1 +1,39 @@
-// Placeholder for compliance_auditor contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.
+//! Compliance auditor contract stub.
+//!
+//! Represents a simplified version of the compliance auditor. The comprehensive logic for
+//! opcode handling and gas management is implemented in Go. This Rust code ensures that
+//! basic checks exist and that the module compiles correctly.
+
+#[derive(Default)]
+pub struct ComplianceAuditor;
+
+impl ComplianceAuditor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn execute_opcode(&self, opcode: u8, gas: u64) -> Result<(), String> {
+        if gas == 0 {
+            return Err("insufficient gas".into());
+        }
+        let _ = opcode;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auditor_runs_with_gas() {
+        let auditor = ComplianceAuditor::new();
+        assert!(auditor.execute_opcode(4, 7).is_ok());
+    }
+
+    #[test]
+    fn auditor_rejects_no_gas() {
+        let auditor = ComplianceAuditor::new();
+        assert!(auditor.execute_opcode(4, 0).is_err());
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/rust/consensus_tester.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/consensus_tester.rs
@@ -1,1 +1,39 @@
-// Placeholder for consensus_tester contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.
+//! Consensus tester contract stub.
+//!
+//! Used to simulate consensus operations within the Synnergy ecosystem. The real
+//! implementation relies on Go for opcode execution and gas handling. This Rust file adds
+//! structural checks and unit tests.
+
+#[derive(Default)]
+pub struct ConsensusTester;
+
+impl ConsensusTester {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn execute_opcode(&self, opcode: u8, gas: u64) -> Result<(), String> {
+        if gas == 0 {
+            return Err("insufficient gas".into());
+        }
+        let _ = opcode;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consensus_with_gas() {
+        let tester = ConsensusTester::new();
+        assert!(tester.execute_opcode(5, 3).is_ok());
+    }
+
+    #[test]
+    fn consensus_without_gas() {
+        let tester = ConsensusTester::new();
+        assert!(tester.execute_opcode(5, 0).is_err());
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/rust/cross_chain_bridge.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/cross_chain_bridge.rs
@@ -1,1 +1,39 @@
-// Placeholder for cross_chain_bridge contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.
+//! Cross-chain bridge contract stub.
+//!
+//! Facilitates asset transfers between chains in the Synnergy network. The complete
+//! execution logic resides within Go-based opcode dispatchers and gas tables. This Rust
+//! version includes basic gas validation and unit tests for structural assurance.
+
+#[derive(Default)]
+pub struct CrossChainBridge;
+
+impl CrossChainBridge {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn execute_opcode(&self, opcode: u8, gas: u64) -> Result<(), String> {
+        if gas == 0 {
+            return Err("insufficient gas".into());
+        }
+        let _ = opcode;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bridge_runs_with_gas() {
+        let bridge = CrossChainBridge::new();
+        assert!(bridge.execute_opcode(6, 8).is_ok());
+    }
+
+    #[test]
+    fn bridge_fails_without_gas() {
+        let bridge = CrossChainBridge::new();
+        assert!(bridge.execute_opcode(6, 0).is_err());
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/rust/cross_chain_protocol.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/cross_chain_protocol.rs
@@ -1,1 +1,39 @@
-// Placeholder for cross_chain_protocol contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.
+//! Cross-chain protocol contract stub.
+//!
+//! Provides the structural foundation for cross-chain communication within Synnergy. The
+//! full opcode execution is delegated to Go infrastructure; here we only handle gas checks
+//! and ensure compilation.
+
+#[derive(Default)]
+pub struct CrossChainProtocol;
+
+impl CrossChainProtocol {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn execute_opcode(&self, opcode: u8, gas: u64) -> Result<(), String> {
+        if gas == 0 {
+            return Err("insufficient gas".into());
+        }
+        let _ = opcode;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_works_with_gas() {
+        let proto = CrossChainProtocol::new();
+        assert!(proto.execute_opcode(7, 2).is_ok());
+    }
+
+    #[test]
+    fn protocol_fails_without_gas() {
+        let proto = CrossChainProtocol::new();
+        assert!(proto.execute_opcode(7, 0).is_err());
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/rust/data_feed_oracle.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/data_feed_oracle.rs
@@ -1,1 +1,39 @@
-// Placeholder for data_feed_oracle contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.
+//! Data feed oracle contract stub.
+//!
+//! Supplies external data to the Synnergy network. The comprehensive opcode and gas logic is
+//! maintained in Go, while this Rust implementation guarantees basic validation and
+//! successful compilation.
+
+#[derive(Default)]
+pub struct DataFeedOracle;
+
+impl DataFeedOracle {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn execute_opcode(&self, opcode: u8, gas: u64) -> Result<(), String> {
+        if gas == 0 {
+            return Err("insufficient gas".into());
+        }
+        let _ = opcode;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oracle_executes_with_gas() {
+        let oracle = DataFeedOracle::new();
+        assert!(oracle.execute_opcode(8, 9).is_ok());
+    }
+
+    #[test]
+    fn oracle_rejects_zero_gas() {
+        let oracle = DataFeedOracle::new();
+        assert!(oracle.execute_opcode(8, 0).is_err());
+    }
+}

--- a/synnergy-network/cmd/smart_contracts/rust/data_marketplace.rs
+++ b/synnergy-network/cmd/smart_contracts/rust/data_marketplace.rs
@@ -1,1 +1,38 @@
-// Placeholder for data_marketplace contract. Uses opcodes from opcode_dispatcher.go with gas costs defined in gas_table.go.
+//! Data marketplace contract stub.
+//!
+//! Acts as the entry point for trading data assets within Synnergy. Opcode execution and gas
+//! accounting are managed in Go. This Rust stub ensures basic gas checks and compilation.
+
+#[derive(Default)]
+pub struct DataMarketplace;
+
+impl DataMarketplace {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn execute_opcode(&self, opcode: u8, gas: u64) -> Result<(), String> {
+        if gas == 0 {
+            return Err("insufficient gas".into());
+        }
+        let _ = opcode;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marketplace_executes_with_gas() {
+        let market = DataMarketplace::new();
+        assert!(market.execute_opcode(9, 6).is_ok());
+    }
+
+    #[test]
+    fn marketplace_rejects_zero_gas() {
+        let market = DataMarketplace::new();
+        assert!(market.execute_opcode(9, 0).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- implement compile-ready Rust stubs for Stage 45 smart contracts
- include basic gas validation and unit tests for each contract

## Testing
- `for f in amm_pool_manager authority_applier bank_node_bridge carbon_credit compliance_auditor consensus_tester cross_chain_bridge cross_chain_protocol data_feed_oracle data_marketplace; do rustc --test synnergy-network/cmd/smart_contracts/rust/$f.rs -o /tmp/${f}_test && /tmp/${f}_test; done`


------
https://chatgpt.com/codex/tasks/task_e_688fcb5931ac8320b4574fcab1706f64