### PR TITLE
Fix staking reward prefix and stablecoin interface assertion

### DIFF
--- a/synnergy-network/core/token_syn600.go
+++ b/synnergy-network/core/token_syn600.go
@@ -94,9 +94,9 @@ func (t *SYN600Token) EngagementOf(addr Address) uint64 {
 // DistributeStakingRewards mints a percentage of the staked amount as reward.
 // rate is interpreted as parts-per-hundred (e.g. 5 = 5%).
 func (t *SYN600Token) DistributeStakingRewards(rate uint64) error {
-	it := t.ledger.PrefixIterator([]byte(stakePrefix))
+	it := t.ledger.PrefixIterator([]byte(syn600StakePrefix))
 	for it.Next() {
-		key := it.Key()[len(stakePrefix):]
+		key := it.Key()[len(syn600StakePrefix):]
 		b, err := hex.DecodeString(string(key))
 		if err != nil || len(b) != 20 {
 			continue

--- a/synnergy-network/core/tokens_syn1000_helpers.go
+++ b/synnergy-network/core/tokens_syn1000_helpers.go
@@ -29,4 +29,5 @@ func TokensStableReserveValue(id TokenID) (float64, error) {
 	return tm.StableReserveValue(id)
 }
 
-var _ Tokens.Stablecoin
+// Ensure the SYN1000 token implements the Stablecoin interface at compile time.
+var _ Tokens.Stablecoin = (*Tokens.SYN1000Token)(nil)


### PR DESCRIPTION
## Summary
- fix SYN600 staking reward prefix usage
- ensure SYN1000 token satisfies Stablecoin interface

## Testing
- `GOPROXY=direct go test ./...` *(fails: unable to access 'https://go.googlesource.com/crypto/'*)

------
https://chatgpt.com/codex/tasks/task_e_688fce355ea8832095ab31ed48d46e27