### PR TITLE
fix: improve content and cross-chain handling

### DIFF
--- a/synnergy-network/core/content_node_impl.go
+++ b/synnergy-network/core/content_node_impl.go
@@ -69,7 +69,10 @@ func (c *ContentNode) StoreContent(data, key []byte) (string, error) {
 	}
 	c.store[cid] = enc
 	meta := ContentMeta{CID: cid, Size: uint64(len(enc)), Uploaded: time.Now().UTC()}
-	raw, _ := json.Marshal(meta)
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		return cid, err
+	}
 	if err := CurrentStore().Set([]byte("content:meta:"+cid), raw); err != nil {
 		return cid, err
 	}
@@ -87,7 +90,6 @@ func (c *ContentNode) RetrieveContent(cid string, key []byte) ([]byte, error) {
 		}
 	}
 	return decryptContent(data, key)
-
 }
 
 // ListContent enumerates pinned content metadata.

--- a/synnergy-network/core/contracts.go
+++ b/synnergy-network/core/contracts.go
@@ -72,7 +72,10 @@ func CompileWASM(srcPath string, outDir string) ([]byte, [32]byte, error) {
 		if err := cmd.Run(); err != nil {
 			return nil, [32]byte{}, err
 		}
-		b, _ := os.ReadFile(out)
+		b, err := os.ReadFile(out)
+		if err != nil {
+			return nil, [32]byte{}, err
+		}
 		wasm = b
 	}
 	hash := sha256.Sum256(wasm)

--- a/synnergy-network/core/cross_chain_bridge.go
+++ b/synnergy-network/core/cross_chain_bridge.go
@@ -42,7 +42,11 @@ func StartBridgeTransfer(ctx *Context, bridgeID string, asset AssetRef, to Addre
 		Amount:   amount,
 		Time:     time.Now().UTC(),
 	}
-	raw, _ := json.Marshal(bt)
+	raw, err := json.Marshal(bt)
+	if err != nil {
+		_ = Transfer(ctx, asset, escrow, ctx.Caller, amount)
+		return BridgeTransfer{}, err
+	}
 	if err := CurrentStore().Set([]byte("crosschain:transfer:"+bt.ID), raw); err != nil {
 		_ = Transfer(ctx, asset, escrow, ctx.Caller, amount)
 		return BridgeTransfer{}, err
@@ -68,7 +72,10 @@ func CompleteBridgeTransfer(ctx *Context, id string, proof Proof) error {
 		return err
 	}
 	bt.Completed = true
-	raw, _ := json.Marshal(bt)
+	raw, err := json.Marshal(bt)
+	if err != nil {
+		return err
+	}
 	if err := CurrentStore().Set([]byte("crosschain:transfer:"+bt.ID), raw); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- ensure content metadata serialization errors surface
- verify wasm compilation errors are propagated
- handle bridge transfer marshalling errors

## Testing
- `go test ./synnergy-network/core -run TestHeavyVMInvokeWithReceipt -count=1` *(fails: NodeID redeclared in network.go)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc46f37c83209cb71e980af40c04