### PR TITLE
refactor: harden core modules

### DIFF
--- a/synnergy-network/core/elected_authority_node.go
+++ b/synnergy-network/core/elected_authority_node.go
@@ -16,7 +16,11 @@ type ElectedAuthorityNode struct {
 
 // NewElectedAuthorityNode constructs a node using the given network adapter and
 // references to the ledger and consensus engine.
+// Returns nil if required dependencies are not provided.
 func NewElectedAuthorityNode(base Nodes.NodeInterface, led *Ledger, cons *SynnergyConsensus, total int) *ElectedAuthorityNode {
+	if led == nil || cons == nil {
+		return nil
+	}
 	return &ElectedAuthorityNode{
 		ElectedAuthorityNode: Nodes.NewElectedAuthorityNode(base, total),
 		ledger:               led,

--- a/synnergy-network/core/energy_efficiency.go
+++ b/synnergy-network/core/energy_efficiency.go
@@ -66,7 +66,10 @@ func (e *EfficiencyEngine) RecordStats(v Address, txs uint64, kwh float64) error
 		return errors.New("invalid stats")
 	}
 	rec := EfficiencyRecord{Validator: v, TxCount: txs, EnergyKWh: kwh, Timestamp: time.Now().Unix()}
-	blob, _ := json.Marshal(rec)
+	blob, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
 	h := sha256.Sum256(blob)
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/synnergy-network/core/energy_efficient_node.go
+++ b/synnergy-network/core/energy_efficient_node.go
@@ -54,7 +54,11 @@ func EnergyNodeRecord(en *EnergyEfficientNode, txs uint64, kwh float64) error {
 	}
 	en.mu.Lock()
 	defer en.mu.Unlock()
-	return EnergyEff().RecordStats(en.validator, txs, kwh)
+	eng := EnergyEff()
+	if eng == nil {
+		return fmt.Errorf("energy engine not initialised")
+	}
+	return eng.RecordStats(en.validator, txs, kwh)
 }
 
 // EnergyNodeEfficiency returns the validator's current transactions-per-kWh.
@@ -64,7 +68,11 @@ func EnergyNodeEfficiency(en *EnergyEfficientNode) (float64, error) {
 	}
 	en.mu.Lock()
 	defer en.mu.Unlock()
-	return EnergyEff().EfficiencyOf(en.validator)
+	eng := EnergyEff()
+	if eng == nil {
+		return 0, fmt.Errorf("energy engine not initialised")
+	}
+	return eng.EfficiencyOf(en.validator)
 }
 
 // EnergyNodeNetworkAvg returns the network-wide transactions-per-kWh score.
@@ -72,7 +80,11 @@ func EnergyNodeNetworkAvg(en *EnergyEfficientNode) (float64, error) {
 	if en == nil {
 		return 0, ErrInvalidNode
 	}
-	return EnergyEff().NetworkAverage()
+	eng := EnergyEff()
+	if eng == nil {
+		return 0, fmt.Errorf("energy engine not initialised")
+	}
+	return eng.NetworkAverage()
 }
 
 var (

--- a/synnergy-network/core/energy_tokens.go
+++ b/synnergy-network/core/energy_tokens.go
@@ -84,13 +84,19 @@ func (e *EnergyEngine) RegisterAsset(owner Address, assetType string, qty uint64
 		Location:      location,
 		Certification: cert,
 	}
-	blob, _ := json.Marshal(asset)
+	blob, err := json.Marshal(asset)
+	if err != nil {
+		e.nextID--
+		return 0, err
+	}
 	if err := e.ledger.SetState(e.assetKey(id), blob); err != nil {
 		e.nextID--
 		return 0, err
 	}
-	b, _ := json.Marshal(e.nextID)
-	_ = e.ledger.SetState([]byte("syn4300:nextID"), b)
+	b, err := json.Marshal(e.nextID)
+	if err == nil {
+		_ = e.ledger.SetState([]byte("syn4300:nextID"), b)
+	}
 	tok, ok := GetToken(e.tokenID)
 	if !ok {
 		return 0, fmt.Errorf("energy token not found")
@@ -121,14 +127,20 @@ func (e *EnergyEngine) TransferAsset(id uint64, to Address) error {
 		return err
 	}
 	asset.Owner = to
-	blob, _ := json.Marshal(asset)
+	blob, err := json.Marshal(asset)
+	if err != nil {
+		return err
+	}
 	return e.ledger.SetState(e.assetKey(id), blob)
 }
 
 // RecordSustainability attaches a sustainability note to an asset.
 func (e *EnergyEngine) RecordSustainability(id uint64, info string) error {
 	rec := SustainabilityRecord{AssetID: id, Details: info, Timestamp: time.Now().Unix()}
-	blob, _ := json.Marshal(rec)
+	blob, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
 	return e.ledger.SetState(e.sustainKey(id, rec.Timestamp), blob)
 }
 

--- a/synnergy-network/core/environmental_monitoring_node.go
+++ b/synnergy-network/core/environmental_monitoring_node.go
@@ -112,7 +112,9 @@ func (e *EnvironmentalMonitoringNode) loop() {
 					continue
 				}
 				key := fmt.Sprintf("env:%s:%d", s.ID, time.Now().UnixNano())
-				_ = e.ledger.SetState([]byte(key), data)
+				if err := e.ledger.SetState([]byte(key), data); err != nil {
+					continue
+				}
 				e.handle(s.ID, data)
 			}
 		case <-e.ctx.Done():

--- a/synnergy-network/core/escrow.go
+++ b/synnergy-network/core/escrow.go
@@ -62,7 +62,10 @@ func EscrowCreate(ctx *Context, parties []EscrowParty) (*EscrowContract, error) 
 		return nil, err
 	}
 
-	data, _ := json.Marshal(esc)
+	data, err := json.Marshal(esc)
+	if err != nil {
+		return nil, err
+	}
 	if err := CurrentStore().Set(escrowKey(esc.ID), data); err != nil {
 		return nil, err
 	}
@@ -93,7 +96,10 @@ func EscrowDeposit(ctx *Context, id string, amount uint64) error {
 		return err
 	}
 	esc.Balance += amount
-	data, _ := json.Marshal(&esc)
+	data, err := json.Marshal(&esc)
+	if err != nil {
+		return err
+	}
 	return CurrentStore().Set(escrowKey(id), data)
 }
 
@@ -126,7 +132,10 @@ func EscrowRelease(ctx *Context, id string) error {
 		esc.Parties[i].Paid = true
 	}
 	esc.Released = true
-	data, _ := json.Marshal(&esc)
+	data, err := json.Marshal(&esc)
+	if err != nil {
+		return err
+	}
 	return CurrentStore().Set(escrowKey(id), data)
 }
 

--- a/synnergy-network/core/event_management.go
+++ b/synnergy-network/core/event_management.go
@@ -44,7 +44,10 @@ func (m *EventManager) Emit(ctx *Context, typ string, data []byte) (string, erro
 	h := sha256.Sum256(append([]byte(typ), data...))
 	id := hex.EncodeToString(h[:])
 	ev := Event{ID: id, Type: typ, Data: data, Height: ctx.BlockHeight, Timestamp: time.Now().Unix()}
-	blob, _ := json.Marshal(ev)
+	blob, err := json.Marshal(ev)
+	if err != nil {
+		return "", err
+	}
 	key := []byte(fmt.Sprintf("event:%s:%s", typ, id))
 	if err := m.ledger.SetState(key, blob); err != nil {
 		return "", err

--- a/synnergy-network/core/execution_management.go
+++ b/synnergy-network/core/execution_management.go
@@ -26,7 +26,11 @@ type ExecutionManager struct {
 }
 
 // NewExecutionManager wires an execution manager with the given ledger and VM.
+// Returns nil if the ledger is not provided.
 func NewExecutionManager(ledger *Ledger, vm VM) *ExecutionManager {
+	if ledger == nil {
+		return nil
+	}
 	return &ExecutionManager{ledger: ledger, vm: vm}
 }
 

--- a/synnergy-network/core/experimental_node.go
+++ b/synnergy-network/core/experimental_node.go
@@ -106,6 +106,8 @@ func decodeExperimentalTx(data []byte) (*Transaction, error) {
 // RandomAddress returns a pseudo-random address useful for testing.
 func RandomAddress() Address {
 	var a Address
-	rand.Read(a[:])
+	if _, err := rand.Read(a[:]); err != nil {
+		return Address{}
+	}
 	return a
 }

--- a/synnergy-network/core/external_sensor.go
+++ b/synnergy-network/core/external_sensor.go
@@ -117,6 +117,10 @@ func PollSensor(id string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("sensor http %d: %s", resp.StatusCode, string(body))
+	}
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,79 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/sirupsen/logrus"
 )
-
-// NodeID uniquely identifies a network peer.
-type NodeID string
-
-// Peer stores information about a connected peer.
-type Peer struct {
-	ID      NodeID
-	Addr    string
-	Latency time.Duration
-	Conn    net.Conn
-}
-
-// Message represents a pubsub message.
-type Message struct {
-	From  NodeID
-	Topic string
-	Data  []byte
-}
-
-// Config holds basic networking configuration.
-type Config struct {
-	ListenAddr     string
-	BootstrapPeers []string
-	DiscoveryTag   string
-}
-
-// NetworkMessage is used for optional replication hooks.
-type NetworkMessage struct {
-	Topic   string
-	Content []byte
-}
-
-// Block is a minimal placeholder for broadcast tests.
-type Block struct{}
-
-// NATManager manages external port mappings.
-type NATManager struct{}
-
-// NewNATManager returns a no-op NAT manager implementation.
-func NewNATManager() (*NATManager, error) { return &NATManager{}, nil }
-
-// Map reserves the given port; in this stub it is a no-op.
-func (m *NATManager) Map(port int) error { return nil }
-
-// Unmap releases any mapped port; in this stub it is a no-op.
-func (m *NATManager) Unmap() error { return nil }
-
-// parsePort extracts the TCP port from a multiaddress string.
-func parsePort(addr string) (int, error) {
-	parts := strings.Split(addr, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "tcp" {
-			return strconv.Atoi(parts[i+1])
-		}
-	}
-	return 0, fmt.Errorf("no tcp port in %s", addr)
-}
-
-// Node represents a Synnergy P2P node.
-type Node struct {
-	host      host.Host
-	pubsub    *pubsub.PubSub
-	topics    map[string]*pubsub.Topic
-	subs      map[string]*pubsub.Subscription
-	topicLock sync.RWMutex
-	subLock   sync.RWMutex
-	peerLock  sync.RWMutex
-	peers     map[NodeID]*Peer
-	nat       *NATManager
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cfg       Config
-}
 
 func NewNode(cfg Config) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- add initialization checks for authority and energy nodes
- tighten error handling in employment, escrow, and energy token logic
- streamline network module by removing duplicate type definitions

## Testing
- `go build ./synnergy-network/core` *(fails: shuffleAddresses undefined, broadcast interface methods missing, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc762ef083208ea1058d3e145d5e