### PR TITLE
Add documentation for governance and green tech helpers

### DIFF
--- a/synnergy-network/core/governance.go
+++ b/synnergy-network/core/governance.go
@@ -28,6 +28,7 @@ type GovProposal struct {
 
 var blockGasLimit = uint64(1000000)
 
+// UpdateParam changes a protocol configuration parameter identified by key.
 func UpdateParam(key, value string) error {
 	switch key {
 	case "block_gas_limit":
@@ -53,6 +54,7 @@ func applyParams(changes map[string]string) error {
 	return nil
 }
 
+// Nodes returns the addresses of all authority members.
 func (a *AuthoritySet) Nodes() []Address {
 	var out []Address
 	for addr := range a.members {
@@ -61,6 +63,7 @@ func (a *AuthoritySet) Nodes() []Address {
 	return out
 }
 
+// IsMember reports whether addr belongs to the authority set.
 func (a *AuthoritySet) IsMember(addr Address) bool {
 	_, ok := a.members[addr]
 	return ok
@@ -72,6 +75,7 @@ var authoritySet = &AuthoritySet{
 	},
 }
 
+// CurrentSet returns the active authority set.
 func CurrentSet() *AuthoritySet {
 	return authoritySet
 }
@@ -96,6 +100,7 @@ func quorumReached(p *GovProposal) bool {
 	return approves*2 > total
 }
 
+// ParseAddress converts a hex-encoded string into an Address.
 func ParseAddress(s string) (Address, error) {
 	b, err := hex.DecodeString(s)
 	if err != nil || len(b) != 20 {
@@ -252,6 +257,7 @@ func SubmitProposal(p *GovProposal) error {
 	return nil
 }
 
+// BalanceOfAsset returns the balance of the specified asset for addr.
 func BalanceOfAsset(asset AssetRef, addr Address) (uint64, error) {
 	switch asset.Kind {
 	case AssetCoin:

--- a/synnergy-network/core/governance_timelock.go
+++ b/synnergy-network/core/governance_timelock.go
@@ -54,7 +54,7 @@ func (t *Timelock) CancelProposal(id string) error {
 	return nil
 }
 
-// List returns a snapshot of all queued proposals.
+// ListTimelocks returns a snapshot of all queued proposals.
 func (t *Timelock) ListTimelocks() []TimelockEntry {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/synnergy-network/core/green_technology.go
+++ b/synnergy-network/core/green_technology.go
@@ -44,13 +44,17 @@ const (
 var green *GreenTechEngine
 var once sync.Once
 
+// InitGreenTech initialises the singleton GreenTechEngine with the provided ledger.
 func InitGreenTech(led StateRW) { once.Do(func() { green = &GreenTechEngine{led: led} }) }
-func Green() *GreenTechEngine   { return green }
+
+// Green returns the global GreenTechEngine instance.
+func Green() *GreenTechEngine { return green }
 
 //---------------------------------------------------------------------
 // Recorders
 //---------------------------------------------------------------------
 
+// RecordUsage logs energy and carbon metrics for validator v.
 func (g *GreenTechEngine) RecordUsage(v Address, energyKWh, carbonKg float64) error {
 	if energyKWh <= 0 || carbonKg <= 0 {
 		return errors.New("usage >0")
@@ -62,6 +66,7 @@ func (g *GreenTechEngine) RecordUsage(v Address, energyKWh, carbonKg float64) er
 	return nil
 }
 
+// RecordOffset logs a carbon offset credit purchase for validator v.
 func (g *GreenTechEngine) RecordOffset(v Address, offsetKg float64) error {
 	if offsetKg <= 0 {
 		return errors.New("offset>0")
@@ -77,6 +82,7 @@ func (g *GreenTechEngine) RecordOffset(v Address, offsetKg float64) error {
 // Aggregate + certify
 //---------------------------------------------------------------------
 
+// Certify recomputes sustainability certificates for all validators.
 func (g *GreenTechEngine) Certify() {
 	sums := make(map[Address]*nodeSummary)
 	iter := g.led.PrefixIterator([]byte("usage:"))
@@ -128,6 +134,7 @@ func (g *GreenTechEngine) Certify() {
 // Public getters
 //---------------------------------------------------------------------
 
+// CertificateOf returns the sustainability certificate assigned to addr.
 func (g *GreenTechEngine) CertificateOf(addr Address) Certificate {
 	key := append([]byte("cert:"), addr.Bytes()...)
 	blob, _ := g.led.GetState(key)
@@ -141,6 +148,7 @@ func (g *GreenTechEngine) CertificateOf(addr Address) Certificate {
 	return tmp.Cert
 }
 
+// ShouldThrottle reports whether addr's emission score warrants throttling.
 func (g *GreenTechEngine) ShouldThrottle(addr Address) bool {
 	key := append([]byte("cert:"), addr.Bytes()...)
 	blob, _ := g.led.GetState(key)


### PR DESCRIPTION
## Summary
- document governance parameter updates, authority set helpers, address parsing, and asset balance retrieval
- clarify Timelock listing behaviour
- document GreenTech engine initialization and sustainability tracking helpers

## Testing
- `go build ./core` *(fails: NodeID redeclared in this block, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc9341908320baf4f21962167331