### PR TITLE
Initialize gas table during package load

### DIFF
--- a/synnergy-network/core/gas_table.go
+++ b/synnergy-network/core/gas_table.go
@@ -38,6 +38,11 @@ var categoryGas = map[byte]uint64{
 	// Remaining categories fall back to DefaultGasCost.
 }
 
+// init ensures the gas table is populated during package initialization.
+func init() {
+	initGasTable()
+}
+
 // initGasTable builds the runtime gas table using the (deduplicated) opcode
 // catalogue assembled in opcode_dispatcher.go.
 func initGasTable() {


### PR DESCRIPTION
## Summary
- ensure the core gas table is populated on package initialization

## Testing
- `go vet synnergy-network/core/gas_table.go` *(fails: undefined: Opcode)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc85b9188320ab94365f44a4b1db