### PR TITLE
Refactor consensus-specific node and isolate connection pool tests

### DIFF
--- a/synnergy-network/core/connection_pool_test.go
+++ b/synnergy-network/core/connection_pool_test.go
@@ -7,6 +7,27 @@ import (
 	"time"
 )
 
+// Dialer provides a minimal network dialer used by connection pool tests.
+// It mirrors the production dialer's API without pulling in the full network
+// stack, keeping unit tests fast and self‑contained.
+type Dialer struct {
+	timeout   time.Duration
+	keepAlive time.Duration
+}
+
+// NewDialer constructs a Dialer with the given timeout and keepalive
+// durations.
+func NewDialer(timeout, keepAlive time.Duration) *Dialer {
+	return &Dialer{timeout: timeout, keepAlive: keepAlive}
+}
+
+// Dial establishes a TCP connection to the provided address using the
+// configured settings.
+func (d *Dialer) Dial(ctx context.Context, address string) (net.Conn, error) {
+	nd := &net.Dialer{Timeout: d.timeout, KeepAlive: d.keepAlive}
+	return nd.DialContext(ctx, "tcp", address)
+}
+
 // startTestServer starts a TCP server that accepts connections and returns listener and slice of accepted conns.
 func startTestServer(t *testing.T) (net.Listener, *[]net.Conn) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")

--- a/synnergy-network/core/consensus_specific_node.go
+++ b/synnergy-network/core/consensus_specific_node.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/hex"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -14,7 +15,8 @@ type ConsensusSpecificNode struct {
 	logger *logrus.Logger
 }
 
-// NewConsensusSpecificNode constructs a consensus node with the provided engine and ledger.
+// NewConsensusSpecificNode constructs a consensus node with the provided
+// engine and ledger.
 func NewConsensusSpecificNode(cfg Config, led *Ledger, engine *SynnergyConsensus, lg *logrus.Logger) (*ConsensusSpecificNode, error) {
 	n, err := NewNode(cfg)
 	if err != nil {
@@ -32,7 +34,9 @@ func (csn *ConsensusSpecificNode) StartConsensus() error {
 		return nil
 	}
 	go csn.engine.Start(context.Background())
-	csn.logger.Info("consensus engine started")
+	if csn.logger != nil {
+		csn.logger.Info("consensus engine started")
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- replace control-character-laden consensus node file with clean implementation
- add lightweight dialer stub so connection pool tests run without full network stack

## Testing
- `go test connection_pool.go connection_pool_test.go`


------
https://chatgpt.com/codex/tasks/task_e_688fcc3aeb5c8320aa706a3b4acafbd9