### PR TITLE
refactor: unify network types and cleanup tests

### DIFF
--- a/synnergy-network/core/access_control_test.go
+++ b/synnergy-network/core/access_control_test.go
@@ -1,57 +1,9 @@
 package core
 
 import (
-	"strings"
 	"sync"
 	"testing"
 )
-
-type Address [20]byte
-
-func (a Address) Hex() string {
-	const hexdigits = "0123456789abcdef"
-	out := make([]byte, 2+len(a)*2)
-	copy(out, "0x")
-	for i, v := range a {
-		out[2+i*2] = hexdigits[v>>4]
-		out[3+i*2] = hexdigits[v&0x0f]
-	}
-	return string(out)
-}
-
-type Ledger struct {
-	State map[string][]byte
-}
-
-func (l *Ledger) HasState(k []byte) (bool, error) { _, ok := l.State[string(k)]; return ok, nil }
-func (l *Ledger) SetState(k, v []byte) error      { l.State[string(k)] = v; return nil }
-func (l *Ledger) DeleteState(k []byte) error      { delete(l.State, string(k)); return nil }
-
-type iterator struct {
-	keys [][]byte
-	idx  int
-}
-
-func (l *Ledger) PrefixIterator(prefix []byte) *iterator {
-	keys := make([][]byte, 0)
-	for k := range l.State {
-		if strings.HasPrefix(k, string(prefix)) {
-			keys = append(keys, []byte(k))
-		}
-	}
-	return &iterator{keys: keys}
-}
-
-func (it *iterator) Next() bool {
-	if it.idx >= len(it.keys) {
-		return false
-	}
-	it.idx++
-	return true
-}
-
-func (it *iterator) Key() []byte  { return it.keys[it.idx-1] }
-func (it *iterator) Error() error { return nil }
 
 func TestAccessControllerCaching(t *testing.T) {
 	led := &Ledger{State: make(map[string][]byte)}

--- a/synnergy-network/core/common_structs.go
+++ b/synnergy-network/core/common_structs.go
@@ -623,7 +623,6 @@ type Storage struct {
 // TxPool & transaction structs (aggregated from transactions.go)
 //---------------------------------------------------------------------
 
-
 // TxType categorises transaction kinds. It mirrors the definition in
 // transactions.go but is repeated here to avoid build tag dependencies.
 type TxType uint8
@@ -638,7 +637,6 @@ const (
 	// a protocol‑defined fee.
 	TxReversal
 )
-
 
 type Transaction struct {
 	// core fields
@@ -668,24 +666,24 @@ type Transaction struct {
 // contents. The resulting hash is stored on the Transaction so subsequent
 // calls avoid recomputing it.
 func (tx *Transaction) HashTx() Hash {
-        b, _ := json.Marshal(tx)
-        h := sha256.Sum256(b)
-        tx.Hash = h
-        return h
+	b, _ := json.Marshal(tx)
+	h := sha256.Sum256(b)
+	tx.Hash = h
+	return h
 }
 
 // IDHex returns the transaction hash as a hex string. If the hash has not yet
 // been computed, it derives it from the transaction contents to ensure a
 // stable identifier.
 func (tx *Transaction) IDHex() string {
-        if tx == nil {
-                return ""
-        }
+	if tx == nil {
+		return ""
+	}
 
-        if tx.Hash == (Hash{}) {
-                tx.HashTx()
-        }
-        return hex.EncodeToString(tx.Hash[:])
+	if tx.Hash == (Hash{}) {
+		tx.HashTx()
+	}
+	return hex.EncodeToString(tx.Hash[:])
 }
 
 type TxInput struct {

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,79 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/sirupsen/logrus"
 )
-
-// NodeID uniquely identifies a network peer.
-type NodeID string
-
-// Peer stores information about a connected peer.
-type Peer struct {
-	ID      NodeID
-	Addr    string
-	Latency time.Duration
-	Conn    net.Conn
-}
-
-// Message represents a pubsub message.
-type Message struct {
-	From  NodeID
-	Topic string
-	Data  []byte
-}
-
-// Config holds basic networking configuration.
-type Config struct {
-	ListenAddr     string
-	BootstrapPeers []string
-	DiscoveryTag   string
-}
-
-// NetworkMessage is used for optional replication hooks.
-type NetworkMessage struct {
-	Topic   string
-	Content []byte
-}
-
-// Block is a minimal placeholder for broadcast tests.
-type Block struct{}
-
-// NATManager manages external port mappings.
-type NATManager struct{}
-
-// NewNATManager returns a no-op NAT manager implementation.
-func NewNATManager() (*NATManager, error) { return &NATManager{}, nil }
-
-// Map reserves the given port; in this stub it is a no-op.
-func (m *NATManager) Map(port int) error { return nil }
-
-// Unmap releases any mapped port; in this stub it is a no-op.
-func (m *NATManager) Unmap() error { return nil }
-
-// parsePort extracts the TCP port from a multiaddress string.
-func parsePort(addr string) (int, error) {
-	parts := strings.Split(addr, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "tcp" {
-			return strconv.Atoi(parts[i+1])
-		}
-	}
-	return 0, fmt.Errorf("no tcp port in %s", addr)
-}
-
-// Node represents a Synnergy P2P node.
-type Node struct {
-	host      host.Host
-	pubsub    *pubsub.PubSub
-	topics    map[string]*pubsub.Topic
-	subs      map[string]*pubsub.Subscription
-	topicLock sync.RWMutex
-	subLock   sync.RWMutex
-	peerLock  sync.RWMutex
-	peers     map[NodeID]*Peer
-	nat       *NATManager
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cfg       Config
-}
 
 func NewNode(cfg Config) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- centralize P2P structures under common_structs
- drop duplicate type declarations from network layer
- update access control tests to leverage core Ledger and Address types

## Testing
- `go test -run TestCoinMintAndBurn -count=1` *(fails: sc.p2p.Broadcast undefined, shuffleAddresses undefined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc2c6c288320b429f7ec00f6ef98