### PR TITLE
fix(core): resolve network recursion and authority tests

### DIFF
--- a/synnergy-network/core/authority_nodes.go
+++ b/synnergy-network/core/authority_nodes.go
@@ -12,12 +12,10 @@ package core
 // Compile‑time dependencies: common, ledger, security (sig verify).
 
 import (
-	crand "crypto/rand"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"github.com/sirupsen/logrus"
-	"math/big"
 	"time"
 )
 

--- a/synnergy-network/core/authority_penalty_test.go
+++ b/synnergy-network/core/authority_penalty_test.go
@@ -27,6 +27,10 @@ func (a Address) Short() string {
 
 type Hash [32]byte
 
+var AddressZero Address
+
+func shuffleAddresses(addrs []Address) error { return nil }
+
 type StateIterator interface {
 	Next() bool
 	Key() []byte
@@ -104,6 +108,7 @@ func (m *memState) PrefixIterator(prefix []byte) StateIterator {
 
 type AuthorityNode struct {
 	Addr        Address
+	Wallet      Address
 	Role        AuthorityRole
 	Active      bool
 	PublicVotes uint32

--- a/synnergy-network/core/autonomous_agent_node.go
+++ b/synnergy-network/core/autonomous_agent_node.go
@@ -63,7 +63,7 @@ func (a *AutonomousAgentNode) Start() {
 	a.wg.Add(1)
 	go func() {
 		defer a.wg.Done()
-		a.ListenAndServe()
+		a.BaseNode.ListenAndServe()
 	}()
 	a.wg.Add(1)
 	go a.loop()
@@ -72,10 +72,10 @@ func (a *AutonomousAgentNode) Start() {
 // Stop gracefully terminates operations.
 func (a *AutonomousAgentNode) Stop() error {
 	close(a.stop)
-	a.wg.Wait()
 	if err := a.Close(); err != nil {
 		return err
 	}
+	a.wg.Wait()
 	return nil
 }
 
@@ -109,6 +109,9 @@ func (a *AutonomousAgentNode) executeRules() {
 }
 
 // ListenAndServe is exposed for the opcode dispatcher.
-func (a *AutonomousAgentNode) ListenAndServe() { a.Start() }
+func (a *AutonomousAgentNode) ListenAndServe() {
+	a.Start()
+	a.wg.Wait()
+}
 
 var _ Nodes.NodeInterface = (*AutonomousAgentNode)(nil)

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -19,78 +18,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// NodeID uniquely identifies a network peer.
-type NodeID string
-
-// Peer stores information about a connected peer.
-type Peer struct {
-	ID      NodeID
-	Addr    string
-	Latency time.Duration
-	Conn    net.Conn
-}
-
-// Message represents a pubsub message.
-type Message struct {
-	From  NodeID
-	Topic string
-	Data  []byte
-}
-
-// Config holds basic networking configuration.
-type Config struct {
-	ListenAddr     string
-	BootstrapPeers []string
-	DiscoveryTag   string
-}
-
-// NetworkMessage is used for optional replication hooks.
-type NetworkMessage struct {
-	Topic   string
-	Content []byte
-}
-
-// Block is a minimal placeholder for broadcast tests.
-type Block struct{}
-
-// NATManager manages external port mappings.
-type NATManager struct{}
-
-// NewNATManager returns a no-op NAT manager implementation.
-func NewNATManager() (*NATManager, error) { return &NATManager{}, nil }
-
-// Map reserves the given port; in this stub it is a no-op.
-func (m *NATManager) Map(port int) error { return nil }
-
-// Unmap releases any mapped port; in this stub it is a no-op.
-func (m *NATManager) Unmap() error { return nil }
-
-// parsePort extracts the TCP port from a multiaddress string.
-func parsePort(addr string) (int, error) {
-	parts := strings.Split(addr, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "tcp" {
-			return strconv.Atoi(parts[i+1])
-		}
-	}
-	return 0, fmt.Errorf("no tcp port in %s", addr)
-}
-
-// Node represents a Synnergy P2P node.
-type Node struct {
-	host      host.Host
-	pubsub    *pubsub.PubSub
-	topics    map[string]*pubsub.Topic
-	subs      map[string]*pubsub.Subscription
-	topicLock sync.RWMutex
-	subLock   sync.RWMutex
-	peerLock  sync.RWMutex
-	peers     map[NodeID]*Peer
-	nat       *NATManager
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cfg       Config
-}
+// Core type definitions (NodeID, Peer, Message, Config, NetworkMessage,
+// Block, NATManager, parsePort, and the Node struct) live in other files of
+// this package.  Duplicating them here previously caused redeclaration
+// errors, so this file now focuses solely on the networking logic and
+// associated methods.
 
 func NewNode(cfg Config) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- streamline core networking by removing duplicate type definitions
- fix AutonomousAgentNode start/stop lifecycle to prevent recursion and deadlocks
- add minimal stubs for authority penalty unit tests and clean unused imports

## Testing
- `go test synnergy-network/core/bft_simulation.go synnergy-network/core/bft_simulation_test.go -run TestSimulateBFTWith -count=1`
- `go test -tags unit synnergy-network/core/authority_penalty_test.go synnergy-network/core/authority_nodes.go synnergy-network/core/stake_penalty.go -run TestAuthorityPenaltyEnforcement -count=1`
- `go test -tags unit synnergy-network/core/authority_penalty_test.go synnergy-network/core/authority_nodes.go synnergy-network/core/stake_penalty.go -run TestSlashStakeInvalidFraction -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688fcc18b23c8320b32aeae268333618