### PR TITLE
refactor: clarify node interfaces

### DIFF
--- a/synnergy-network/core/Nodes/authority_nodes/index.go
+++ b/synnergy-network/core/Nodes/authority_nodes/index.go
@@ -1,9 +1,9 @@
 package authority_nodes
 
-import "synnergy-network/core/Nodes"
+import nodes "synnergy-network/core/Nodes"
 
 // AuthorityNodeInterface extends NodeInterface with authority-specific actions.
 type AuthorityNodeInterface interface {
-	Nodes.NodeInterface
+	nodes.NodeInterface
 	PromoteAuthority(addr string) error
 }

--- a/synnergy-network/core/Nodes/bank_nodes/index.go
+++ b/synnergy-network/core/Nodes/bank_nodes/index.go
@@ -1,11 +1,11 @@
 package bank_nodes
 
-import "synnergy-network/core/Nodes"
+import nodes "synnergy-network/core/Nodes"
 
 // BankInstitutionalNodeInterface extends NodeInterface with
 // bank/institution specific operations.
 type BankInstitutionalNodeInterface interface {
-	Nodes.NodeInterface
+	nodes.NodeInterface
 	// MonitorTransaction processes raw transaction bytes for compliance checks.
 	MonitorTransaction(data []byte) error
 	// ComplianceReport generates an aggregated compliance report.

--- a/synnergy-network/core/Nodes/elected_authority_node.go
+++ b/synnergy-network/core/Nodes/elected_authority_node.go
@@ -78,3 +78,6 @@ func (n *ElectedAuthorityNode) ViewPrivateTransaction(hash Hash) ([]byte, error)
 
 // ApproveLoanProposal records approval for a loan or grant request.
 func (n *ElectedAuthorityNode) ApproveLoanProposal(id string) error { return nil }
+
+// Ensure ElectedAuthorityNode implements NodeInterface.
+var _ NodeInterface = (*ElectedAuthorityNode)(nil)

--- a/synnergy-network/core/Nodes/holographic_node.go
+++ b/synnergy-network/core/Nodes/holographic_node.go
@@ -83,3 +83,6 @@ func (h *HolographicNode) ProcessTx(tx interface{}) error {
 func (h *HolographicNode) ExecuteContract(ctx interface{}, vm VMExecutor, code []byte) error {
 	return vm.Execute(ctx, code)
 }
+
+// Ensure HolographicNode implements NodeInterface.
+var _ NodeInterface = (*HolographicNode)(nil)


### PR DESCRIPTION
## Summary
- clarify authority and bank node interface imports
- add interface compliance checks for elected authority and holographic nodes

## Testing
- `go vet ./core/Nodes ./core/Nodes/authority_nodes ./core/Nodes/bank_nodes`
- `go test ./core/Nodes ./core/Nodes/authority_nodes ./core/Nodes/bank_nodes`


------
https://chatgpt.com/codex/tasks/task_e_688fcba467cc8320810b36036ac9df6b