### PR TITLE
fix ledger test and clean network types

### DIFF
--- a/synnergy-network/core/ledger_test.go
+++ b/synnergy-network/core/ledger_test.go
@@ -76,7 +76,7 @@ func TestAddBlockHeightMismatch(t *testing.T) {
 
 func TestMintTokenBalance(t *testing.T) {
 	cfg, _ := tmpLedgerConfig(t, nil)
-	led, _ := NewLedger(cfg)
+	ledger, _ := NewLedger(cfg)
 	addr := Address{0xAA}
 
 	if err := ledger.MintToken(addr, "SYNN", 0); err == nil {

--- a/synnergy-network/core/network.go
+++ b/synnergy-network/core/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,79 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/sirupsen/logrus"
 )
-
-// NodeID uniquely identifies a network peer.
-type NodeID string
-
-// Peer stores information about a connected peer.
-type Peer struct {
-	ID      NodeID
-	Addr    string
-	Latency time.Duration
-	Conn    net.Conn
-}
-
-// Message represents a pubsub message.
-type Message struct {
-	From  NodeID
-	Topic string
-	Data  []byte
-}
-
-// Config holds basic networking configuration.
-type Config struct {
-	ListenAddr     string
-	BootstrapPeers []string
-	DiscoveryTag   string
-}
-
-// NetworkMessage is used for optional replication hooks.
-type NetworkMessage struct {
-	Topic   string
-	Content []byte
-}
-
-// Block is a minimal placeholder for broadcast tests.
-type Block struct{}
-
-// NATManager manages external port mappings.
-type NATManager struct{}
-
-// NewNATManager returns a no-op NAT manager implementation.
-func NewNATManager() (*NATManager, error) { return &NATManager{}, nil }
-
-// Map reserves the given port; in this stub it is a no-op.
-func (m *NATManager) Map(port int) error { return nil }
-
-// Unmap releases any mapped port; in this stub it is a no-op.
-func (m *NATManager) Unmap() error { return nil }
-
-// parsePort extracts the TCP port from a multiaddress string.
-func parsePort(addr string) (int, error) {
-	parts := strings.Split(addr, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "tcp" {
-			return strconv.Atoi(parts[i+1])
-		}
-	}
-	return 0, fmt.Errorf("no tcp port in %s", addr)
-}
-
-// Node represents a Synnergy P2P node.
-type Node struct {
-	host      host.Host
-	pubsub    *pubsub.PubSub
-	topics    map[string]*pubsub.Topic
-	subs      map[string]*pubsub.Subscription
-	topicLock sync.RWMutex
-	subLock   sync.RWMutex
-	peerLock  sync.RWMutex
-	peers     map[NodeID]*Peer
-	nat       *NATManager
-	ctx       context.Context
-	cancel    context.CancelFunc
-	cfg       Config
-}
 
 func NewNode(cfg Config) (*Node, error) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
- fix incorrect ledger variable usage in ledger tests
- remove duplicate type declarations from network.go and rely on shared structs

## Testing
- `go test ./synnergy-network/core -run TestMintTokenBalance -count=1` *(fails: Address redeclared in access_control_test.go)*

------
https://chatgpt.com/codex/tasks/task_e_688fccb7e9b083208518b442c8f3bc02