### PR TITLE
fix benchmark env cache

### DIFF
--- a/synnergy-network/pkg/utils/env_benchmark_test.go
+++ b/synnergy-network/pkg/utils/env_benchmark_test.go
@@ -7,6 +7,7 @@ import (
 
 func BenchmarkEnvOrDefault(b *testing.B) {
 	os.Unsetenv("BENCH_KEY")
+	clearEnvCache("BENCH_KEY")
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		EnvOrDefault("BENCH_KEY", "fallback")
@@ -15,6 +16,7 @@ func BenchmarkEnvOrDefault(b *testing.B) {
 
 func BenchmarkEnvOrDefaultInt(b *testing.B) {
 	os.Setenv("BENCH_INT", "123")
+	clearEnvCache("BENCH_INT")
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		EnvOrDefaultInt("BENCH_INT", 0)
@@ -23,6 +25,7 @@ func BenchmarkEnvOrDefaultInt(b *testing.B) {
 
 func BenchmarkEnvOrDefaultUint64(b *testing.B) {
 	os.Setenv("BENCH_UINT", "123")
+	clearEnvCache("BENCH_UINT")
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		EnvOrDefaultUint64("BENCH_UINT", 0)


### PR DESCRIPTION
## Summary
- clear environment-variable cache in benchmarks to avoid stale reads

## Testing
- `go test ./synnergy-network/internal/testutil -count=1`
- `go test ./synnergy-network/pkg/utils -count=1`
- `go test ./synnergy-network/pkg/config -run TestNonexistent -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688fce6e8a988320956a5d83e79c98fc