### PR TITLE
Improve error handling in state channel management

### DIFF
--- a/synnergy-network/core/state_channel_management.go
+++ b/synnergy-network/core/state_channel_management.go
@@ -61,7 +61,9 @@ func (e *ChannelEngine) CancelClose(id ChannelID) error {
 	if err := e.led.SetState(chKey(id), mustJSON(ch)); err != nil {
 		return err
 	}
-	e.led.DeleteState(pendingKey(id))
+	if err := e.led.DeleteState(pendingKey(id)); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- handle possible errors when removing pending state in channel cancellation

## Testing
- `go vet ./core` *(fails: NodeID redeclared in core/network.go)*
- `go vet synnergy-network/core/state_channel_management.go` *(fails: undefined: ChannelEngine)*

------
https://chatgpt.com/codex/tasks/task_e_688fcdc3b25883209d5ab757ba5e2f08