### PR TITLE
Add non-token TxType definitions and format fee distribution

### DIFF
--- a/synnergy-network/core/transaction_distribution.go
+++ b/synnergy-network/core/transaction_distribution.go
@@ -88,7 +88,6 @@ func (d *TxDistributor) DistributeFees(from Address, minerPk []byte, fee uint64)
 		return fmt.Errorf("decode miner: %w", err)
 	}
 
-
 	// Compute fixed percentage shares first to minimise rounding loss and
 	// avoid overflow by dividing before multiplying.
 	onePercent := fee / 100
@@ -109,7 +108,6 @@ func (d *TxDistributor) DistributeFees(from Address, minerPk []byte, fee uint64)
 	minerShare := remaining * 50 / totalWeight
 	posShare := remaining * 39 / totalWeight
 	pohShare := remaining - minerShare - posShare
-
 
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/synnergy-network/core/tx_types.go
+++ b/synnergy-network/core/tx_types.go
@@ -20,6 +20,4 @@ const (
 	// TxReversal denotes an authority-approved reversal of a previous
 	// transaction. The recipient refunds the sender minus a protocol fee.
 	TxReversal
-
-
 )

--- a/synnergy-network/core/tx_types_nontokens.go
+++ b/synnergy-network/core/tx_types_nontokens.go
@@ -1,0 +1,15 @@
+//go:build !tokens
+
+package core
+
+// TxType categorizes transaction kinds for non-token builds.
+type TxType uint8
+
+const (
+	// TxPayment transfers value between addresses.
+	TxPayment TxType = iota + 1
+	// TxContractCall executes a smart contract.
+	TxContractCall
+	// TxReversal denotes an authority-approved reversal of a previous transaction.
+	TxReversal
+)


### PR DESCRIPTION
## Summary
- add tx_types_nontokens.go to define TxType for non-token builds
- tidy TxType and transaction distribution sources

## Testing
- `go build ./synnergy-network/core` *(fails: Node redeclared in network.go)*

------
https://chatgpt.com/codex/tasks/task_e_688fce417980832080a03b5d9f487afe