### PR TITLE
core: add hash helper and strengthen ID wallet registration

### DIFF
--- a/synnergy-network/core/helpers.go
+++ b/synnergy-network/core/helpers.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"sync"
 )
@@ -46,6 +47,9 @@ func InitTxDistributor(l *Ledger) {
 
 // CurrentTxDistributor returns the fee distributor if initialised.
 func CurrentTxDistributor() *TxDistributor { return globalDist }
+
+// HashBytes returns the SHA-256 digest of b as a Hash type.
+func HashBytes(b []byte) Hash { return sha256.Sum256(b) }
 
 // ------------------------------------------------------------------
 // TF gRPC stub client for AI module wiring

--- a/synnergy-network/core/idwallet_registration.go
+++ b/synnergy-network/core/idwallet_registration.go
@@ -43,11 +43,16 @@ func RegisterIDWallet(addr Address, info string) error {
 		return fmt.Errorf("id registry not initialised")
 	}
 	key := append([]byte("idwallet:"), addr[:]...)
-	if ok, _ := idReg.led.HasState(key); ok {
+	if ok, err := idReg.led.HasState(key); err != nil {
+		return err
+	} else if ok {
 		return fmt.Errorf("wallet already registered")
 	}
 	rec := IDRegistration{Address: addr, Details: info}
-	data, _ := json.Marshal(rec)
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
 	if err := idReg.led.SetState(key, data); err != nil {
 		return err
 	}
@@ -67,6 +72,12 @@ func IsIDWalletRegistered(addr Address) bool {
 		return false
 	}
 	key := append([]byte("idwallet:"), addr[:]...)
-	ok, _ := idReg.led.HasState(key)
+	ok, err := idReg.led.HasState(key)
+	if err != nil {
+		if idReg.logger != nil {
+			idReg.logger.WithError(err).Warn("idwallet lookup failed")
+		}
+		return false
+	}
 	return ok
 }


### PR DESCRIPTION
## Summary
- add SHA-256 based `HashBytes` helper for consistent hashing
- harden ID wallet registration with proper error handling and logging

## Testing
- `golangci-lint run synnergy-network/core/helpers.go synnergy-network/core/high_availability.go synnergy-network/core/historical_node.go synnergy-network/core/holographic.go synnergy-network/core/identity_verification.go synnergy-network/core/idwallet_registration.go synnergy-network/core/immutability_enforcement.go synnergy-network/core/indexing_node.go synnergy-network/core/initialization_replication.go synnergy-network/core/intangible_assets.go synnergy-network/core/integration_node.go` *(fails: undefined: AuthoritySet)*

------
https://chatgpt.com/codex/tasks/task_e_688fcca3be0c83209bb8215304c2b3fd